### PR TITLE
pr: capitalize standalone lowercase i, add math normalizer

### DIFF
--- a/Core/Normalization/CodeishLineDetector.swift
+++ b/Core/Normalization/CodeishLineDetector.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+enum CodeishLineDetector {
+    private static let codeOperators = ["==", "!=", "<=", ">=", "=>", "->", "::", "&&", "||", "++", "--"]
+    private static let assignmentLikeRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b[A-Za-z_][A-Za-z0-9_]*\s*=\s*"#,
+        options: []
+    )
+
+    static func isLikelyCodeishLine(_ line: String) -> Bool {
+        guard !line.isEmpty else { return false }
+        if line.contains("`") { return true }
+        if codeOperators.contains(where: line.contains) { return true }
+
+        if let assignmentRegex = assignmentLikeRegex {
+            let nsLine = line as NSString
+            let range = NSRange(location: 0, length: nsLine.length)
+            if assignmentRegex.firstMatch(in: line, options: [], range: range) != nil {
+                return true
+            }
+        }
+
+        if line.contains(";") {
+            let hasBracesOrBrackets = line.contains("{") || line.contains("}") || line.contains("[") || line.contains("]")
+            if hasBracesOrBrackets {
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/Core/Normalization/MathExpressionNormalizer.swift
+++ b/Core/Normalization/MathExpressionNormalizer.swift
@@ -9,6 +9,7 @@ struct MathExpressionNormalizer {
         pattern: #"[+\-*/^=%]"#,
         options: []
     )
+    private static let maxChainedOperatorPasses = 4
     private static let protectedEmailRegex: NSRegularExpression? = try? NSRegularExpression(
         pattern: #"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#,
         options: [.caseInsensitive]
@@ -39,10 +40,6 @@ struct MathExpressionNormalizer {
     )
     private static let protectedVersionRegex: NSRegularExpression? = try? NSRegularExpression(
         pattern: #"\b\d+(?:\.\d+){2,}\b"#,
-        options: []
-    )
-    private static let assignmentLikeRegex: NSRegularExpression? = try? NSRegularExpression(
-        pattern: #"\b[A-Za-z_][A-Za-z0-9_]*\s*=\s*"#,
         options: []
     )
     private static let mathTriggerRegex: NSRegularExpression? = try? NSRegularExpression(
@@ -226,7 +223,7 @@ struct MathExpressionNormalizer {
 
     private func normalizeChainedOperatorWords(in text: String) -> String {
         var current = text
-        for _ in 0..<4 {
+        for _ in 0..<Self.maxChainedOperatorPasses {
             let next = replaceMatches(in: current, using: Self.expressionOperatorRegex) { match, nsText in
                 let lhs = normalizeMathSymbolSpacing(nsText.substring(with: match.range(at: 1)))
                 let operatorWord = nsText.substring(with: match.range(at: 2)).lowercased()
@@ -262,27 +259,7 @@ struct MathExpressionNormalizer {
     }
 
     private func isLikelyCodeishLine(_ line: String) -> Bool {
-        if line.contains("`") { return true }
-
-        let codeOperators = ["==", "!=", "<=", ">=", "=>", "->", "::", "&&", "||", "++", "--"]
-        if codeOperators.contains(where: line.contains) { return true }
-
-        if line.contains(";") {
-            let hasBracesOrBrackets = line.contains("{") || line.contains("}") || line.contains("[") || line.contains("]")
-            if hasBracesOrBrackets {
-                return true
-            }
-        }
-
-        if let assignmentRegex = Self.assignmentLikeRegex {
-            let nsLine = line as NSString
-            let range = NSRange(location: 0, length: nsLine.length)
-            if assignmentRegex.firstMatch(in: line, options: [], range: range) != nil {
-                return true
-            }
-        }
-
-        return false
+        CodeishLineDetector.isLikelyCodeishLine(line)
     }
 
     private func normalizeMathSymbolSpacing(_ text: String) -> String {

--- a/Core/Normalization/MathExpressionNormalizer.swift
+++ b/Core/Normalization/MathExpressionNormalizer.swift
@@ -1,0 +1,413 @@
+import Foundation
+
+struct MathExpressionNormalizer {
+    private static let standaloneMathAllowedCharsRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"^[\s0-9().+\-*/^=%]+$"#,
+        options: []
+    )
+    private static let standaloneMathOperatorRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"[+\-*/^=%]"#,
+        options: []
+    )
+    private static let protectedEmailRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#,
+        options: [.caseInsensitive]
+    )
+    private static let protectedURLRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(?:https?:\/\/|www\.)[^\s]+"#,
+        options: []
+    )
+    private static let protectedDomainRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(?:[A-Z0-9\-]+\.)+[A-Z]{2,}(?:\/[^\s]*)?"#,
+        options: []
+    )
+    private static let protectedTimeRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b\d{1,2}:\d{2}(?:\s?[AP]M)?\b"#,
+        options: []
+    )
+    private static let protectedMalformedTimeWithMeridiemRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(?:[1-9]|1[0-2])[.-][0-5][0-9](?:\s*(?:a\.?m\.?|am|a\.?n\.?|an|p\.?m\.?|pm))\b"#,
+        options: []
+    )
+    private static let protectedMalformedTimeWithDaypartRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(?:[1-9]|1[0-2])[.-][0-5][0-9](?=\s+(?:in the morning|this morning|in the afternoon|this afternoon|in the evening|this evening|at night|tonight)\b)"#,
+        options: []
+    )
+    private static let protectedDateRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b\d{4}-\d{2}-\d{2}\b"#,
+        options: []
+    )
+    private static let protectedVersionRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b\d+(?:\.\d+){2,}\b"#,
+        options: []
+    )
+    private static let assignmentLikeRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b[A-Za-z_][A-Za-z0-9_]*\s*=\s*"#,
+        options: []
+    )
+    private static let mathTriggerRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(?:plus|minus|subtract|subtracted\s+by|times|multiplied\s+by|divided\s+by|equals|percent|squared|cubed|power\s+of|to\s+the\s+power\s+of|to\s+the\s+[A-Z0-9\-]+\s+power|raised\s+to)\b|(?<=\d)\s*-\s*(?=\d)"#,
+        options: []
+    )
+    private static let toThePowerOfRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(\d+(?:\.\d+)?)\s+to\s+the\s+power\s+of\s+(\d+(?:\.\d+)?)\b"#,
+        options: []
+    )
+    private static let toTheOrdinalPowerRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(\d+(?:\.\d+)?)\s+to\s+the\s+([A-Z0-9.\-]+)\s+power\b"#,
+        options: []
+    )
+    private static let raisedToRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(\d+(?:\.\d+)?)\s+raised\s+to\s+(?:the\s+)?([A-Z0-9.\-]+)(?:\s+power)?\b"#,
+        options: []
+    )
+    private static let powerRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(\d+(?:\.\d+)?)\s+power\s+of\s+(\d+(?:\.\d+)?)\b"#,
+        options: []
+    )
+    private static let squaredRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(\d+(?:\.\d+)?)\s+squared\b"#,
+        options: []
+    )
+    private static let cubedRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(\d+(?:\.\d+)?)\s+cubed\b"#,
+        options: []
+    )
+    private static let percentRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(\d+(?:\.\d+)?)\s+percent\b"#,
+        options: []
+    )
+    private static let multiplicationByXRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?<=\d)\s*[x×]\s*(?=\d)"#,
+        options: [.caseInsensitive]
+    )
+    private static let binaryOperatorRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(\d+(?:\.\d+)?)\s+(plus|minus|subtract|subtracted\s+by|times|multiplied\s+by|divided\s+by)\s+(\d+(?:\.\d+)?)\b"#,
+        options: []
+    )
+    private static let expressionOperatorRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b((?:\d|\()[0-9().+\-*/^%\s]*?\d)\s*,?\s*(plus|minus|subtract|subtracted\s+by|times|multiplied\s+by|divided\s+by)\s+(\d+(?:\.\d+)?)\b"#,
+        options: []
+    )
+    private static let equalsRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)\b(\d+(?:\.\d+)?(?:\s*(?:\^|[+\-*/])\s*\d+(?:\.\d+)?)*)\s+equals\s+(\d+(?:\.\d+)?)\b"#,
+        options: []
+    )
+    private static let subtractionSymbolRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?<=\d)\s*-\s*(?=\d)"#,
+        options: []
+    )
+    private static let binarySymbolSpacingRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\s*([+\-*/=])\s*"#,
+        options: []
+    )
+    private static let exponentTighteningRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\s*\^\s*"#,
+        options: []
+    )
+    private static let whitespaceCollapseRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\s{2,}"#,
+        options: []
+    )
+    private static let trailingTerminalPunctuationRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"[.!?]+\s*$"#,
+        options: []
+    )
+    private static let numericOrdinalExponentRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)^(\d+)(?:st|nd|rd|th)?$"#,
+        options: []
+    )
+    private static let ordinalWordToExponent: [String: String] = [
+        "first": "1",
+        "second": "2",
+        "third": "3",
+        "fourth": "4",
+        "fifth": "5",
+        "sixth": "6",
+        "seventh": "7",
+        "eighth": "8",
+        "ninth": "9",
+        "tenth": "10",
+        "eleventh": "11",
+        "twelfth": "12",
+        "thirteenth": "13",
+        "fourteenth": "14",
+        "fifteenth": "15",
+        "sixteenth": "16",
+        "seventeenth": "17",
+        "eighteenth": "18",
+        "nineteenth": "19",
+        "twentieth": "20"
+    ]
+
+    func normalize(in text: String) -> String {
+        guard !text.isEmpty else { return text }
+        guard text.rangeOfCharacter(from: .decimalDigits) != nil else { return text }
+
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let normalizedLines = lines.map(normalizeLine(_:))
+        let normalized = normalizedLines.joined(separator: "\n")
+        return stripTerminalPunctuationIfStandaloneMath(in: normalized)
+    }
+
+    private func normalizeLine(_ line: String) -> String {
+        guard !line.isEmpty else { return line }
+        guard containsMathTrigger(line) else { return line }
+        guard !isLikelyCodeishLine(line) else { return line }
+
+        var output = line
+        output = replaceMatches(in: output, using: Self.toThePowerOfRegex) { match, nsText in
+            let base = nsText.substring(with: match.range(at: 1))
+            let exponent = nsText.substring(with: match.range(at: 2))
+            return "\(base)^\(exponent)"
+        }
+        output = replaceMatches(in: output, using: Self.toTheOrdinalPowerRegex) { match, nsText in
+            let base = nsText.substring(with: match.range(at: 1))
+            let rawExponent = nsText.substring(with: match.range(at: 2))
+            guard let exponent = normalizedExponentToken(rawExponent) else { return nil }
+            return "\(base)^\(exponent)"
+        }
+        output = replaceMatches(in: output, using: Self.raisedToRegex) { match, nsText in
+            let base = nsText.substring(with: match.range(at: 1))
+            let rawExponent = nsText.substring(with: match.range(at: 2))
+            guard let exponent = normalizedExponentToken(rawExponent) else { return nil }
+            return "\(base)^\(exponent)"
+        }
+        output = replaceMatches(in: output, using: Self.powerRegex) { match, nsText in
+            let base = nsText.substring(with: match.range(at: 1))
+            let exponent = nsText.substring(with: match.range(at: 2))
+            return "\(base)^\(exponent)"
+        }
+        output = replaceMatches(in: output, using: Self.squaredRegex) { match, nsText in
+            let value = nsText.substring(with: match.range(at: 1))
+            return "\(value)^2"
+        }
+        output = replaceMatches(in: output, using: Self.cubedRegex) { match, nsText in
+            let value = nsText.substring(with: match.range(at: 1))
+            return "\(value)^3"
+        }
+        output = replaceMatches(in: output, using: Self.percentRegex) { match, nsText in
+            let value = nsText.substring(with: match.range(at: 1))
+            return "\(value)%"
+        }
+        output = replaceMatches(in: output, using: Self.multiplicationByXRegex) { _, _ in
+            " * "
+        }
+        output = normalizeChainedOperatorWords(in: output)
+        output = replaceMatches(in: output, using: Self.binaryOperatorRegex) { match, nsText in
+            let lhs = nsText.substring(with: match.range(at: 1))
+            let operatorWord = nsText.substring(with: match.range(at: 2)).lowercased()
+            let rhs = nsText.substring(with: match.range(at: 3))
+            let symbol: String
+            switch operatorWord {
+            case "plus":
+                symbol = "+"
+            case "minus", "subtract", "subtracted by":
+                symbol = "-"
+            case "times", "multiplied by":
+                symbol = "*"
+            case "divided by":
+                symbol = "/"
+            default:
+                return nil
+            }
+            return "\(lhs) \(symbol) \(rhs)"
+        }
+        output = replaceMatches(in: output, using: Self.equalsRegex) { match, nsText in
+            let lhs = normalizeMathSymbolSpacing(nsText.substring(with: match.range(at: 1)))
+            let rhs = nsText.substring(with: match.range(at: 2))
+            return "\(lhs) = \(rhs)"
+        }
+        output = replaceMatches(in: output, using: Self.subtractionSymbolRegex) { _, _ in
+            " - "
+        }
+        return output
+    }
+
+    private func normalizeChainedOperatorWords(in text: String) -> String {
+        var current = text
+        for _ in 0..<4 {
+            let next = replaceMatches(in: current, using: Self.expressionOperatorRegex) { match, nsText in
+                let lhs = normalizeMathSymbolSpacing(nsText.substring(with: match.range(at: 1)))
+                let operatorWord = nsText.substring(with: match.range(at: 2)).lowercased()
+                let rhs = nsText.substring(with: match.range(at: 3))
+                let symbol: String
+                switch operatorWord {
+                case "plus":
+                    symbol = "+"
+                case "minus", "subtract", "subtracted by":
+                    symbol = "-"
+                case "times", "multiplied by":
+                    symbol = "*"
+                case "divided by":
+                    symbol = "/"
+                default:
+                    return nil
+                }
+                return "\(lhs) \(symbol) \(rhs)"
+            }
+            if next == current {
+                return current
+            }
+            current = next
+        }
+        return current
+    }
+
+    private func containsMathTrigger(_ line: String) -> Bool {
+        guard let triggerRegex = Self.mathTriggerRegex else { return false }
+        let nsLine = line as NSString
+        let range = NSRange(location: 0, length: nsLine.length)
+        return triggerRegex.firstMatch(in: line, options: [], range: range) != nil
+    }
+
+    private func isLikelyCodeishLine(_ line: String) -> Bool {
+        if line.contains("`") { return true }
+
+        let codeOperators = ["==", "!=", "<=", ">=", "=>", "->", "::", "&&", "||", "++", "--"]
+        if codeOperators.contains(where: line.contains) { return true }
+
+        if line.contains(";") {
+            let hasBracesOrBrackets = line.contains("{") || line.contains("}") || line.contains("[") || line.contains("]")
+            if hasBracesOrBrackets {
+                return true
+            }
+        }
+
+        if let assignmentRegex = Self.assignmentLikeRegex {
+            let nsLine = line as NSString
+            let range = NSRange(location: 0, length: nsLine.length)
+            if assignmentRegex.firstMatch(in: line, options: [], range: range) != nil {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func normalizeMathSymbolSpacing(_ text: String) -> String {
+        var output = text
+
+        if let spacingRegex = Self.binarySymbolSpacingRegex {
+            let range = NSRange(location: 0, length: (output as NSString).length)
+            output = spacingRegex.stringByReplacingMatches(in: output, options: [], range: range, withTemplate: " $1 ")
+        }
+
+        if let exponentRegex = Self.exponentTighteningRegex {
+            let range = NSRange(location: 0, length: (output as NSString).length)
+            output = exponentRegex.stringByReplacingMatches(in: output, options: [], range: range, withTemplate: "^")
+        }
+
+        if let collapseRegex = Self.whitespaceCollapseRegex {
+            let collapsedRange = NSRange(location: 0, length: (output as NSString).length)
+            output = collapseRegex.stringByReplacingMatches(in: output, options: [], range: collapsedRange, withTemplate: " ")
+        }
+
+        return output.trimmingCharacters(in: .whitespaces)
+    }
+
+    private func replaceMatches(
+        in text: String,
+        using regex: NSRegularExpression?,
+        transform: (_ match: NSTextCheckingResult, _ nsText: NSString) -> String?
+    ) -> String {
+        guard let regex else { return text }
+        let nsText = text as NSString
+        let range = NSRange(location: 0, length: nsText.length)
+        let matches = regex.matches(in: text, options: [], range: range)
+        guard !matches.isEmpty else { return text }
+
+        let protectedRanges = protectedRanges(in: text)
+        let mutable = NSMutableString(string: text)
+        for match in matches.reversed() {
+            if intersectsProtectedRange(match.range, protectedRanges: protectedRanges) {
+                continue
+            }
+            guard let replacement = transform(match, nsText) else { continue }
+            mutable.replaceCharacters(in: match.range, with: replacement)
+        }
+
+        return mutable as String
+    }
+
+    private func protectedRanges(in text: String) -> [NSRange] {
+        var protected: [NSRange] = []
+        protected.append(contentsOf: ranges(matching: Self.protectedEmailRegex, in: text))
+        protected.append(contentsOf: ranges(matching: Self.protectedURLRegex, in: text))
+        protected.append(contentsOf: ranges(matching: Self.protectedDomainRegex, in: text))
+        protected.append(contentsOf: ranges(matching: Self.protectedTimeRegex, in: text))
+        protected.append(contentsOf: ranges(matching: Self.protectedMalformedTimeWithMeridiemRegex, in: text))
+        protected.append(contentsOf: ranges(matching: Self.protectedMalformedTimeWithDaypartRegex, in: text))
+        protected.append(contentsOf: ranges(matching: Self.protectedDateRegex, in: text))
+        protected.append(contentsOf: ranges(matching: Self.protectedVersionRegex, in: text))
+        return protected
+    }
+
+    private func ranges(matching regex: NSRegularExpression?, in text: String) -> [NSRange] {
+        guard let regex else { return [] }
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        return regex.matches(in: text, options: [], range: fullRange).map(\.range)
+    }
+
+    private func intersectsProtectedRange(_ range: NSRange, protectedRanges: [NSRange]) -> Bool {
+        for protected in protectedRanges where NSIntersectionRange(range, protected).length > 0 {
+            return true
+        }
+        return false
+    }
+
+    private func stripTerminalPunctuationIfStandaloneMath(in text: String) -> String {
+        guard !text.contains("\n") else { return text }
+        guard let trailingRegex = Self.trailingTerminalPunctuationRegex else { return text }
+
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        guard let trailingMatch = trailingRegex.firstMatch(in: text, options: [], range: fullRange) else {
+            return text
+        }
+
+        let coreRange = NSRange(location: 0, length: trailingMatch.range.location)
+        let core = nsText.substring(with: coreRange).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !core.isEmpty else { return text }
+        guard core.rangeOfCharacter(from: .letters) == nil else { return text }
+
+        guard let allowedCharsRegex = Self.standaloneMathAllowedCharsRegex,
+              let operatorRegex = Self.standaloneMathOperatorRegex else {
+            return text
+        }
+
+        let coreNS = core as NSString
+        let coreFullRange = NSRange(location: 0, length: coreNS.length)
+        guard allowedCharsRegex.firstMatch(in: core, options: [], range: coreFullRange) != nil else {
+            return text
+        }
+        guard operatorRegex.firstMatch(in: core, options: [], range: coreFullRange) != nil else {
+            return text
+        }
+        guard core.rangeOfCharacter(from: .decimalDigits) != nil else { return text }
+
+        return core
+    }
+
+    private func normalizedExponentToken(_ token: String) -> String? {
+        let trimmed = token
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'“”‘’()[]{}.,;:!?"))
+        guard !trimmed.isEmpty else { return nil }
+
+        if let value = Self.ordinalWordToExponent[trimmed] {
+            return value
+        }
+
+        if let regex = Self.numericOrdinalExponentRegex {
+            let nsToken = trimmed as NSString
+            let range = NSRange(location: 0, length: nsToken.length)
+            if let match = regex.firstMatch(in: trimmed, options: [], range: range) {
+                return nsToken.substring(with: match.range(at: 1))
+            }
+        }
+
+        return nil
+    }
+}

--- a/Core/Normalization/SentenceCapitalizationNormalizer.swift
+++ b/Core/Normalization/SentenceCapitalizationNormalizer.swift
@@ -10,11 +10,19 @@ struct SentenceCapitalizationNormalizer {
         options: []
     )
     private static let sentenceBoundaryRegex: NSRegularExpression? = try? NSRegularExpression(
-        pattern: #"(?<!\d)([.!?;:…]["'”’\)\]\}]*)(\s*)([a-z])"#,
+        pattern: #"(?<!\d)([.!?:…]["'”’\)\]\}]*)(\s*)([a-z])"#,
         options: []
     )
     private static let lineBreakRegex: NSRegularExpression? = try? NSRegularExpression(
         pattern: #"(\n)([ \t]*["'“”‘’\(\[\{]*)([a-z])"#,
+        options: []
+    )
+    private static let standaloneLowercasePronounRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?<![A-Za-z0-9_])i(?![A-Za-z0-9_])"#,
+        options: []
+    )
+    private static let assignmentLikeRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b[A-Za-z_][A-Za-z0-9_]*\s*=\s*"#,
         options: []
     )
     private static let commonTopLevelDomains: Set<String> = [
@@ -28,7 +36,8 @@ struct SentenceCapitalizationNormalizer {
     func normalizeSentenceStarts(in text: String) -> String {
         let textStartNormalized = capitalizeAtTextStart(text)
         let sentenceStartNormalized = capitalizeAfterSentenceBoundary(textStartNormalized)
-        return capitalizeAfterLineBreak(sentenceStartNormalized)
+        let lineBreakNormalized = capitalizeAfterLineBreak(sentenceStartNormalized)
+        return capitalizeStandalonePronounI(in: lineBreakNormalized)
     }
 
     private func capitalizeAtTextStart(_ text: String) -> String {
@@ -45,6 +54,33 @@ struct SentenceCapitalizationNormalizer {
         let mutable = NSMutableString(string: text)
         mutable.replaceCharacters(in: match.range, with: "\(prefix)\(nextLetter)")
         return mutable as String
+    }
+
+    private func capitalizeStandalonePronounI(in text: String) -> String {
+        guard !text.isEmpty else { return text }
+        guard let regex = Self.standaloneLowercasePronounRegex else { return text }
+
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard !lines.isEmpty else { return text }
+
+        let normalizedLines = lines.map { line -> String in
+            guard !line.isEmpty else { return line }
+            guard !isLikelyCodeishLine(line) else { return line }
+
+            let nsLine = line as NSString
+            let fullRange = NSRange(location: 0, length: nsLine.length)
+            let matches = regex.matches(in: line, options: [], range: fullRange)
+            guard !matches.isEmpty else { return line }
+
+            let mutable = NSMutableString(string: line)
+            for match in matches.reversed() {
+                guard shouldCapitalizeStandalonePronounI(in: nsLine, matchRange: match.range) else { continue }
+                mutable.replaceCharacters(in: match.range, with: "I")
+            }
+            return mutable as String
+        }
+
+        return normalizedLines.joined(separator: "\n")
     }
 
     private func capitalizeAfterSentenceBoundary(_ text: String) -> String {
@@ -154,6 +190,94 @@ struct SentenceCapitalizationNormalizer {
             .split(whereSeparator: \.isWhitespace)
             .first
             .map(String.init) ?? ""
+    }
+
+    private func shouldCapitalizeStandalonePronounI(in line: NSString, matchRange: NSRange) -> Bool {
+        let start = matchRange.location
+        let endExclusive = matchRange.location + matchRange.length
+        guard start >= 0, endExclusive <= line.length else { return false }
+
+        if start > 0, let previous = UnicodeScalar(line.character(at: start - 1)),
+           "_$/@".unicodeScalars.contains(previous) {
+            return false
+        }
+        if endExclusive < line.length, let next = UnicodeScalar(line.character(at: endExclusive)),
+           "_$/@".unicodeScalars.contains(next) {
+            return false
+        }
+
+        guard let tokenRange = tokenRange(containing: start, in: line) else { return false }
+        let token = line.substring(with: tokenRange)
+        if isAddressOrURLToken(token) {
+            return false
+        }
+        if isLikelyTechnicalToken(token) {
+            return false
+        }
+
+        return true
+    }
+
+    private func tokenRange(containing location: Int, in text: NSString) -> NSRange? {
+        guard location >= 0, location < text.length else { return nil }
+
+        var start = location
+        while start > 0 {
+            guard let scalar = UnicodeScalar(text.character(at: start - 1)),
+                  !CharacterSet.whitespacesAndNewlines.contains(scalar) else {
+                break
+            }
+            start -= 1
+        }
+
+        var end = location + 1
+        while end < text.length {
+            guard let scalar = UnicodeScalar(text.character(at: end)),
+                  !CharacterSet.whitespacesAndNewlines.contains(scalar) else {
+                break
+            }
+            end += 1
+        }
+
+        guard end > start else { return nil }
+        return NSRange(location: start, length: end - start)
+    }
+
+    private func isLikelyTechnicalToken(_ token: String) -> Bool {
+        let stripped = token.trimmingCharacters(in: CharacterSet(charactersIn: "\"'“”‘’()[]{}.,;:!?"))
+        guard !stripped.isEmpty else { return false }
+        if stripped.contains("/") { return true }
+        if stripped.contains("::") { return true }
+        if stripped.contains("_") { return true }
+        if stripped.contains("$") { return true }
+        return false
+    }
+
+    private func isLikelyCodeishLine(_ line: String) -> Bool {
+        guard !line.isEmpty else { return false }
+        if line.contains("`") { return true }
+
+        let codeOperators = ["==", "!=", "<=", ">=", "=>", "->", "::", "&&", "||", "++", "--"]
+        if codeOperators.contains(where: line.contains) {
+            return true
+        }
+
+        if let assignmentRegex = Self.assignmentLikeRegex {
+            let nsLine = line as NSString
+            let range = NSRange(location: 0, length: nsLine.length)
+            if assignmentRegex.firstMatch(in: line, options: [], range: range) != nil {
+                return true
+            }
+        }
+
+        if line.contains(";") {
+            let hasBracesOrBrackets = line.contains("{") || line.contains("}") || line.contains("[") || line.contains("]")
+            if hasBracesOrBrackets {
+                return true
+            }
+        }
+
+        return false
     }
 
     private func isLikelyDomainBoundary(_ text: String, dotLocation: Int) -> Bool {

--- a/Core/Normalization/SentenceCapitalizationNormalizer.swift
+++ b/Core/Normalization/SentenceCapitalizationNormalizer.swift
@@ -21,10 +21,6 @@ struct SentenceCapitalizationNormalizer {
         pattern: #"(?<![A-Za-z0-9_])i(?![A-Za-z0-9_])"#,
         options: []
     )
-    private static let assignmentLikeRegex: NSRegularExpression? = try? NSRegularExpression(
-        pattern: #"\b[A-Za-z_][A-Za-z0-9_]*\s*=\s*"#,
-        options: []
-    )
     private static let commonTopLevelDomains: Set<String> = [
         "com", "net", "org", "io", "app", "dev", "ai", "co", "me", "edu", "gov",
         "us", "uk", "ca", "au", "de", "fr", "jp"
@@ -254,30 +250,7 @@ struct SentenceCapitalizationNormalizer {
     }
 
     private func isLikelyCodeishLine(_ line: String) -> Bool {
-        guard !line.isEmpty else { return false }
-        if line.contains("`") { return true }
-
-        let codeOperators = ["==", "!=", "<=", ">=", "=>", "->", "::", "&&", "||", "++", "--"]
-        if codeOperators.contains(where: line.contains) {
-            return true
-        }
-
-        if let assignmentRegex = Self.assignmentLikeRegex {
-            let nsLine = line as NSString
-            let range = NSRange(location: 0, length: nsLine.length)
-            if assignmentRegex.firstMatch(in: line, options: [], range: range) != nil {
-                return true
-            }
-        }
-
-        if line.contains(";") {
-            let hasBracesOrBrackets = line.contains("{") || line.contains("}") || line.contains("[") || line.contains("]")
-            if hasBracesOrBrackets {
-                return true
-            }
-        }
-
-        return false
+        CodeishLineDetector.isLikelyCodeishLine(line)
     }
 
     private func isLikelyDomainBoundary(_ text: String, dotLocation: Int) -> Bool {

--- a/Core/Transcription/TranscriptionPostProcessor.swift
+++ b/Core/Transcription/TranscriptionPostProcessor.swift
@@ -9,6 +9,7 @@ final class TranscriptionPostProcessor {
     private let laughterNormalizer = LaughterNormalizer()
     private let characterSpamNormalizer = CharacterSpamNormalizer()
     private let timeExpressionNormalizer = TimeExpressionNormalizer()
+    private let mathExpressionNormalizer = MathExpressionNormalizer()
     private let colonNormalizer = ColonNormalizer()
     private let allCapsOverrideNormalizer = AllCapsOverrideNormalizer()
     private let whitespaceNormalizer = WhitespaceNormalizer()
@@ -79,9 +80,13 @@ final class TranscriptionPostProcessor {
         #if DEBUG
         logPipelineStage("colonNormalized", colonNormalized)
         #endif
+        let mathNormalized = mathExpressionNormalizer.normalize(in: colonNormalized)
+        #if DEBUG
+        logPipelineStage("mathNormalized", mathNormalized)
+        #endif
         let listFormatted = listFormattingEnabled
-            ? listFormattingEngine.formatIfNeeded(colonNormalized, renderMode: renderMode)
-            : colonNormalized
+            ? listFormattingEngine.formatIfNeeded(mathNormalized, renderMode: renderMode)
+            : mathNormalized
         #if DEBUG
         logPipelineStage("listFormatted", listFormatted)
         #endif

--- a/Docs/CODEMAP.md
+++ b/Docs/CODEMAP.md
@@ -113,6 +113,8 @@ KeyVox/
 │   │   ├── EmailAddressNormalizer.swift
 │   │   ├── WebsiteNormalizer.swift
 │   │   ├── TimeExpressionNormalizer.swift
+│   │   ├── MathExpressionNormalizer.swift
+│   │   ├── CodeishLineDetector.swift
 │   │   ├── WhitespaceNormalizer.swift
 │   │   ├── SentenceCapitalizationNormalizer.swift
 │   │   ├── ColonNormalizer.swift
@@ -276,6 +278,11 @@ KeyVox/
   - Post-transcription orchestration (dictionary, colon cleanup, list, laughter, spam/time/email/website cleanup, then delegated normalization passes).
 - `Core/Normalization/TimeExpressionNormalizer.swift`
   - Isolated time-shape and meridiem normalization helper used by post-processing.
+- `Core/Normalization/MathExpressionNormalizer.swift`
+  - Deterministic math phrase/operator normalization (`plus/minus/times/divided by`, exponents, percent, chained expressions) with protected URL/email/code/time/date/version spans.
+  - Strips terminal punctuation only for standalone math utterances while preserving sentence punctuation.
+- `Core/Normalization/CodeishLineDetector.swift`
+  - Shared code-like line detector used by normalization passes that must avoid mutating code-ish text.
 - `Core/Normalization/LaughterNormalizer.swift`
   - Dedicated laughter normalization pass (`ha ha` -> `haha`) separated from time normalization.
 - `Core/Normalization/CharacterSpamNormalizer.swift`
@@ -351,6 +358,11 @@ KeyVox/
 - `Core/Normalization/WebsiteNormalizer.swift`
   - Shared website/domain helper for compact-domain detection, leading-domain normalization, and standalone website checks.
   - Used by list marker parsing/detection and dictionary email normalization to keep website rules centralized.
+- `Core/Normalization/MathExpressionNormalizer.swift`
+  - Shared deterministic math normalizer pass used by post-processing before list parsing.
+  - Converts high-confidence spoken math into symbol form while preserving non-math structures and protected spans.
+- `Core/Normalization/CodeishLineDetector.swift`
+  - Shared utility for code-ish text guards consumed by capitalization/math normalization paths.
 - `Core/Normalization/ColonNormalizer.swift`
   - Provides spoken-colon normalization before list detection to stabilize `label colon value` phrasing into deterministic punctuation.
 - `Core/Normalization/CharacterSpamNormalizer.swift`

--- a/Docs/ENGINEERING.md
+++ b/Docs/ENGINEERING.md
@@ -29,7 +29,7 @@ KeyVox is organized by responsibility:
 - `Core/Transcription/`: Runtime state machine and the transcribe -> post-process -> paste orchestration boundary (`TranscriptionManager`, `DictationPipeline`, `TranscriptionPostProcessor`).
 - `Core/Audio/`: Recording, stream processing, silence classification, and threshold policy.
 - `Core/AI/Dictionary/` and `Core/Lists/`: Deterministic dictionary correction and list parsing/rendering.
-- `Core/Normalization/`: Ordered pure normalization passes (email/website, colon, laughter, spam, whitespace, capitalization, terminal punctuation, all-caps override).
+- `Core/Normalization/`: Ordered pure normalization passes (email/website, colon, math, laughter, spam, whitespace, capitalization, terminal punctuation, all-caps override) plus shared normalization utilities (for example code-ish line detection guards).
 - `Core/Services/`: Whisper inference, paste/injection, and update/checking services.
 - `Core/Overlay/`: Floating overlay lifecycle, persistence, and motion.
 - `Views/`: Onboarding/settings/warnings and presentation-only UI composition.
@@ -54,11 +54,12 @@ For the full file-level map, see [`CODEMAP.md`](CODEMAP.md).
 3. `EmailAddressNormalizer` runs first (email literal case + punctuation/sentence-boundary cleanup).
 4. Dictionary correction applies custom-word adherence, including dictionary-backed spoken/literal email recovery.
 5. `ColonNormalizer` converts spoken/delimiter colon phrases into deterministic punctuation before list parsing.
-6. List formatting applies numeric list rendering when confidence gates pass.
-7. Dedicated laughter normalization (`LaughterNormalizer`) and repeated-character spam cleanup (`CharacterSpamNormalizer`) run, then time normalization (`TimeExpressionNormalizer`) and final email boundary repair.
-8. Normalization helpers apply render-mode whitespace, capitalization guards, and terminal-time punctuation completion.
-9. `AllCapsOverrideNormalizer` applies a final uppercase override when Caps Lock mode is active.
-10. Final text is inserted via the paste service.
+6. `MathExpressionNormalizer` converts high-confidence spoken math into deterministic symbol form while preserving protected URL/email/code/time/date/version spans.
+7. List formatting applies numeric list rendering when confidence gates pass.
+8. Dedicated laughter normalization (`LaughterNormalizer`) and repeated-character spam cleanup (`CharacterSpamNormalizer`) run, then time normalization (`TimeExpressionNormalizer`) and final email boundary repair.
+9. Normalization helpers apply render-mode whitespace, capitalization guards (including shared code-ish line guards), and terminal-time punctuation completion.
+10. `AllCapsOverrideNormalizer` applies a final uppercase override when Caps Lock mode is active.
+11. Final text is inserted via the paste service.
 
 ## Update Feed and Release Checks
 

--- a/KeyVox.xcodeproj/project.pbxproj
+++ b/KeyVox.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		AB3000422F60000100AA0001 /* TranscriptionPostProcessorTests+LanguageHeuristics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000422F60000100AA0001 /* TranscriptionPostProcessorTests+LanguageHeuristics.swift */; };
 		AB3000432F60000100AA0001 /* TranscriptionPostProcessorTests+MathNormalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000432F60000100AA0001 /* TranscriptionPostProcessorTests+MathNormalization.swift */; };
 		B21000112F61000100AA0001 /* MathExpressionNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21000012F61000100AA0001 /* MathExpressionNormalizer.swift */; };
+		B22000112F62000100AA0001 /* CodeishLineDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B22000012F62000100AA0001 /* CodeishLineDetector.swift */; };
 		BF1000012F70000100AA0001 /* OnboardingMicrophoneStepController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2000012F70000100AA0001 /* OnboardingMicrophoneStepController.swift */; };
 		BF1000022F70000100AA0001 /* OnboardingMicrophonePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2000022F70000100AA0001 /* OnboardingMicrophonePickerView.swift */; };
 		C11000122F90000100AA0001 /* ModelDownloader+DownloadLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11000022F90000100AA0001 /* ModelDownloader+DownloadLifecycle.swift */; };
@@ -315,6 +316,7 @@
 		AB2000422F60000100AA0001 /* TranscriptionPostProcessorTests+LanguageHeuristics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptionPostProcessorTests+LanguageHeuristics.swift"; sourceTree = "<group>"; };
 		AB2000432F60000100AA0001 /* TranscriptionPostProcessorTests+MathNormalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptionPostProcessorTests+MathNormalization.swift"; sourceTree = "<group>"; };
 		B21000012F61000100AA0001 /* MathExpressionNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MathExpressionNormalizer.swift; sourceTree = "<group>"; };
+		B22000012F62000100AA0001 /* CodeishLineDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodeishLineDetector.swift; sourceTree = "<group>"; };
 		BF2000012F70000100AA0001 /* OnboardingMicrophoneStepController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMicrophoneStepController.swift; sourceTree = "<group>"; };
 		BF2000022F70000100AA0001 /* OnboardingMicrophonePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMicrophonePickerView.swift; sourceTree = "<group>"; };
 		C11000022F90000100AA0001 /* ModelDownloader+DownloadLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelDownloader+DownloadLifecycle.swift"; sourceTree = "<group>"; };
@@ -797,6 +799,7 @@
 				F1B100012FC2000100AA0001 /* WebsiteNormalizer.swift */,
 				E71000012FB2000100AA0001 /* TimeExpressionNormalizer.swift */,
 				B21000012F61000100AA0001 /* MathExpressionNormalizer.swift */,
+				B22000012F62000100AA0001 /* CodeishLineDetector.swift */,
 				C13000052F92000100AA0001 /* WhitespaceNormalizer.swift */,
 				C13000062F92000100AA0001 /* SentenceCapitalizationNormalizer.swift */,
 				C13000072F92000100AA0001 /* TerminalPunctuationNormalizer.swift */,
@@ -995,6 +998,7 @@
 				8EE602832F4117470094EC16 /* TranscriptionPostProcessor.swift in Sources */,
 				E71000112FB2000100AA0001 /* TimeExpressionNormalizer.swift in Sources */,
 				B21000112F61000100AA0001 /* MathExpressionNormalizer.swift in Sources */,
+				B22000112F62000100AA0001 /* CodeishLineDetector.swift in Sources */,
 				C13000142F92000100AA0001 /* WhitespaceNormalizer.swift in Sources */,
 				C13000152F92000100AA0001 /* SentenceCapitalizationNormalizer.swift in Sources */,
 				C13000162F92000100AA0001 /* TerminalPunctuationNormalizer.swift in Sources */,

--- a/KeyVox.xcodeproj/project.pbxproj
+++ b/KeyVox.xcodeproj/project.pbxproj
@@ -139,6 +139,8 @@
 		AB3000402F60000100AA0001 /* TranscriptionPostProcessorTests+Email.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000402F60000100AA0001 /* TranscriptionPostProcessorTests+Email.swift */; };
 		AB3000412F60000100AA0001 /* TranscriptionPostProcessorTests+CapitalizationAndTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000412F60000100AA0001 /* TranscriptionPostProcessorTests+CapitalizationAndTime.swift */; };
 		AB3000422F60000100AA0001 /* TranscriptionPostProcessorTests+LanguageHeuristics.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000422F60000100AA0001 /* TranscriptionPostProcessorTests+LanguageHeuristics.swift */; };
