### PR TITLE
pr: prevent split-join from consuming trailing words after exact brand matches

### DIFF
--- a/Core/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinScoring.swift
+++ b/Core/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinScoring.swift
@@ -1,5 +1,4 @@
 import Foundation
-import NaturalLanguage
 
 private enum SplitJoinScoringConstants {
     static let hyphenLaneMinimumFirstTokenLength = 1
@@ -82,10 +81,9 @@ extension DictionaryMatcher {
             let candidateIsCommonWord = lexicon.isCommonWord(candidateToken)
 
             // If the first token already matches the single-token candidate
-            // exactly, do not allow split-join to consume a following
-            // conjunction (e.g. "KeyVox, and" -> "KeyVox").
-            if window[0].normalized == candidateToken,
-               window[1].lexicalClass == .conjunction {
+            // exactly, split-join must not consume the following token
+            // (e.g. "KeyVox, and" -> "KeyVox" or "KeyVox bug" -> "KeyVox").
+            if window[0].normalized == candidateToken {
                 continue
             }
 

--- a/KeyVox.xcodeproj/xcshareddata/xcschemes/KeyVox DEBUG.xcscheme
+++ b/KeyVox.xcodeproj/xcshareddata/xcschemes/KeyVox DEBUG.xcscheme
@@ -88,7 +88,7 @@
          <EnvironmentVariable
             key = "KVX_DEBUG_LOG_RAW_TEXT"
             value = "1"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/KeyVoxTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/KeyVoxTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -241,6 +241,21 @@ final class DictionaryMatcherTests: XCTestCase {
         )
     }
 
+    func testDoesNotConsumeNounAfterExactSingleTokenBrandInSplitJoinPath() {
+        let matcher = DictionaryMatcher(
+            lexicon: PronunciationLexicon.shared,
+            encoder: PhoneticEncoder(),
+            scorer: .balanced
+        )
+        matcher.rebuildIndex(entries: [
+            DictionaryEntry(phrase: "KeyVox"),
+        ])
+
+        let result = matcher.apply(to: "I'm going to catch a KeyVox bug here or there.")
+
+        XCTAssertEqual(result.text, "I'm going to catch a KeyVox bug here or there.")
+    }
+
     func testDisambiguatesCommonWordBrandTailToCorrectDictionaryEntryWithRuntimeLexicon() {
         let matcher = DictionaryMatcher(
             lexicon: PronunciationLexicon.shared,


### PR DESCRIPTION
## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text processing logic to better handle exact brand names in split-join evaluation, preventing unintended noun consumption after single-token brands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->