### PR TITLE
fix(normalization): handle split-meridiem hyphenated times and protect them from math parsing

### DIFF
--- a/Core/Normalization/MathExpressionNormalizer.swift
+++ b/Core/Normalization/MathExpressionNormalizer.swift
@@ -51,7 +51,7 @@ struct MathExpressionNormalizer {
         options: []
     )
     private static let protectedMalformedTimeWithMeridiemRegex: NSRegularExpression? = try? NSRegularExpression(
-        pattern: #"(?i)\b(?:[1-9]|1[0-2])[.-][0-5][0-9](?:\s*(?:a\.?m\.?|am|a\.?n\.?|an|p\.?m\.?|pm))\b"#,
+        pattern: #"(?i)\b(?:[1-9]|1[0-2])\s*[.-]\s*[0-5][0-9](?:[\s-]*(?:a[\s.-]*m\.?|a[\s.-]*n\.?|p[\s.-]*m\.?))\b"#,
         options: []
     )
     private static let protectedMalformedTimeWithDaypartRegex: NSRegularExpression? = try? NSRegularExpression(

--- a/Core/Normalization/TimeExpressionNormalizer.swift
+++ b/Core/Normalization/TimeExpressionNormalizer.swift
@@ -137,7 +137,7 @@ struct TimeExpressionNormalizer {
             .lowercased()
             .replacingOccurrences(of: ".", with: "")
             .replacingOccurrences(of: "-", with: "")
-            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: #"\s"#, with: "", options: .regularExpression)
         if lettersOnly == "am" || lettersOnly == "an" { return "AM" }
         if lettersOnly == "pm" { return "PM" }
         return value

--- a/Core/Normalization/TimeExpressionNormalizer.swift
+++ b/Core/Normalization/TimeExpressionNormalizer.swift
@@ -6,8 +6,8 @@ struct TimeExpressionNormalizer {
 
         let daypartPattern =
             "(?:in the morning|this morning|in the afternoon|this afternoon|in the evening|this evening|at night|tonight)"
-        let amMeridiemPattern = "(?:a\\.?m\\.?|am|a\\.?n\\.?|an)"
-        let pmMeridiemPattern = "(?:p\\.?m\\.?|pm)"
+        let amMeridiemPattern = "(?:a[\\s\\.-]*m\\.?|a[\\s\\.-]*n\\.?)"
+        let pmMeridiemPattern = "(?:p[\\s\\.-]*m\\.?)"
         let meridiemPattern = "(?:\(amMeridiemPattern)|\(pmMeridiemPattern))"
 
         var output = text
@@ -24,7 +24,7 @@ struct TimeExpressionNormalizer {
         }
 
         output = replacingMatches(
-            pattern: #"\b([1-9]|1[0-2])[\.-]([0-5][0-9])[\s-]*(\#(meridiemPattern))(?=$|\s|[,;:!?\)\.])"#,
+            pattern: #"\b([1-9]|1[0-2])\s*[\.-]\s*([0-5][0-9])[\s-]*(\#(meridiemPattern))(?=$|\s|[,;:!?\)\.])"#,
             in: output
         ) { match, nsText in
             let hour = nsText.substring(with: match.range(at: 1))
@@ -73,7 +73,7 @@ struct TimeExpressionNormalizer {
 
         // Preserve spoken daypart phrases and only normalize malformed numeric time shape.
         output = replacingMatches(
-            pattern: #"\b([1-9]|1[0-2])[\.-]([0-5][0-9])(?=\s+\#(daypartPattern)\b)"#,
+            pattern: #"\b([1-9]|1[0-2])\s*[\.-]\s*([0-5][0-9])(?=\s+\#(daypartPattern)\b)"#,
             in: output
         ) { match, nsText in
             let hour = nsText.substring(with: match.range(at: 1))
@@ -136,6 +136,8 @@ struct TimeExpressionNormalizer {
         let lettersOnly = value
             .lowercased()
             .replacingOccurrences(of: ".", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: " ", with: "")
         if lettersOnly == "am" || lettersOnly == "an" { return "AM" }
         if lettersOnly == "pm" { return "PM" }
         return value

--- a/Core/Normalization/TimeExpressionNormalizer.swift
+++ b/Core/Normalization/TimeExpressionNormalizer.swift
@@ -6,8 +6,8 @@ struct TimeExpressionNormalizer {
 
         let daypartPattern =
             "(?:in the morning|this morning|in the afternoon|this afternoon|in the evening|this evening|at night|tonight)"
-        let amMeridiemPattern = "(?:a[\\s\\.-]*m\\.?|a[\\s\\.-]*n\\.?)"
-        let pmMeridiemPattern = "(?:p[\\s\\.-]*m\\.?)"
+        let amMeridiemPattern = "a[\\s\\.-]{0,3}(?:m\\.?|n\\.?)"
+        let pmMeridiemPattern = "p[\\s\\.-]{0,3}m\\.?"
         let meridiemPattern = "(?:\(amMeridiemPattern)|\(pmMeridiemPattern))"
 
         var output = text

--- a/KeyVoxTests/Core/TranscriptionPostProcessorTests+CapitalizationAndTime.swift
+++ b/KeyVoxTests/Core/TranscriptionPostProcessorTests+CapitalizationAndTime.swift
@@ -26,6 +26,17 @@ extension TranscriptionPostProcessorTests {
 
         XCTAssertEqual(output, "10:00 AM 10:00 AM 10:00 AM 10:00 PM 10:00 PM 10:00 PM")
     }
+    func testNormalizesHyphenSeparatedTimesWithSplitMeridiemAndMathSpacedVariant() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "10-01-A-M 10 - 03-AM 10 - 04-A-M 10-05-P-M",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "10:01 AM 10:03 AM 10:04 AM 10:05 PM")
+    }
     func testPreservesDaypartPhrasingWhileFixingTimeShape() {
         let processor = TranscriptionPostProcessor()
 


### PR DESCRIPTION
fix(normalization): handle split-meridiem hyphenated times and protect them from math parsing

- expand malformed-time meridiem matching to accept split variants like `A-M` / `P-M` and optional spacing around separators in time normalization
- normalize meridiem tokens after stripping dots, hyphens, and spaces so variant inputs collapse to standard `AM` / `PM`
- widen math normalizer malformed-time protection regex so `HH-MM-AM/PM` patterns are not treated as subtraction and reformatted before time normalization runs

Tests:
- add regression coverage for hyphen-separated times with split meridiem tokens, including a math-spaced variant (`10 - 03-AM`, `10 - 04-A-M`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-expression handling to tolerate optional whitespace and varied separators, and to better recognize diverse meridiem formats—reducing incorrect transformations and preserving intended time-like text.

* **Tests**
  * Added a unit test covering hyphen/space-separated time strings with split meridiem and spaced variants to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->