+		AB3000432F60000100AA0001 /* TranscriptionPostProcessorTests+MathNormalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000432F60000100AA0001 /* TranscriptionPostProcessorTests+MathNormalization.swift */; };
+		B21000112F61000100AA0001 /* MathExpressionNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B21000012F61000100AA0001 /* MathExpressionNormalizer.swift */; };
 		BF1000012F70000100AA0001 /* OnboardingMicrophoneStepController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2000012F70000100AA0001 /* OnboardingMicrophoneStepController.swift */; };
 		BF1000022F70000100AA0001 /* OnboardingMicrophonePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2000022F70000100AA0001 /* OnboardingMicrophonePickerView.swift */; };
 		C11000122F90000100AA0001 /* ModelDownloader+DownloadLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11000022F90000100AA0001 /* ModelDownloader+DownloadLifecycle.swift */; };
@@ -311,6 +313,8 @@
 		AB2000402F60000100AA0001 /* TranscriptionPostProcessorTests+Email.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptionPostProcessorTests+Email.swift"; sourceTree = "<group>"; };
 		AB2000412F60000100AA0001 /* TranscriptionPostProcessorTests+CapitalizationAndTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptionPostProcessorTests+CapitalizationAndTime.swift"; sourceTree = "<group>"; };
 		AB2000422F60000100AA0001 /* TranscriptionPostProcessorTests+LanguageHeuristics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptionPostProcessorTests+LanguageHeuristics.swift"; sourceTree = "<group>"; };
+		AB2000432F60000100AA0001 /* TranscriptionPostProcessorTests+MathNormalization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TranscriptionPostProcessorTests+MathNormalization.swift"; sourceTree = "<group>"; };
+		B21000012F61000100AA0001 /* MathExpressionNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MathExpressionNormalizer.swift; sourceTree = "<group>"; };
 		BF2000012F70000100AA0001 /* OnboardingMicrophoneStepController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMicrophoneStepController.swift; sourceTree = "<group>"; };
 		BF2000022F70000100AA0001 /* OnboardingMicrophonePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMicrophonePickerView.swift; sourceTree = "<group>"; };
 		C11000022F90000100AA0001 /* ModelDownloader+DownloadLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ModelDownloader+DownloadLifecycle.swift"; sourceTree = "<group>"; };
@@ -639,6 +643,7 @@
 				AB2000402F60000100AA0001 /* TranscriptionPostProcessorTests+Email.swift */,
 				AB2000412F60000100AA0001 /* TranscriptionPostProcessorTests+CapitalizationAndTime.swift */,
 				AB2000422F60000100AA0001 /* TranscriptionPostProcessorTests+LanguageHeuristics.swift */,
