### PR TITLE
fix(update): normalize release-note preview limits and align prompt header layout

### DIFF
--- a/Core/Services/AppUpdateService.swift
+++ b/Core/Services/AppUpdateService.swift
@@ -272,7 +272,9 @@ final class AppUpdateService: ObservableObject {
         let normalized = body.replacingOccurrences(of: "\r\n", with: "\n")
 
         if let summarySection = extractSummarySection(from: normalized) {
-            return truncateReleasePreview(summarySection)
+            if let summaryPreview = truncateReleasePreview(summarySection) {
+                return summaryPreview
+            }
         }
 
         return truncateReleasePreview(normalized)
@@ -328,6 +330,11 @@ final class AppUpdateService: ObservableObject {
         }
 
         if wasTrimmed, !preview.hasSuffix("…") {
+            let maxCharsBeforeEllipsis = max(ReleaseNotesPreview.maxCharacters - 1, 0)
+            if preview.count > maxCharsBeforeEllipsis {
+                let cutoff = preview.index(preview.startIndex, offsetBy: maxCharsBeforeEllipsis)
+                preview = String(preview[..<cutoff]).trimmingCharacters(in: .whitespacesAndNewlines)
+            }
             preview += "…"
         }
 

--- a/Core/Services/AppUpdateService.swift
+++ b/Core/Services/AppUpdateService.swift
@@ -49,6 +49,11 @@ final class AppUpdateService: ObservableObject {
 
     @Published private(set) var latestRemoteInfo: LatestReleaseInfo?
 
+    private enum ReleaseNotesPreview {
+        static let maxLines = 4
+        static let maxCharacters = 240
+    }
+
     private let feedConfig: UpdateFeedConfig
     private let bundle: Bundle
     private let urlSession: URLSession
@@ -158,7 +163,7 @@ final class AppUpdateService: ObservableObject {
         let fallbackMessage = "A new version of KeyVox is available. Please update for the best experience."
         let promptMessage: String
         if let body = remoteInfo.message, !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            promptMessage = body
+            promptMessage = summarizedReleaseBody(body) ?? fallbackMessage
         } else {
             promptMessage = fallbackMessage
         }
@@ -261,6 +266,86 @@ final class AppUpdateService: ObservableObject {
 
         let normalizedLocalVersion = AppUpdateLogic.normalizeVersionTag(localVersion)
         return AppUpdateLogic.compareVersionStrings(remoteInfo.version, normalizedLocalVersion) > 0
+    }
+
+    private func summarizedReleaseBody(_ body: String) -> String? {
+        let normalized = body.replacingOccurrences(of: "\r\n", with: "\n")
+
+        if let summarySection = extractSummarySection(from: normalized) {
+            return truncateReleasePreview(summarySection)
+        }
+
+        return truncateReleasePreview(normalized)
+    }
+
+    private func extractSummarySection(from body: String) -> String? {
+        let lines = body.components(separatedBy: .newlines)
+        guard let summaryHeadingIndex = lines.firstIndex(where: { line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard trimmed.hasPrefix("##") else { return false }
+            let headingText = trimmed
+                .drop(while: { $0 == "#" })
+                .trimmingCharacters(in: .whitespaces)
+                .trimmingCharacters(in: CharacterSet(charactersIn: ":"))
+                .lowercased()
+            return headingText == "summary"
+        }) else {
+            return nil
+        }
+
+        var summaryLines: [String] = []
+        for line in lines.dropFirst(summaryHeadingIndex + 1) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("#") {
+                break
+            }
+            summaryLines.append(line)
+        }
+
+        let summary = summaryLines
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return summary.isEmpty ? nil : summary
+    }
+
+    private func truncateReleasePreview(_ text: String) -> String? {
+        let lines = text
+            .components(separatedBy: .newlines)
+            .map(sanitizeReleaseLine)
+            .filter { !$0.isEmpty }
+
+        guard !lines.isEmpty else { return nil }
+
+        let hadMoreLines = lines.count > ReleaseNotesPreview.maxLines
+        let visible = Array(lines.prefix(ReleaseNotesPreview.maxLines))
+        var preview = visible.joined(separator: "\n")
+        var wasTrimmed = hadMoreLines
+
+        if preview.count > ReleaseNotesPreview.maxCharacters {
+            let cutoff = preview.index(preview.startIndex, offsetBy: ReleaseNotesPreview.maxCharacters)
+            preview = String(preview[..<cutoff]).trimmingCharacters(in: .whitespacesAndNewlines)
+            wasTrimmed = true
+        }
+
+        if wasTrimmed, !preview.hasSuffix("…") {
+            preview += "…"
+        }
+
+        return preview.isEmpty ? nil : preview
+    }
+
+    private func sanitizeReleaseLine(_ line: String) -> String {
+        var cleaned = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        while cleaned.hasPrefix("#") {
+            cleaned.removeFirst()
+            cleaned = cleaned.trimmingCharacters(in: .whitespaces)
+        }
+        cleaned = cleaned
+            .replacingOccurrences(of: "**", with: "")
+            .replacingOccurrences(of: "__", with: "")
+            .replacingOccurrences(of: "`", with: "")
+            .replacingOccurrences(of: #"^\s*([-*+]|\d+\.)\s+"#, with: "", options: .regularExpression)
+        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// For testing: clears the update prompt cooldown.

--- a/KeyVoxTests/Services/AppUpdateServiceTests.swift
+++ b/KeyVoxTests/Services/AppUpdateServiceTests.swift
@@ -45,6 +45,93 @@ final class AppUpdateServiceTests: XCTestCase {
         XCTAssertTrue(service.latestRemoteInfo?.version == "999.0.0")
     }
 
+    func testUpdatePromptUsesSummarySectionWhenPresent() async throws {
+        let promptPresenter = RecordingPromptPresenter()
+        let now = MutableNow(Date(timeIntervalSince1970: 1_700_000_000))
+        let session = makeMockSession()
+
+        MockURLProtocol.handler = { _ in
+            let body = """
+            Intro text that should not appear.
+
+            ## Summary
+            Faster startup time
+            Better paste reliability
+
+            ## Details
+            Full details follow here.
+            """
+            let data = self.releaseData(
+                tag: "999.0.0",
+                htmlURL: "https://github.com/macmixing/keyvox/releases/tag/v999.0.0",
+                body: body,
+                dmgURL: "https://github.com/macmixing/keyvox/releases/download/v999.0.0/KeyVox-999.0.0.dmg"
+            )
+            return (self.okResponse(), data)
+        }
+
+        let service = makeService(promptPresenter: promptPresenter, now: now, session: session, checkInterval: 60 * 60 * 24)
+        service.checkForUpdatesIfNeeded()
+        try await waitForCondition { promptPresenter.prompts.count == 1 }
+
+        XCTAssertTrue(promptPresenter.prompts[0].message == "Faster startup time\nBetter paste reliability")
+    }
+
+    func testUpdatePromptFallsBackToShortPreviewWithoutSummary() async throws {
+        let promptPresenter = RecordingPromptPresenter()
+        let now = MutableNow(Date(timeIntervalSince1970: 1_700_000_000))
+        let session = makeMockSession()
+
+        MockURLProtocol.handler = { _ in
+            let body = """
+            Line 1
+            Line 2
+            Line 3
+            Line 4
+            Line 5 should be trimmed
+            """
+            let data = self.releaseData(
+                tag: "999.0.0",
+                htmlURL: "https://github.com/macmixing/keyvox/releases/tag/v999.0.0",
+                body: body,
+                dmgURL: "https://github.com/macmixing/keyvox/releases/download/v999.0.0/KeyVox-999.0.0.dmg"
+            )
+            return (self.okResponse(), data)
+        }
+
+        let service = makeService(promptPresenter: promptPresenter, now: now, session: session, checkInterval: 60 * 60 * 24)
+        service.checkForUpdatesIfNeeded()
+        try await waitForCondition { promptPresenter.prompts.count == 1 }
+
+        XCTAssertTrue(promptPresenter.prompts[0].message == "Line 1\nLine 2\nLine 3\nLine 4…")
+    }
+
+    func testUpdatePromptStripsBasicMarkdownFormatting() async throws {
+        let promptPresenter = RecordingPromptPresenter()
+        let now = MutableNow(Date(timeIntervalSince1970: 1_700_000_000))
+        let session = makeMockSession()
+
+        MockURLProtocol.handler = { _ in
+            let body = """
+            ## **KeyVox v1.0.0** - Initial Public Release
+            **Release date:** March 1, 2026
+            """
+            let data = self.releaseData(
+                tag: "999.0.0",
+                htmlURL: "https://github.com/macmixing/keyvox/releases/tag/v999.0.0",
+                body: body,
+                dmgURL: "https://github.com/macmixing/keyvox/releases/download/v999.0.0/KeyVox-999.0.0.dmg"
+            )
+            return (self.okResponse(), data)
+        }
+
+        let service = makeService(promptPresenter: promptPresenter, now: now, session: session, checkInterval: 60 * 60 * 24)
+        service.checkForUpdatesIfNeeded()
+        try await waitForCondition { promptPresenter.prompts.count == 1 }
+
+        XCTAssertTrue(promptPresenter.prompts[0].message == "KeyVox v1.0.0 - Initial Public Release\nRelease date: March 1, 2026")
+    }
+
     func testManualCheckShowsUnavailablePromptWhenFetchFails() async throws {
         let promptPresenter = RecordingPromptPresenter()
         let now = MutableNow(Date(timeIntervalSince1970: 1_700_000_000))
@@ -144,21 +231,19 @@ final class AppUpdateServiceTests: XCTestCase {
     }
 
     private func releaseData(tag: String, htmlURL: String, body: String, dmgURL: String? = nil) -> Data {
-        let assetsJSON: String
+        let assets: [[String: String]]
         if let dmgURL {
-            assetsJSON = "[{\"name\":\"KeyVox.dmg\",\"browser_download_url\":\"\(dmgURL)\"}]"
+            assets = [["name": "KeyVox.dmg", "browser_download_url": dmgURL]]
         } else {
-            assetsJSON = "[]"
+            assets = []
         }
 
-        let json = """
-        {
-          "tag_name": "\(tag)",
-          "body": "\(body)",
-          "html_url": "\(htmlURL)",
-          "assets": \(assetsJSON)
-        }
-        """
-        return Data(json.utf8)
+        let payload: [String: Any] = [
+            "tag_name": tag,
+            "body": body,
+            "html_url": htmlURL,
+            "assets": assets
+        ]
+        return try! JSONSerialization.data(withJSONObject: payload, options: [])
     }
 }

--- a/KeyVoxTests/Services/AppUpdateServiceTests.swift
+++ b/KeyVoxTests/Services/AppUpdateServiceTests.swift
@@ -132,6 +132,62 @@ final class AppUpdateServiceTests: XCTestCase {
         XCTAssertTrue(promptPresenter.prompts[0].message == "KeyVox v1.0.0 - Initial Public Release\nRelease date: March 1, 2026")
     }
 
+    func testUpdatePromptFallsBackWhenSummarySanitizesToEmpty() async throws {
+        let promptPresenter = RecordingPromptPresenter()
+        let now = MutableNow(Date(timeIntervalSince1970: 1_700_000_000))
+        let session = makeMockSession()
+
+        MockURLProtocol.handler = { _ in
+            let body = """
+            ## Summary
+            **
+            __
+            `
+
+            ## Details
+            Stable improvements shipped
+            """
+            let data = self.releaseData(
+                tag: "999.0.0",
+                htmlURL: "https://github.com/macmixing/keyvox/releases/tag/v999.0.0",
+                body: body,
+                dmgURL: "https://github.com/macmixing/keyvox/releases/download/v999.0.0/KeyVox-999.0.0.dmg"
+            )
+            return (self.okResponse(), data)
+        }
+
+        let service = makeService(promptPresenter: promptPresenter, now: now, session: session, checkInterval: 60 * 60 * 24)
+        service.checkForUpdatesIfNeeded()
+        try await waitForCondition { promptPresenter.prompts.count == 1 }
+
+        XCTAssertTrue(promptPresenter.prompts[0].message == "Summary\nDetails\nStable improvements shipped")
+    }
+
+    func testUpdatePromptRespects240CharLimitWithEllipsis() async throws {
+        let promptPresenter = RecordingPromptPresenter()
+        let now = MutableNow(Date(timeIntervalSince1970: 1_700_000_000))
+        let session = makeMockSession()
+
+        MockURLProtocol.handler = { _ in
+            let longLine = String(repeating: "A", count: 300)
+            let data = self.releaseData(
+                tag: "999.0.0",
+                htmlURL: "https://github.com/macmixing/keyvox/releases/tag/v999.0.0",
+                body: longLine,
+                dmgURL: "https://github.com/macmixing/keyvox/releases/download/v999.0.0/KeyVox-999.0.0.dmg"
+            )
+            return (self.okResponse(), data)
+        }
+
+        let service = makeService(promptPresenter: promptPresenter, now: now, session: session, checkInterval: 60 * 60 * 24)
+        service.checkForUpdatesIfNeeded()
+        try await waitForCondition { promptPresenter.prompts.count == 1 }
+
+        let message = promptPresenter.prompts[0].message
+        XCTAssertTrue(message.count <= 240)
+        XCTAssertTrue(message.hasSuffix("…"))
+    }
+
     func testManualCheckShowsUnavailablePromptWhenFetchFails() async throws {
         let promptPresenter = RecordingPromptPresenter()
         let now = MutableNow(Date(timeIntervalSince1970: 1_700_000_000))

--- a/Views/Settings/SettingsComponents.swift
+++ b/Views/Settings/SettingsComponents.swift
@@ -21,7 +21,17 @@ enum SettingsTab: String, CaseIterable, Identifiable {
 
 
 // MARK: - Animated Wave Header
-struct AnimatedWaveHeader: View {
+struct AnimatedWaveHeader<Trailing: View>: View {
+    private let trailing: Trailing
+
+    init() where Trailing == EmptyView {
+        self.trailing = EmptyView()
+    }
+
+    init(@ViewBuilder trailing: () -> Trailing) {
+        self.trailing = trailing()
+    }
+
     var body: some View {
         HStack(spacing: 16) {
             KeyVoxLogo()
@@ -35,6 +45,9 @@ struct AnimatedWaveHeader: View {
                     .foregroundColor(.secondary)
                     .tracking(0.8)
             }
+
+            Spacer(minLength: 8)
+            trailing
         }
     }
 }

--- a/Views/UpdatePromptOverlay.swift
+++ b/Views/UpdatePromptOverlay.swift
@@ -62,12 +62,17 @@ struct UpdatePromptOverlay: View {
                     .controlSize(.regular)
 
                 if let primaryButtonTitle = prompt.primaryButtonTitle {
-                    Button(primaryButtonTitle, action: onPrimaryAction)
-                        .buttonStyle(.borderedProminent)
-                        .tint(.indigo)
-                        .controlSize(.regular)
+                    Button(action: onPrimaryAction) {
+                        Text(primaryButtonTitle)
+                            .fontWeight(.bold)
+                            .foregroundColor(.black)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.indigo)
+                    .controlSize(.regular)
                 }
             }
+            .environment(\.controlActiveState, .active)
             .padding(.horizontal, 8)
             .frame(maxWidth: .infinity, alignment: .center)
         }

--- a/Views/UpdatePromptOverlay.swift
+++ b/Views/UpdatePromptOverlay.swift
@@ -4,6 +4,8 @@ import AppKit
 private enum UpdatePromptLayout {
     static let width: CGFloat = 430
     static let height: CGFloat = 250
+    static let messageMinHeight: CGFloat = 42
+    static let messageMaxHeight: CGFloat = 84
 }
 
 struct UpdatePromptOverlay: View {
@@ -20,24 +22,39 @@ struct UpdatePromptOverlay: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            AnimatedWaveHeader()
+        VStack(alignment: .leading, spacing: 14) {
+            AnimatedWaveHeader {
+                if let versionBadgeTitle {
+                    StatusBadge(title: versionBadgeTitle, color: .indigo)
+                }
+            }
+            .padding(.horizontal, 8)
 
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .center, spacing: 8) {
                 Text(prompt.title)
                     .font(.custom("Kanit Medium", size: 19))
                     .foregroundColor(.white)
+                    .frame(maxWidth: .infinity, alignment: .center)
 
                 Text(prompt.message)
                     .font(.custom("Kanit Medium", size: 12))
                     .foregroundColor(.secondary)
-                    .lineSpacing(2)
+                    .lineSpacing(0.5)
+                    .multilineTextAlignment(.center)
+                    .truncationMode(.tail)
+                    .lineLimit(4)
                     .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                .frame(maxWidth: .infinity)
+                .frame(
+                    minHeight: UpdatePromptLayout.messageMinHeight,
+                    maxHeight: UpdatePromptLayout.messageMaxHeight,
+                    alignment: .center
+                )
             }
+            .padding(.horizontal, 8)
 
-            if let versionBadgeTitle {
-                StatusBadge(title: versionBadgeTitle, color: .indigo)
-            }
+            Spacer(minLength: 0)
 
             HStack(spacing: 10) {
                 Button(prompt.dismissButtonTitle, action: onDismiss)
@@ -51,6 +68,8 @@ struct UpdatePromptOverlay: View {
                         .controlSize(.regular)
                 }
             }
+            .padding(.horizontal, 8)
+            .frame(maxWidth: .infinity, alignment: .center)
         }
         .padding(20)
         .frame(width: UpdatePromptLayout.width, height: UpdatePromptLayout.height)


### PR DESCRIPTION
- summarize release notes from ## Summary when present, otherwise use sanitized fallback text
- enforce consistent preview caps at 4 lines / 240 chars in AppUpdateService
- keep update prompt rendering aligned with service limits (lineLimit(4) already in view)
- tighten update message line spacing while preserving current popup sizing/visual layout
- move version badge inline with the logo/header row
- make AnimatedWaveHeader reusable with optional trailing content to avoid duplicated header markup
- expand AppUpdateService tests for summary extraction, markdown cleanup, and 4-line fallback truncation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release note previews now prefer a "Summary" section when present and are capped to 4 lines / 240 characters.

* **Improvements**
  * Update prompt message centered, constrained, truncated with ellipsis when needed; version badge integrated into header.
  * Basic Markdown stripped from release notes for cleaner display.
  * Header component accepts an optional trailing view to allow custom content (e.g., badges).

* **Tests**
  * Added tests covering summary extraction, truncation, sanitization, and prompt content behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->