### PR TITLE
feat(audio): replace mic name heuristics with macOS 15 headphone status and update bluetooth messaging

### DIFF
--- a/Core/AudioDeviceManager.swift
+++ b/Core/AudioDeviceManager.swift
@@ -287,6 +287,7 @@ final class AudioDeviceManager: ObservableObject {
                 #if DEBUG
                 print("CMHeadphoneActivityManager status update error: \(error)")
                 #endif
+                return
             }
             guard let self else { return }
             let isConnected = status == .connected

--- a/Core/AudioDeviceManager.swift
+++ b/Core/AudioDeviceManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import AVFoundation
 import CoreAudio
+import CoreMotion
 
 enum MicrophoneKind {
     case builtIn
@@ -96,8 +97,12 @@ final class AudioDeviceManager: ObservableObject {
 
     private var deviceObservers: [NSObjectProtocol] = []
     private var cancellables = Set<AnyCancellable>()
+    private var compatibleHeadphonesConnected = false
+    private var headphoneActivityManager: AnyObject?
+    private var headphoneStatusQueue: OperationQueue?
 
     var selectedMicrophoneUID: String { settingsStore.selectedMicrophoneUID }
+    var hasConnectedCompatibleHeadphones: Bool { compatibleHeadphonesConnected }
     var hasRecommendedBuiltInMicrophone: Bool {
         Self.containsRecommendedBuiltInMicrophone(availableMicrophones)
     }
@@ -117,7 +122,7 @@ final class AudioDeviceManager: ObservableObject {
         self.notificationCenter = notificationCenter
         self.startMonitoringOnInit = startMonitoringOnInit
 
-        availableMicrophones = discoverInputMicrophonesProvider()
+        availableMicrophones = applyCompatibleHeadphoneOverrides(to: discoverInputMicrophonesProvider())
         applyInitialSelectionPolicy()
         syncSelectedMicrophone()
         settingsStore.selectedMicrophoneUIDPublisher
@@ -129,12 +134,17 @@ final class AudioDeviceManager: ObservableObject {
 
         if startMonitoringOnInit {
             startMonitoringCaptureDevices()
+            startMonitoringCompatibleHeadphones()
         }
     }
 
     deinit {
         for observer in deviceObservers {
             notificationCenter.removeObserver(observer)
+        }
+        if #available(macOS 15.0, *),
+           let headphoneActivityManager = headphoneActivityManager as? CMHeadphoneActivityManager {
+            headphoneActivityManager.stopStatusUpdates()
         }
     }
 
@@ -185,7 +195,7 @@ final class AudioDeviceManager: ObservableObject {
 
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
-            self.availableMicrophones = discovered
+            self.availableMicrophones = self.applyCompatibleHeadphoneOverrides(to: discovered)
             self.syncSelectedMicrophone()
         }
     }
@@ -260,6 +270,48 @@ final class AudioDeviceManager: ObservableObject {
         deviceObservers = [connectedObserver, disconnectedObserver]
     }
 
+    private func startMonitoringCompatibleHeadphones() {
+        guard #available(macOS 15.0, *) else { return }
+
+        let manager = CMHeadphoneActivityManager()
+        guard manager.isStatusAvailable else { return }
+
+        let queue = OperationQueue()
+        queue.qualityOfService = .utility
+        queue.maxConcurrentOperationCount = 1
+
+        headphoneActivityManager = manager
+        headphoneStatusQueue = queue
+
+        manager.startStatusUpdates(to: queue) { [weak self] status, _ in
+            guard let self else { return }
+            let isConnected = status == .connected
+            DispatchQueue.main.async {
+                guard self.compatibleHeadphonesConnected != isConnected else { return }
+                self.compatibleHeadphonesConnected = isConnected
+                self.refreshAvailableMicrophones()
+            }
+        }
+    }
+
+    private func applyCompatibleHeadphoneOverrides(to microphones: [MicrophoneOption]) -> [MicrophoneOption] {
+        guard compatibleHeadphonesConnected else { return microphones }
+
+        let selectedUID = settingsStore.selectedMicrophoneUID
+        let selectedBluetoothIndex = microphones.firstIndex {
+            $0.id == selectedUID && $0.kind == .bluetooth
+        }
+
+        let bluetoothIndices = microphones.indices.filter { microphones[$0].kind == .bluetooth }
+        let targetIndex = selectedBluetoothIndex ?? (bluetoothIndices.count == 1 ? bluetoothIndices.first : nil)
+        guard let targetIndex else { return microphones }
+
+        var updated = microphones
+        let mic = updated[targetIndex]
+        updated[targetIndex] = MicrophoneOption(id: mic.id, name: mic.name, kind: .airPods, isAvailable: mic.isAvailable)
+        return Self.sortedMicrophones(updated)
+    }
+
     private func deviceForID(_ uniqueID: String) -> AVCaptureDevice? {
         captureAudioDevicesProvider().first(where: { $0.uniqueID == uniqueID })
     }
@@ -309,7 +361,7 @@ final class AudioDeviceManager: ObservableObject {
     }
 
     nonisolated private static func sortRank(for kind: MicrophoneKind) -> Int {
-        // Picker policy: built-in first (recommended), then wired/other, then Bluetooth classes.
+        // Picker policy: built-in first (recommended), then wired/other, then AirPods, then Bluetooth.
         switch kind {
         case .builtIn:
             return 0
@@ -323,33 +375,12 @@ final class AudioDeviceManager: ObservableObject {
     }
 
     nonisolated static func classifyDeviceKind(_ input: AudioDeviceClassificationInput) -> MicrophoneKind {
-        let lowered = input.name.lowercased()
-
-        if lowered.contains("airpods") {
-            return .airPods
-        }
-
         if input.transportType == kAudioDeviceTransportTypeBluetooth ||
             input.transportType == kAudioDeviceTransportTypeBluetoothLE {
             return .bluetooth
         }
 
         if input.transportType == kAudioDeviceTransportTypeBuiltIn {
-            return .builtIn
-        }
-
-        // Name heuristics are a fallback for devices that do not report a reliable CoreAudio transport type.
-        if lowered.contains("bluetooth") ||
-            lowered.contains("hands-free") ||
-            lowered.contains("headset") ||
-            lowered.contains("earbuds") ||
-            lowered.contains("buds") {
-            return .bluetooth
-        }
-
-        if lowered.contains("built-in") ||
-            lowered.contains("built in") ||
-            lowered.contains("internal") {
             return .builtIn
         }
 

--- a/Core/AudioDeviceManager.swift
+++ b/Core/AudioDeviceManager.swift
@@ -127,7 +127,12 @@ final class AudioDeviceManager: ObservableObject {
         settingsStore.selectedMicrophoneUIDPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.syncSelectedMicrophone()
+                guard let self else { return }
+                self.syncSelectedMicrophone()
+                if self.compatibleHeadphonesConnected {
+                    self.recomputeAvailableMicrophoneOverrides()
+                    self.syncSelectedMicrophone()
+                }
             }
             .store(in: &cancellables)
 
@@ -247,6 +252,19 @@ final class AudioDeviceManager: ObservableObject {
 
     private func syncSelectedMicrophone() {
         selectedMicrophone = availableMicrophones.first(where: { $0.id == settingsStore.selectedMicrophoneUID })
+    }
+
+    private func recomputeAvailableMicrophoneOverrides() {
+        let normalized = availableMicrophones.map { microphone in
+            guard microphone.kind == .airPods else { return microphone }
+            return MicrophoneOption(
+                id: microphone.id,
+                name: microphone.name,
+                kind: .bluetooth,
+                isAvailable: microphone.isAvailable
+            )
+        }
+        availableMicrophones = applyCompatibleHeadphoneOverrides(to: normalized)
     }
 
     private func startMonitoringCaptureDevices() {

--- a/Core/AudioDeviceManager.swift
+++ b/Core/AudioDeviceManager.swift
@@ -19,7 +19,6 @@ struct MicrophoneOption: Identifiable, Equatable {
 }
 
 struct AudioDeviceClassificationInput {
-    let name: String
     let transportType: UInt32
 }
 
@@ -283,7 +282,12 @@ final class AudioDeviceManager: ObservableObject {
         headphoneActivityManager = manager
         headphoneStatusQueue = queue
 
-        manager.startStatusUpdates(to: queue) { [weak self] status, _ in
+        manager.startStatusUpdates(to: queue) { [weak self] status, error in
+            if let error {
+                #if DEBUG
+                print("CMHeadphoneActivityManager status update error: \(error)")
+                #endif
+            }
             guard let self else { return }
             let isConnected = status == .connected
             DispatchQueue.main.async {
@@ -295,11 +299,22 @@ final class AudioDeviceManager: ObservableObject {
     }
 
     private func applyCompatibleHeadphoneOverrides(to microphones: [MicrophoneOption]) -> [MicrophoneOption] {
+        Self.applyCompatibleHeadphoneOverrides(
+            to: microphones,
+            compatibleHeadphonesConnected: compatibleHeadphonesConnected,
+            selectedMicrophoneUID: settingsStore.selectedMicrophoneUID
+        )
+    }
+
+    static func applyCompatibleHeadphoneOverrides(
+        to microphones: [MicrophoneOption],
+        compatibleHeadphonesConnected: Bool,
+        selectedMicrophoneUID: String
+    ) -> [MicrophoneOption] {
         guard compatibleHeadphonesConnected else { return microphones }
 
-        let selectedUID = settingsStore.selectedMicrophoneUID
         let selectedBluetoothIndex = microphones.firstIndex {
-            $0.id == selectedUID && $0.kind == .bluetooth
+            $0.id == selectedMicrophoneUID && $0.kind == .bluetooth
         }
 
         let bluetoothIndices = microphones.indices.filter { microphones[$0].kind == .bluetooth }
@@ -309,7 +324,7 @@ final class AudioDeviceManager: ObservableObject {
         var updated = microphones
         let mic = updated[targetIndex]
         updated[targetIndex] = MicrophoneOption(id: mic.id, name: mic.name, kind: .airPods, isAvailable: mic.isAvailable)
-        return Self.sortedMicrophones(updated)
+        return sortedMicrophones(updated)
     }
 
     private func deviceForID(_ uniqueID: String) -> AVCaptureDevice? {
@@ -390,7 +405,6 @@ final class AudioDeviceManager: ObservableObject {
     nonisolated private static func classifyDeviceKind(for device: AVCaptureDevice) -> MicrophoneKind {
         classifyDeviceKind(
             AudioDeviceClassificationInput(
-                name: device.localizedName,
                 transportType: UInt32(bitPattern: device.transportType)
             )
         )

--- a/KeyVoxTests/Core/AudioDeviceManagerTests.swift
+++ b/KeyVoxTests/Core/AudioDeviceManagerTests.swift
@@ -10,40 +10,89 @@ final class AudioDeviceManagerTests: XCTestCase {
     func testClassificationMatrixUsesTransportTypeOnly() {
         XCTAssertEqual(
             AudioDeviceManager.classifyDeviceKind(
-                AudioDeviceClassificationInput(name: "Built-in Microphone", transportType: kAudioDeviceTransportTypeBuiltIn)
+                AudioDeviceClassificationInput(transportType: kAudioDeviceTransportTypeBuiltIn)
             ),
             .builtIn
         )
         XCTAssertEqual(
             AudioDeviceManager.classifyDeviceKind(
-                AudioDeviceClassificationInput(name: "USB Bluetooth Adapter", transportType: kAudioDeviceTransportTypeBluetooth)
+                AudioDeviceClassificationInput(transportType: kAudioDeviceTransportTypeBluetooth)
             ),
             .bluetooth
         )
         XCTAssertEqual(
             AudioDeviceManager.classifyDeviceKind(
-                AudioDeviceClassificationInput(name: "Desk Headset", transportType: kAudioDeviceTransportTypeUSB)
+                AudioDeviceClassificationInput(transportType: kAudioDeviceTransportTypeUSB)
             ),
             .wiredOrOther
         )
         XCTAssertEqual(
             AudioDeviceManager.classifyDeviceKind(
-                AudioDeviceClassificationInput(name: "AirPods Pro", transportType: kAudioDeviceTransportTypeUSB)
+                AudioDeviceClassificationInput(transportType: kAudioDeviceTransportTypeUSB)
             ),
             .wiredOrOther
         )
         XCTAssertEqual(
             AudioDeviceManager.classifyDeviceKind(
-                AudioDeviceClassificationInput(name: "Studio USB Mic", transportType: kAudioDeviceTransportTypeUSB)
+                AudioDeviceClassificationInput(transportType: kAudioDeviceTransportTypeUSB)
             ),
             .wiredOrOther
         )
         XCTAssertEqual(
             AudioDeviceManager.classifyDeviceKind(
-                AudioDeviceClassificationInput(name: "Built In Mic", transportType: kAudioDeviceTransportTypeUSB)
+                AudioDeviceClassificationInput(transportType: kAudioDeviceTransportTypeUSB)
             ),
             .wiredOrOther
         )
+    }
+
+    func testCompatibleHeadphoneOverrideRelabelsSingleBluetoothMicrophoneAsAirPods() {
+        let microphones: [MicrophoneOption] = [
+            .init(id: "usb", name: "USB Mic", kind: .wiredOrOther, isAvailable: true),
+            .init(id: "bt", name: "Bluetooth Headset", kind: .bluetooth, isAvailable: true)
+        ]
+
+        let overridden = AudioDeviceManager.applyCompatibleHeadphoneOverrides(
+            to: microphones,
+            compatibleHeadphonesConnected: true,
+            selectedMicrophoneUID: ""
+        )
+
+        XCTAssertEqual(overridden.first(where: { $0.id == "bt" })?.kind, .airPods)
+        XCTAssertEqual(overridden.first(where: { $0.id == "usb" })?.kind, .wiredOrOther)
+    }
+
+    func testCompatibleHeadphoneOverridePrefersSelectedBluetoothMicrophoneWhenMultipleExist() {
+        let microphones: [MicrophoneOption] = [
+            .init(id: "bt-1", name: "Bluetooth Mic A", kind: .bluetooth, isAvailable: true),
+            .init(id: "bt-2", name: "Bluetooth Mic B", kind: .bluetooth, isAvailable: true),
+            .init(id: "builtin", name: "Built-in Mic", kind: .builtIn, isAvailable: true)
+        ]
+
+        let overridden = AudioDeviceManager.applyCompatibleHeadphoneOverrides(
+            to: microphones,
+            compatibleHeadphonesConnected: true,
+            selectedMicrophoneUID: "bt-2"
+        )
+
+        XCTAssertEqual(overridden.first(where: { $0.id == "bt-2" })?.kind, .airPods)
+        XCTAssertEqual(overridden.first(where: { $0.id == "bt-1" })?.kind, .bluetooth)
+        XCTAssertEqual(overridden.first(where: { $0.id == "builtin" })?.kind, .builtIn)
+    }
+
+    func testCompatibleHeadphoneOverrideLeavesDevicesUnchangedWhenDisconnected() {
+        let microphones: [MicrophoneOption] = [
+            .init(id: "bt", name: "Bluetooth Headset", kind: .bluetooth, isAvailable: true),
+            .init(id: "builtin", name: "Built-in Mic", kind: .builtIn, isAvailable: true)
+        ]
+
+        let overridden = AudioDeviceManager.applyCompatibleHeadphoneOverrides(
+            to: microphones,
+            compatibleHeadphonesConnected: false,
+            selectedMicrophoneUID: "bt"
+        )
+
+        XCTAssertEqual(overridden, microphones)
     }
 
     func testSortedMicrophonesPrioritizeBuiltInThenWiredThenAirPodsThenBluetooth() {

--- a/KeyVoxTests/Core/AudioDeviceManagerTests.swift
+++ b/KeyVoxTests/Core/AudioDeviceManagerTests.swift
@@ -7,7 +7,7 @@ import CoreAudio
 final class AudioDeviceManagerTests: XCTestCase {
     private var cancellables = Set<AnyCancellable>()
 
-    func testClassificationMatrixCoversTransportAndNameHeuristics() {
+    func testClassificationMatrixUsesTransportTypeOnly() {
         XCTAssertEqual(
             AudioDeviceManager.classifyDeviceKind(
                 AudioDeviceClassificationInput(name: "Built-in Microphone", transportType: kAudioDeviceTransportTypeBuiltIn)
@@ -24,17 +24,23 @@ final class AudioDeviceManagerTests: XCTestCase {
             AudioDeviceManager.classifyDeviceKind(
                 AudioDeviceClassificationInput(name: "Desk Headset", transportType: kAudioDeviceTransportTypeUSB)
             ),
-            .bluetooth
+            .wiredOrOther
         )
         XCTAssertEqual(
             AudioDeviceManager.classifyDeviceKind(
                 AudioDeviceClassificationInput(name: "AirPods Pro", transportType: kAudioDeviceTransportTypeUSB)
             ),
-            .airPods
+            .wiredOrOther
         )
         XCTAssertEqual(
             AudioDeviceManager.classifyDeviceKind(
                 AudioDeviceClassificationInput(name: "Studio USB Mic", transportType: kAudioDeviceTransportTypeUSB)
+            ),
+            .wiredOrOther
+        )
+        XCTAssertEqual(
+            AudioDeviceManager.classifyDeviceKind(
+                AudioDeviceClassificationInput(name: "Built In Mic", transportType: kAudioDeviceTransportTypeUSB)
             ),
             .wiredOrOther
         )

--- a/Views/Settings/SettingsView+Audio.swift
+++ b/Views/Settings/SettingsView+Audio.swift
@@ -127,9 +127,9 @@ extension SettingsView {
             }
             return "\(selected.name) selected."
         case .airPods:
-            return "\(selected.name) selected. Bluetooth mics may start slower and reduce dictation accuracy."
+            return "\(selected.name) selected. This microphone may start slower and reduce dictation accuracy."
         case .bluetooth:
-            return "\(selected.name) selected. Startup can be slower before dictation begins."
+            return "\(selected.name) selected. Bluetooth devices may start slower and reduce dictation accuracy."
         case .wiredOrOther:
             return "\(selected.name) selected. Built-in Microphone is still recommended for best speed."
         }


### PR DESCRIPTION
feat(audio): replace mic name heuristics with macOS 15 headphone status and update bluetooth messaging
- remove hard-coded microphone name matching from AudioDeviceManager classification
- add macOS 15+ CMHeadphoneActivityManager status updates and use connected compatible headphones to relabel the selected/only Bluetooth mic as .airPods
- keep CoreAudio transportType classification as the fallback path
- update AudioDeviceManager tests for transport-only classification behavior
- update Bluetooth subtitle wording in SettingsView+Audio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and monitors compatible headphone connections and exposes connection state via a public property.
  * Automatically relabels and overrides microphone selection when compatible headphones connect.

* **Behavior Changes**
  * Microphone classification now uses transport type (not device name); AirPods are ordered between wired and Bluetooth.
  * Microphone list refreshes when headphone connection state changes.

* **Documentation**
  * Updated microphone warning messages for AirPods and Bluetooth devices.

* **Tests**
  * Updated and added tests covering transport-type classification and headphone-override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->