+				AB2000432F60000100AA0001 /* TranscriptionPostProcessorTests+MathNormalization.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -791,6 +796,7 @@
 				9C3000062F4D000100AA0001 /* EmailAddressNormalizer.swift */,
 				F1B100012FC2000100AA0001 /* WebsiteNormalizer.swift */,
 				E71000012FB2000100AA0001 /* TimeExpressionNormalizer.swift */,
+				B21000012F61000100AA0001 /* MathExpressionNormalizer.swift */,
 				C13000052F92000100AA0001 /* WhitespaceNormalizer.swift */,
 				C13000062F92000100AA0001 /* SentenceCapitalizationNormalizer.swift */,
 				C13000072F92000100AA0001 /* TerminalPunctuationNormalizer.swift */,
@@ -988,6 +994,7 @@
 				8F4402032F46010000DD4401 /* ListRenderer.swift in Sources */,
 				8EE602832F4117470094EC16 /* TranscriptionPostProcessor.swift in Sources */,
 				E71000112FB2000100AA0001 /* TimeExpressionNormalizer.swift in Sources */,
+				B21000112F61000100AA0001 /* MathExpressionNormalizer.swift in Sources */,
 				C13000142F92000100AA0001 /* WhitespaceNormalizer.swift in Sources */,
 				C13000152F92000100AA0001 /* SentenceCapitalizationNormalizer.swift in Sources */,
 				C13000162F92000100AA0001 /* TerminalPunctuationNormalizer.swift in Sources */,
