### PR TITLE
feat(overlay): add indigo hands-free lock indicator and shift preview state

### DIFF
--- a/Core/Overlay/OverlayManager.swift
+++ b/Core/Overlay/OverlayManager.swift
@@ -6,6 +6,8 @@ import SwiftUI
 class OverlayVisibilityManager: ObservableObject {
     @Published var isVisible: Bool = false
     @Published var shouldDismiss: Bool = false
+    @Published var isHandsFreeLocked: Bool = false
+    @Published var isHandsFreeModifierPreviewActive: Bool = false
 }
 
 class OverlayManager {
@@ -81,10 +83,20 @@ class OverlayManager {
         }
     }
 
+    func setHandsFreeLocked(_ isLocked: Bool) {
+        visibilityManager.isHandsFreeLocked = isLocked
+    }
+
+    func setHandsFreeModifierPreviewActive(_ isActive: Bool) {
+        visibilityManager.isHandsFreeModifierPreviewActive = isActive
+    }
+
     func hide() {
         pendingHideWorkItem?.cancel()
         motionController.cancelPendingMotionAnimations(panel: window)
 
+        visibilityManager.isHandsFreeLocked = false
+        visibilityManager.isHandsFreeModifierPreviewActive = false
         visibilityManager.isVisible = false
         visibilityManager.shouldDismiss = true
 

--- a/Core/Transcription/TranscriptionManager.swift
+++ b/Core/Transcription/TranscriptionManager.swift
@@ -88,6 +88,13 @@ class TranscriptionManager: ObservableObject {
                 self?.handleTriggerKey(isPressed: isPressed)
             }
             .store(in: &cancellables)
+
+        keyboardMonitor.$isShiftPressed
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateOverlayHandsFreeVisualState()
+            }
+            .store(in: &cancellables)
             
         keyboardMonitor.$escapePressedSignal
             .dropFirst()
@@ -140,6 +147,7 @@ class TranscriptionManager: ObservableObject {
         audioRecorder.stopRecording { _ in }
         whisperService.cancelTranscription()
         isLocked = false
+        updateOverlayHandsFreeVisualState()
         OverlayManager.shared.hide()
         state = .idle
     }
@@ -153,6 +161,7 @@ class TranscriptionManager: ObservableObject {
             } else if state == .recording && isLocked {
                 // If we are locked and press the key again, stop recording
                 isLocked = false
+                OverlayManager.shared.setHandsFreeLocked(false)
                 stopRecordingAndTranscribe()
             }
         } else {
@@ -160,6 +169,7 @@ class TranscriptionManager: ObservableObject {
             if state == .recording {
                 if keyboardMonitor.isShiftPressed {
                     isLocked = true
+                    OverlayManager.shared.setHandsFreeLocked(true)
                     #if DEBUG
                     print("Hands-free mode LOCKED")
                     #endif
@@ -168,6 +178,8 @@ class TranscriptionManager: ObservableObject {
                 }
             }
         }
+
+        updateOverlayHandsFreeVisualState()
     }
     
     private func startRecording() {
@@ -188,6 +200,7 @@ class TranscriptionManager: ObservableObject {
 
         state = .recording
         WarningManager.shared.hide()
+        updateOverlayHandsFreeVisualState()
         OverlayManager.shared.show(recorder: audioRecorder)
         audioRecorder.startRecording()
     }
@@ -205,6 +218,7 @@ class TranscriptionManager: ObservableObject {
         
         isLocked = false
         cachedCapsLockIsOn = keyboardMonitor.isCapsLockOn
+        updateOverlayHandsFreeVisualState()
 
         audioRecorder.stopRecording { [weak self] frames in
             guard let self = self else { return }
@@ -310,6 +324,15 @@ class TranscriptionManager: ObservableObject {
                 }
             }
         }
+    }
+
+    private func updateOverlayHandsFreeVisualState() {
+        let isPreviewActive = state == .recording &&
+            !isLocked &&
+            keyboardMonitor.isTriggerKeyPressed &&
+            keyboardMonitor.isShiftPressed
+        OverlayManager.shared.setHandsFreeLocked(isLocked)
+        OverlayManager.shared.setHandsFreeModifierPreviewActive(isPreviewActive)
     }
     
     private func playSound(named name: String) {

--- a/Core/Transcription/TranscriptionManager.swift
+++ b/Core/Transcription/TranscriptionManager.swift
@@ -161,7 +161,6 @@ class TranscriptionManager: ObservableObject {
             } else if state == .recording && isLocked {
                 // If we are locked and press the key again, stop recording
                 isLocked = false
-                OverlayManager.shared.setHandsFreeLocked(false)
                 stopRecordingAndTranscribe()
             }
         } else {
@@ -169,7 +168,6 @@ class TranscriptionManager: ObservableObject {
             if state == .recording {
                 if keyboardMonitor.isShiftPressed {
                     isLocked = true
-                    OverlayManager.shared.setHandsFreeLocked(true)
                     #if DEBUG
                     print("Hands-free mode LOCKED")
                     #endif

--- a/Views/RecordingOverlay.swift
+++ b/Views/RecordingOverlay.swift
@@ -34,7 +34,7 @@ struct RecordingOverlay: View {
                 .fill(Color.black.opacity(0.8))
                 .overlay(
                     Circle()
-                        .stroke(Color.yellow.opacity(0.6), lineWidth: 2)
+                        .stroke(overlayRingColor.opacity(0.6), lineWidth: 2)
                 )
                 .shadow(radius: 10)
                 .frame(width: isDevModeOversized ? 300 : 50, height: isDevModeOversized ? 300 : 50)
@@ -138,6 +138,10 @@ struct RecordingOverlay: View {
     private func stopRippleAnimation() {
         rippleTimer?.invalidate()
         rippleTimer = nil
+    }
+
+    private var overlayRingColor: Color {
+        (visibilityManager.isHandsFreeLocked || visibilityManager.isHandsFreeModifierPreviewActive) ? .indigo : .yellow
     }
 }
 


### PR DESCRIPTION
- change recording overlay ring from fixed yellow to state-driven color
- show indigo ring while Shift is held during trigger press (pre-lock preview)
- keep ring indigo after Shift+trigger release commits hands-free lock
- reset overlay ring to yellow when lock is cleared / overlay hides
- wire TranscriptionManager lock + Shift modifier state into OverlayManager visibility state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hands-free recording now tracks a lock state and a "modifier preview" mode, affecting behavior when using the trigger key and Shift.
  * Trigger + Shift interactions can lock/unlock hands-free and influence transcription start/stop.

* **UI**
  * Overlay ring color switches to Indigo when locked or in modifier preview, otherwise Yellow.

* **Bug Fixes**
  * Overlay hands-free states are cleared when the overlay is hidden to keep UI consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->