### PR TITLE
feat(normalization): normalize hour-only am/pm variants to full clock times

### DIFF
--- a/Core/Normalization/TimeExpressionNormalizer.swift
+++ b/Core/Normalization/TimeExpressionNormalizer.swift
@@ -43,6 +43,15 @@ struct TimeExpressionNormalizer {
             return "\(formatted) \(normalizedMeridiem(meridiem))"
         }
 
+        output = replacingMatches(
+            pattern: #"\b([1-9]|1[0-2])[\s-]*(\#(meridiemPattern))(?=$|\s|[,;:!?\)\.])"#,
+            in: output
+        ) { match, nsText in
+            let hour = nsText.substring(with: match.range(at: 1))
+            let meridiem = nsText.substring(with: match.range(at: 2))
+            return "\(hour):00 \(normalizedMeridiem(meridiem))"
+        }
+
         // Balanced fuzzy-AM pass: map "AND" only when it behaves like a terminal meridiem token.
         output = replacingMatches(
             pattern: #"\b([1-9]|1[0-2])[:\.-]([0-5][0-9])[\s-]*and\.?(?=$|[,;:!?\)\.])"#,

--- a/KeyVoxTests/Core/TranscriptionPostProcessorTests+CapitalizationAndTime.swift
+++ b/KeyVoxTests/Core/TranscriptionPostProcessorTests+CapitalizationAndTime.swift
@@ -15,6 +15,17 @@ extension TranscriptionPostProcessorTests {
 
         XCTAssertTrue(output == "3:15 AM 3:17 AM 4:19 PM")
     }
+    func testNormalizesHourOnlyMeridiemVariantsToFullTime() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "10am 10 a.m. 10AM 10pm 10 p.m. 10PM",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "10:00 AM 10:00 AM 10:00 AM 10:00 PM 10:00 PM 10:00 PM")
+    }
     func testPreservesDaypartPhrasingWhileFixingTimeShape() {
         let processor = TranscriptionPostProcessor()
 


### PR DESCRIPTION
### Time Normalization 
- add support in TimeExpressionNormalizer for hour-only meridiem expressions:
  - `10am`, `10 a.m.`, `10AM`
  - `10pm`, `10 p.m.`, `10PM`
- normalize those variants to the full project time format with minutes:
  - `10:00 AM`
  - `10:00 PM`

Implementation details:
- add a dedicated hour-only regex pass for `[1-12] + meridiem` tokens
- reuse existing meridiem canonicalization so dotted/cased variants map to `AM`/`PM`
- emit `:00` minutes for hour-only inputs while leaving existing minute-bearing time normalization unchanged

Tests:
- add regression coverage in `TranscriptionPostProcessorTests+CapitalizationAndTime` for all requested hour-only variants and assert full-time output
- keep existing compact/dotted minute-based normalization test passing

Notes:
- removed the temporary standalone `TimeExpressionNormalizerTests` file because it was not part of the Xcode test target; regression coverage now lives in an existing in-target test file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved time expression normalization. Time inputs without explicit minutes (e.g., "9 am", "9-pm") are now automatically converted to full hour format with zero minutes (e.g., "9:00 AM", "9:00 PM").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->