### PR TITLE
pr: warning/recovery overlay polish + 3s silence threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ KeyVox.dmg
 
 # Local release helper script copy
 release_dmg_notarize.sh
+
+# Marketing artifacts
+Tools/Marketing/

--- a/Core/Audio/AudioRecorder+Session.swift
+++ b/Core/Audio/AudioRecorder+Session.swift
@@ -68,6 +68,7 @@ extension AudioRecorder {
         lastVisualActiveSignalTime = Date.distantPast
         currentActiveSignalRunDuration = 0
         maxActiveSignalRunDuration = 0
+        lastCaptureHadNonDeadSignal = false
         captureStartedAt = Date()
         DispatchQueue.main.async {
             self.audioLevel = 0

--- a/Core/Audio/AudioRecorder+Streaming.swift
+++ b/Core/Audio/AudioRecorder+Streaming.swift
@@ -78,6 +78,7 @@ extension AudioRecorder: AVCaptureAudioDataOutputSampleBufferDelegate {
         let now = Date()
         if peak > deadSignalPeakThreshold {
             lastNonDeadSignalTime = now
+            lastCaptureHadNonDeadSignal = true
         }
         if rms > sessionActiveSignalRMSThreshold {
             currentActiveSignalRunDuration += frameDuration

--- a/Core/Audio/AudioRecorder.swift
+++ b/Core/Audio/AudioRecorder.swift
@@ -55,6 +55,7 @@ class AudioRecorder: NSObject, ObservableObject {
     var lastVisualActiveSignalTime: Date = Date.distantPast
     var currentActiveSignalRunDuration: TimeInterval = 0
     var maxActiveSignalRunDuration: TimeInterval = 0
+    var lastCaptureHadNonDeadSignal: Bool = false
     var captureStartedAt = Date.distantPast
 
     func startRecording() {

--- a/Core/Audio/AudioSilencePolicy.swift
+++ b/Core/Audio/AudioSilencePolicy.swift
@@ -6,7 +6,7 @@ struct AudioSilenceGatePolicy {
     static let longCaptureMinimumDuration: TimeInterval = 2.0
     static let lowConfidenceRMSCutoff: Float = 0.0032
     static let minimumActiveSignalRunDuration: TimeInterval = 0.22
-    static let longTrueSilenceMinimumDuration: TimeInterval = 5.0
+    static let longTrueSilenceMinimumDuration: TimeInterval = 3.0
     static let trueSilenceWindowSize = 1600
     static let trueSilenceWindowRMSThreshold: Float = 0.0018
     static let trueSilenceMinimumWindowRatio: Float = 0.93

--- a/Core/Transcription/TranscriptionManager.swift
+++ b/Core/Transcription/TranscriptionManager.swift
@@ -235,6 +235,16 @@ class TranscriptionManager: ObservableObject {
             #if DEBUG
             print("1. Audio stop & buffer retrieve: \(String(format: "%.3f", stopDuration))s")
             #endif
+
+            if !self.audioRecorder.lastCaptureHadNonDeadSignal {
+                OverlayManager.shared.hide()
+                WarningManager.shared.show(.microphoneSilence(
+                    reason: .muted,
+                    microphoneName: self.audioRecorder.currentCaptureDeviceName
+                ))
+                self.state = .idle
+                return
+            }
             
             guard !frames.isEmpty else {
                 OverlayManager.shared.hide()
@@ -248,11 +258,6 @@ class TranscriptionManager: ObservableObject {
                 if self.audioRecorder.lastCaptureWasLongTrueSilence {
                     showMicrophoneSilenceWarning(.microphoneSilence(
                         reason: .noSpeechDetected,
-                        microphoneName: microphoneName
-                    ))
-                } else if self.audioRecorder.lastCaptureWasAbsoluteSilence {
-                    showMicrophoneSilenceWarning(.microphoneSilence(
-                        reason: .muted,
                         microphoneName: microphoneName
                     ))
                 } else if self.audioRecorder.lastCaptureWasLikelySilence && shouldShowNoSpeechWarning {

--- a/KeyVoxTests/Core/AudioCaptureClassificationTests.swift
+++ b/KeyVoxTests/Core/AudioCaptureClassificationTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import KeyVox
 
 final class AudioCaptureClassificationTests: XCTestCase {
-    func testClassifyMarksAbsoluteSilenceAndLikelySilenceForLongQuietCapture() {
+    func testClassifyMarksAbsoluteSilenceLikelySilenceAndLongTrueSilenceAtThreshold() {
         let snapshot = Array(repeating: Float(0), count: 16_000 * 3)
         let speechOnly = snapshot
 
@@ -17,10 +17,10 @@ final class AudioCaptureClassificationTests: XCTestCase {
         XCTAssertTrue(result.isAbsoluteSilence)
         XCTAssertTrue(!result.hadActiveSignal)
         XCTAssertTrue(result.shouldRejectLikelySilence)
-        XCTAssertTrue(!result.isLongTrueSilence)
+        XCTAssertTrue(result.isLongTrueSilence)
     }
 
-    func testClassifyMarksLongTrueSilenceAfterFiveSeconds() {
+    func testClassifyMarksLongTrueSilenceAfterThreeSeconds() {
         let snapshot = Array(repeating: Float(0), count: 16_000 * 6)
         let speechOnly = snapshot
 

--- a/KeyVoxTests/Core/AudioSilenceGatePolicyTests.swift
+++ b/KeyVoxTests/Core/AudioSilenceGatePolicyTests.swift
@@ -104,7 +104,7 @@ final class AudioSilenceGatePolicyTests: XCTestCase {
     func testDoesNotFlagLongTrueSilenceWhenDurationIsBelowThreshold() {
         XCTAssertTrue(
             !AudioSilenceGatePolicy.shouldFlagLongTrueSilence(
-                captureDuration: 4.9,
+                captureDuration: 2.9,
                 hadActiveSignal: false,
                 silentWindowRatio: 1.0
             )

--- a/Views/Warnings/WarningManager.swift
+++ b/Views/Warnings/WarningManager.swift
@@ -17,6 +17,7 @@ final class WarningManager {
     private let dismissSlideDistance: CGFloat = 64
     private var recoveryWindow: NSPanel?
     private var recoveryModel: PasteFailureRecoveryOverlayModel?
+    private var recoveryPresentationID: UInt = 0
 
     func show(_ kind: WarningKind) {
         playCancelSound()
@@ -78,6 +79,7 @@ final class WarningManager {
     @MainActor
     func showPasteFailureRecovery(progress: Double, onDismiss: @escaping () -> Void) {
         playCancelSound()
+        recoveryPresentationID &+= 1
 
         if recoveryWindow == nil {
             let panel = NSPanel(
@@ -108,6 +110,7 @@ final class WarningManager {
             recoveryWindow?.setFrameOrigin(NSPoint(x: rect.midX - 160, y: rect.minY + 50))
         }
 
+        recoveryWindow?.alphaValue = 1
         recoveryWindow?.orderFrontRegardless()
     }
 
@@ -118,8 +121,7 @@ final class WarningManager {
 
     @MainActor
     func hidePasteFailureRecovery() {
-        recoveryWindow?.orderOut(nil)
-        recoveryModel = nil
+        hidePasteFailureRecoveryWithDismissTransition(expectedPresentationID: nil)
     }
 
     private func playCancelSound() {
@@ -217,33 +219,93 @@ final class WarningManager {
     }
 
     private func hideWithDismissTransition(expectedPresentationID: UInt?) {
-        if let expectedPresentationID, expectedPresentationID != warningPresentationID {
+        dismissPanelWithTransition(
+            panel: window,
+            expectedPresentationID: expectedPresentationID,
+            currentPresentationID: warningPresentationID,
+            isCurrentPresentation: { [weak self] presentationID in
+                presentationID == self?.warningPresentationID
+            },
+            prepareForDismiss: { [weak self] in
+                self?.cancelDismissSchedules()
+                self?.isWarningHovered = false
+            },
+            handleMissingPanel: { [weak self] in
+                self?.removeWarningDismissMonitors()
+            },
+            handlePanelNotVisible: { [weak self] in
+                self?.removeWarningDismissMonitors()
+            },
+            completeDismiss: { [weak self] in
+                self?.removeWarningDismissMonitors()
+            }
+        )
+    }
+
+    private func hidePasteFailureRecoveryWithDismissTransition(expectedPresentationID: UInt?) {
+        dismissPanelWithTransition(
+            panel: recoveryWindow,
+            expectedPresentationID: expectedPresentationID,
+            currentPresentationID: recoveryPresentationID,
+            isCurrentPresentation: { [weak self] presentationID in
+                presentationID == self?.recoveryPresentationID
+            },
+            handleMissingPanel: { [weak self] in
+                self?.recoveryModel = nil
+            },
+            handlePanelNotVisible: { [weak self] in
+                self?.recoveryModel = nil
+            },
+            completeDismiss: { [weak self] in
+                self?.recoveryModel = nil
+            }
+        )
+    }
+
+    private func dismissPanelWithTransition(
+        panel: NSPanel?,
+        expectedPresentationID: UInt?,
+        currentPresentationID: UInt,
+        isCurrentPresentation: @escaping (UInt) -> Bool,
+        prepareForDismiss: () -> Void = {},
+        handleMissingPanel: () -> Void = {},
+        handlePanelNotVisible: () -> Void = {},
+        completeDismiss: @escaping () -> Void
+    ) {
+        if let expectedPresentationID, !isCurrentPresentation(expectedPresentationID) {
             return
         }
-        cancelDismissSchedules()
-        isWarningHovered = false
-        guard let window, window.isVisible else {
-            removeWarningDismissMonitors()
+
+        prepareForDismiss()
+
+        guard let panel else {
+            handleMissingPanel()
             return
         }
-        let startFrame = window.frame
+
+        guard panel.isVisible else {
+            panel.alphaValue = 1
+            handlePanelNotVisible()
+            return
+        }
+
+        let startFrame = panel.frame
         var endFrame = startFrame
         endFrame.origin.y -= dismissSlideDistance
-        let dismissingPresentationID = warningPresentationID
+        let dismissingPresentationID = currentPresentationID
 
         NSAnimationContext.runAnimationGroup { context in
             context.duration = dismissAnimationDuration
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-            window.animator().setFrame(endFrame, display: false)
-            window.animator().alphaValue = 0
-        } completionHandler: { [weak self] in
-            guard let self else { return }
-            // If a newer warning started while this one was animating out, do not mutate it.
-            guard dismissingPresentationID == self.warningPresentationID else { return }
-            window.orderOut(nil)
-            window.setFrame(startFrame, display: false)
-            window.alphaValue = 1
-            self.removeWarningDismissMonitors()
+            panel.animator().setFrame(endFrame, display: false)
+            panel.animator().alphaValue = 0
+        } completionHandler: {
+            // If a newer overlay started while this one was animating out, do not mutate it.
+            guard isCurrentPresentation(dismissingPresentationID) else { return }
+            panel.orderOut(nil)
+            panel.setFrame(startFrame, display: false)
+            panel.alphaValue = 1
+            completeDismiss()
         }
     }
 }

--- a/Views/Warnings/WarningOverlayView.swift
+++ b/Views/Warnings/WarningOverlayView.swift
@@ -4,15 +4,16 @@ struct WarningOverlayView: View {
     let kind: WarningKind
     let openSystemSettings: () -> Void
     let openKeyVoxSettings: () -> Void
+    private let contentRailWidth: CGFloat = 214
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 8) {
                 Image(systemName: kind.iconName)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(.yellow)
                 Text(kind.title)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.system(size: 12, weight: .semibold))
                     .foregroundColor(.primary)
             }
 
@@ -22,35 +23,24 @@ struct WarningOverlayView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .lineSpacing(2)
 
-            if kind.systemSettingsURL != nil && kind.showsKeyVoxSettingsButton {
-                HStack(spacing: 8) {
+            HStack(spacing: 8) {
+                if kind.systemSettingsURL != nil {
                     Button("System Settings", action: openSystemSettings)
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                }
 
+                if kind.showsKeyVoxSettingsButton {
                     Button("KeyVox Settings", action: openKeyVoxSettings)
                         .buttonStyle(.borderedProminent)
                         .tint(.indigo)
                         .controlSize(.small)
                 }
-                .frame(maxWidth: .infinity, alignment: .center)
-            } else {
-                HStack {
-                    Spacer(minLength: 0)
-                    if kind.showsKeyVoxSettingsButton {
-                        Button("KeyVox Settings", action: openKeyVoxSettings)
-                            .buttonStyle(.borderedProminent)
-                            .tint(.indigo)
-                            .controlSize(.small)
-                    } else {
-                        Button("System Settings", action: openSystemSettings)
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                    }
-                    Spacer(minLength: 0)
-                }
             }
+            .frame(maxWidth: .infinity, alignment: .center)
         }
+        .frame(width: contentRailWidth, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .center)
         .padding(14)
         .frame(width: 260)
         .background(


### PR DESCRIPTION
- constrain warning title/message to a centered content rail and simplify button-row rendering
- animate paste recovery dismiss with the same slide/fade transition used by warnings
- refactor WarningManager dismiss logic to shared panel-transition helper
- show muted warning immediately when capture has zero non-dead signal
- lower long true-silence threshold from 5.0s to 3.0s
- update AudioCaptureClassificationTests and AudioSilenceGatePolicyTests to match 3.0s behavior
- ignore Tools/Marketing/ in .git

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved silence detection sensitivity; adjusted threshold for triggering silence warnings.
  * Enhanced reliability of warning overlay dismissal behavior.

* **UI/UX Improvements**
  * Refined warning overlay typography and button layout for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->