### PR TITLE
Improve Bluetooth audio cue reliability by delaying start and deferring stop cue

### DIFF
--- a/Core/TranscriptionManager.swift
+++ b/Core/TranscriptionManager.swift
@@ -17,6 +17,7 @@ class TranscriptionManager: ObservableObject {
     private let whisperService = WhisperService()
     private var isLocked = false
     private var cancellables = Set<AnyCancellable>()
+    private let startCueLeadIn: TimeInterval = 0.18
     
     init() {
         setupBindings()
@@ -79,11 +80,16 @@ class TranscriptionManager: ObservableObject {
     
     private func startRecording() {
         guard case .idle = state else { return }
-        
+
         playSound(named: "Morse") // Start sound
-        state = .recording
-        OverlayManager.shared.show(recorder: audioRecorder)
-        audioRecorder.startRecording()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + startCueLeadIn) { [weak self] in
+            guard let self = self, self.state == .idle else { return }
+
+            self.state = .recording
+            OverlayManager.shared.show(recorder: self.audioRecorder)
+            self.audioRecorder.startRecording()
+        }
     }
     
     private var stopRequestedAt: Date?
@@ -97,7 +103,6 @@ class TranscriptionManager: ObservableObject {
         print("--- Speed Profile Start ---")
         #endif
         
-        playSound(named: "Frog") // Stop sound
         state = .transcribing
         isLocked = false
         
@@ -105,6 +110,8 @@ class TranscriptionManager: ObservableObject {
         OverlayManager.shared.show(recorder: audioRecorder, isTranscribing: true)
         
         audioRecorder.stopRecording { [weak self] frames in
+            self?.playSound(named: "Frog") // Stop sound
+
             let stopDuration = Date().timeIntervalSince(startTime)
             #if DEBUG
             print("1. Audio stop & buffer retrieve: \(String(format: "%.3f", stopDuration))s")


### PR DESCRIPTION
### Motivation
- Bluetooth headsets (AirPods and similar) were only playing a short blip of the start/stop cues when dictation began or ended because the output path and capture can compete or the device needs time to wake. 
- The change aims to avoid truncated cues and reduce race conditions between cue playback and the audio engine startup/shutdown.

### Description
- Add a `startCueLeadIn` constant (`0.18s`) to provide a short lead-in after the start cue is played before beginning capture (`Core/TranscriptionManager.swift`).
- After calling `playSound(named: "Morse")`, delay transitioning to `.recording` and starting the audio engine using `DispatchQueue.main.asyncAfter`, and guard that the `state` is still `.idle` before starting to avoid races.
- Move the stop cue playback (`playSound(named: "Frog")`) into the completion handler of `audioRecorder.stopRecording` so the stop cue is played after recording has stopped and no longer competes with active input.

### Testing
- Attempted to run a build with `xcodebuild -project KeyVox.xcodeproj -scheme KeyVox -configuration Debug -sdk macosx build`, but it failed in this environment because `xcodebuild` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d1a886fc48322954f59eb9102d2c0)