@@ -1042,6 +1049,7 @@
 				AB3000402F60000100AA0001 /* TranscriptionPostProcessorTests+Email.swift in Sources */,
 				AB3000412F60000100AA0001 /* TranscriptionPostProcessorTests+CapitalizationAndTime.swift in Sources */,
 				AB3000422F60000100AA0001 /* TranscriptionPostProcessorTests+LanguageHeuristics.swift in Sources */,
+				AB3000432F60000100AA0001 /* TranscriptionPostProcessorTests+MathNormalization.swift in Sources */,
 				AB3000072F60000100AA0001 /* PhoneticEncoderTests.swift in Sources */,
 				AB3000082F60000100AA0001 /* ReplacementScorerTests.swift in Sources */,
 				AB3000292F60000100AA0001 /* CustomVocabularyNormalizerTests.swift in Sources */,

--- a/KeyVoxTests/Core/TranscriptionPostProcessorTests+CapitalizationAndTime.swift
+++ b/KeyVoxTests/Core/TranscriptionPostProcessorTests+CapitalizationAndTime.swift
@@ -92,6 +92,83 @@ extension TranscriptionPostProcessorTests {
 
         XCTAssertEqual(output, "I think you're so cool. And honestly, I wish I could be like you.")
     }
+    func testCapitalizesStandaloneLowercasePronounIInProse() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "I'm sorry i love you.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "I'm sorry I love you.")
+    }
+    func testCapitalizesMultipleStandaloneLowercasePronounIWithPunctuation() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "i, then i; finally i.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "I, then I; finally I.")
+    }
+    func testCapitalizesStandalonePronounIWithoutTouchingEmbeddedWords() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "inside bit i am",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Inside bit I am")
+    }
+    func testKeepsEmailLocalPartLowercaseIAndCapitalizesStandalonePronounI() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "reach me at i@example.com and i will reply",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Reach me at i@example.com and I will reply")
+    }
+    func testKeepsURLSubdomainLowercaseIAndCapitalizesStandalonePronounI() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "visit https://i.example.com and i can explain",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Visit https://i.example.com and I can explain")
+    }
+    func testDoesNotCapitalizeVariableIInCodeishLine() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "for (i = 0; i < n; i++) { total += i; }",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "For (i = 0; i < n; i++) { total += i; }")
+    }
+    func testDoesNotCapitalizeVariableIInAssignmentLikeLine() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "let i = value",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Let i = value")
+    }
     func testPreservesDaypartPhrasingForHyphenSeparatedTimes() {
         let processor = TranscriptionPostProcessor()
 

--- a/KeyVoxTests/Core/TranscriptionPostProcessorTests+MathNormalization.swift
+++ b/KeyVoxTests/Core/TranscriptionPostProcessorTests+MathNormalization.swift
@@ -1,0 +1,323 @@
+import Foundation
+import XCTest
+@testable import KeyVox
+
+@MainActor
+extension TranscriptionPostProcessorTests {
+    func testNormalizesBasicSpokenAddition() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "12 plus 8",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "12 + 8")
+    }
+
+    func testNormalizesPercentEqualsAndExponentPhrases() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "3 squared equals 9 and 50 percent",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "3^2 = 9 and 50%")
+    }
+
+    func testNormalizesCubedToExponent() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "4 cubed",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "4^3")
+    }
+
+    func testNormalizesToThePowerOfPhrase() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "2 to the power of 5",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "2^5")
+    }
+
+    func testNormalizesToTheOrdinalPowerPhrase() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "7 to the fourth power",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "7^4")
+    }
+
+    func testNormalizesRaisedToPhrase() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "9 raised to 3",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "9^3")
+    }
+
+    func testNormalizesRaisedToOrdinalPhrase() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "9 raised to the third power",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "9^3")
+    }
+
+    func testNormalizesXMultiplicationThenPlusForStandaloneMath() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "2x2, plus 6.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "2 * 2 + 6")
+    }
+
+    func testNormalizesXMultiplicationThenDivisionForStandaloneMath() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "4x5 divided by 2.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "4 * 5 / 2")
+    }
+
+    func testNormalizesCombinedOperatorPhrasesInSingleUtterance() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "2x2 plus 6 divided by 3.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "2 * 2 + 6 / 3")
+    }
+
+    func testPreservesTerminalPunctuationForSentenceContainingCombinedMathPhrase() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Please compute 2x2, plus 6.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Please compute 2 * 2 + 6.")
+    }
+
+    func testNormalizesSubtractWordingInStandaloneMath() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "10 subtract 3.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "10 - 3")
+    }
+
+    func testNormalizesSubtractedByWordingInStandaloneMath() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "10 subtracted by 3.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "10 - 3")
+    }
+
+    func testNormalizesSymbolicDivisionFollowedByMultipliedByPhrase() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "50 / 2 multiplied by 6.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "50 / 2 * 6")
+    }
+
+    func testNormalizesMathInsideParagraphsWithoutChangingStructure() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            """
+            Budget update:
+            we calculated 12 plus 8 for phase one.
+
+            then 3 power of 2 equals 9.
+            """,
+            dictionaryEntries: [],
+            renderMode: .multiline
+        )
+
+        XCTAssertEqual(
+            output,
+            """
+            Budget update:
+            We calculated 12 + 8 for phase one.
+
+            Then 3^2 = 9.
+            """
+        )
+    }
+
+    func testNormalizesMathInsideNumberedListsWithoutBreakingMarkers() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            """
+            1. 12 plus 8
+            2. 50 percent
+            3. 3 squared
+            """,
+            dictionaryEntries: [],
+            renderMode: .multiline
+        )
+
+        XCTAssertEqual(
+            output,
+            """
+            1. 12 + 8
+            2. 50%
+            3. 3^2
+            """
+        )
+    }
+
+    func testSkipsUrlAndEmailTokensWhileStillNormalizingMathInSentence() {
+        let processor = TranscriptionPostProcessor()
+        let entries = [DictionaryEntry(phrase: "dom@example.com")]
+
+        let output = processor.process(
+            "Visit www.example.com and email dom@example.com then compute 12 plus 8.",
+            dictionaryEntries: entries,
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Visit www.example.com and email dom@example.com then compute 12 + 8.")
+    }
+
+    func testSkipsCodeishLinesEntirely() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "`for (i = 0; i < n; i++) { total += 12 plus 8; }`",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "`for (i = 0; i < n; i++) { total += 12 plus 8; }`")
+    }
+
+    func testSkipsTimeDateAndVersionShapes() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Meet at 4:15 PM on 2026-02-19 and version 1.2.3 while we do 12 plus 8.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Meet at 4:15 PM on 2026-02-19 and version 1.2.3 while we do 12 + 8.")
+    }
+
+    func testTreatsHyphenAsSubtractionOnlyBetweenNumbers() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Date 2026-02-19 but 12-8 is subtraction.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Date 2026-02-19 but 12 - 8 is subtraction.")
+    }
+
+    func testMathNormalizationIsIdempotentAcrossPipeline() {
+        let processor = TranscriptionPostProcessor()
+        let first = processor.process(
+            "12 plus 8 and 3 squared equals 9 and 50 percent",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+        let second = processor.process(
+            first,
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(first, second)
+    }
+
+    func testStripsTerminalPunctuationForStandaloneMathUtterance() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "12 plus 8.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "12 + 8")
+    }
+
+    func testPreservesTerminalPunctuationWhenMathIsInSentence() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Please compute 12 plus 8.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Please compute 12 + 8.")
+    }
+
+    func testStripsQuestionMarkForStandaloneMathUtterance() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "3 squared equals 9?",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "3^2 = 9")
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spoken math is now converted to symbolic form in transcriptions (e.g., "12 plus 8" → "12 + 8"), with safe handling to avoid altering URLs, emails, timestamps, or code-like text.
  * Improved capitalization of standalone "I" with better context awareness.

* **Documentation**
  * Normalization pipeline and related utilities documented.

* **Tests**
  * Extensive tests added to validate math normalization and capitalization behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->