### PR TITLE
fix(normalization): replace static TLD lists with shared domain heurstics and preserve prose-dot capitalization

### DIFF
--- a/Core/Normalization/SentenceCapitalizationNormalizer.swift
+++ b/Core/Normalization/SentenceCapitalizationNormalizer.swift
@@ -22,10 +22,6 @@ struct SentenceCapitalizationNormalizer {
         pattern: #"(?<![A-Za-z0-9_])i(?![A-Za-z0-9_])"#,
         options: []
     )
-    private static let commonTopLevelDomains: Set<String> = [
-        "com", "net", "org", "io", "app", "dev", "ai", "co", "me", "edu", "gov",
-        "us", "uk", "ca", "au", "de", "fr", "jp"
-    ]
     private static let domainLabelCharacterSet = CharacterSet(
         charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-"
     )
@@ -310,8 +306,17 @@ struct SentenceCapitalizationNormalizer {
             return true
         }
 
+        if dotCount == 1,
+           WebsiteNormalizer.isLikelySentenceGlueJoin(
+               token: normalized,
+               in: nsText,
+               tokenEnd: end
+           ) {
+            return false
+        }
+
         guard let tld = normalized.split(separator: ".").last.map(String.init) else { return false }
-        return Self.commonTopLevelDomains.contains(tld)
+        return WebsiteNormalizer.isLikelyTopLevelDomain(tld)
     }
 
     private func isLikelyFilenameExtensionBoundary(_ text: String, dotLocation: Int) -> Bool {

--- a/Core/Normalization/WebsiteNormalizer.swift
+++ b/Core/Normalization/WebsiteNormalizer.swift
@@ -176,21 +176,29 @@ enum WebsiteNormalizer {
         guard location >= 0, location <= text.length else { return nil }
         var index = location
         while index < text.length {
-            guard let scalar = UnicodeScalar(text.character(at: index)) else { break }
-            if !CharacterSet.whitespacesAndNewlines.contains(scalar) {
+            let composedRange = text.rangeOfComposedCharacterSequence(at: index)
+            let cluster = text.substring(with: composedRange)
+            let isWhitespace = cluster.unicodeScalars.allSatisfy {
+                CharacterSet.whitespacesAndNewlines.contains($0)
+            }
+            if !isWhitespace {
                 break
             }
-            index += 1
+            index = composedRange.location + composedRange.length
         }
 
         guard index < text.length else { return nil }
         let start = index
         while index < text.length {
-            guard let scalar = UnicodeScalar(text.character(at: index)),
-                  !CharacterSet.whitespacesAndNewlines.contains(scalar) else {
+            let composedRange = text.rangeOfComposedCharacterSequence(at: index)
+            let cluster = text.substring(with: composedRange)
+            let isWhitespace = cluster.unicodeScalars.allSatisfy {
+                CharacterSet.whitespacesAndNewlines.contains($0)
+            }
+            if isWhitespace {
                 break
             }
-            index += 1
+            index = composedRange.location + composedRange.length
         }
 
         guard index > start else { return nil }

--- a/Core/Normalization/WebsiteNormalizer.swift
+++ b/Core/Normalization/WebsiteNormalizer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NaturalLanguage
 
 enum WebsiteNormalizer {
     static let attachedDomainLookaheadPattern = "(?=[A-Za-z0-9\\-]+(?:\\.[A-Za-z0-9\\-]+)+\\b)"
@@ -23,10 +24,14 @@ enum WebsiteNormalizer {
         pattern: #"(?i)(?<![@A-Z0-9._%+\-])((?:https?:\/\/)?(?:www\.)?(?:[A-Z0-9\-]+\.)+[A-Z0-9\-]{2,}(?::\d{2,5})?)(\/[A-Z0-9._~%!$&'()*+,;=:@\/-]*)?"#,
         options: []
     )
-    private static let commonTopLevelDomains: Set<String> = [
-        "com", "net", "org", "io", "app", "co", "dev", "ai", "me", "edu", "gov", "uk",
-        "us", "ca", "biz", "info", "xyz", "site", "online", "tech", "store", "blog"
-    ]
+    private static let asciiTopLevelDomainRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)^[a-z]{2,63}$"#,
+        options: []
+    )
+    private static let punycodeTopLevelDomainRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"(?i)^xn--[a-z0-9-]{2,59}$"#,
+        options: []
+    )
 
     static func isCompactDomainToken(_ text: String) -> Bool {
         guard let regex = compactDomainTokenRegex else { return false }
@@ -99,9 +104,99 @@ enum WebsiteNormalizer {
         }
 
         let hostWithoutPort = lowercased.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: true).first.map(String.init) ?? lowercased
+        if hasLikelyInitialismPrefixLabels(hostWithoutPort) {
+            return false
+        }
         guard let tld = hostWithoutPort.split(separator: ".").last.map(String.init), !tld.isEmpty else {
             return false
         }
-        return commonTopLevelDomains.contains(tld)
+        return isLikelyTopLevelDomain(tld)
+    }
+
+    static func isLikelyTopLevelDomain(_ value: String) -> Bool {
+        let tld = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !tld.isEmpty else { return false }
+
+        let range = NSRange(location: 0, length: (tld as NSString).length)
+        if let asciiRegex = asciiTopLevelDomainRegex,
+           asciiRegex.firstMatch(in: tld, options: [], range: range) != nil {
+            return true
+        }
+
+        if let punycodeRegex = punycodeTopLevelDomainRegex,
+           punycodeRegex.firstMatch(in: tld, options: [], range: range) != nil {
+            return true
+        }
+
+        return false
+    }
+
+    static func isLikelySentenceGlueJoin(token: String, in text: NSString, tokenEnd: Int) -> Bool {
+        let labels = token.split(separator: ".").map(String.init)
+        guard labels.count == 2 else { return false }
+
+        let first = labels[0].lowercased()
+        let second = labels[1].lowercased()
+        guard first.range(of: #"^[a-z]+$"#, options: .regularExpression) != nil else { return false }
+        guard second.range(of: #"^[a-z]+$"#, options: .regularExpression) != nil else { return false }
+        guard let following = nextWord(in: text, from: tokenEnd) else { return false }
+
+        let phrase = "\(first) \(second) \(following)"
+        let tagger = NLTagger(tagSchemes: [.lexicalClass])
+        tagger.string = phrase
+
+        var wordIndex = 0
+        var middleTag: NLTag?
+        tagger.enumerateTags(
+            in: phrase.startIndex..<phrase.endIndex,
+            unit: .word,
+            scheme: .lexicalClass,
+            options: [.omitPunctuation, .omitWhitespace]
+        ) { tag, _ in
+            if wordIndex == 1 {
+                middleTag = tag
+                return false
+            }
+            wordIndex += 1
+            return true
+        }
+
+        return middleTag == .conjunction
+    }
+
+    private static func hasLikelyInitialismPrefixLabels(_ host: String) -> Bool {
+        let labels = host.split(separator: ".").map(String.init)
+        guard labels.count >= 3 else { return false }
+        let prefixLabelCount = labels.count - 1
+        let singleCharacterPrefixLabels = labels.prefix(prefixLabelCount).filter { $0.count == 1 }.count
+        return singleCharacterPrefixLabels >= 2
+    }
+
+    private static func nextWord(in text: NSString, from location: Int) -> String? {
+        guard location >= 0, location <= text.length else { return nil }
+        var index = location
+        while index < text.length {
+            guard let scalar = UnicodeScalar(text.character(at: index)) else { break }
+            if !CharacterSet.whitespacesAndNewlines.contains(scalar) {
+                break
+            }
+            index += 1
+        }
+
+        guard index < text.length else { return nil }
+        let start = index
+        while index < text.length {
+            guard let scalar = UnicodeScalar(text.character(at: index)),
+                  !CharacterSet.whitespacesAndNewlines.contains(scalar) else {
+                break
+            }
+            index += 1
+        }
+
+        guard index > start else { return nil }
+        let word = text.substring(with: NSRange(location: start, length: index - start))
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'“”‘’()[]{}.,;:!?"))
+        return word.isEmpty ? nil : word
     }
 }

--- a/KeyVoxTests/Core/TranscriptionPostProcessorTests+CapitalizationAndTime.swift
+++ b/KeyVoxTests/Core/TranscriptionPostProcessorTests+CapitalizationAndTime.swift
@@ -192,6 +192,18 @@ extension TranscriptionPostProcessorTests {
         XCTAssertEqual(output, "Visit https://i.example.com and I can explain")
     }
 
+    func testDoesNotSplitLongTopLevelDomainIntoSentenceBoundary() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "please visit keyvox.photography and share it",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Please visit keyvox.photography and share it")
+    }
+
     func testPreservesDaypartPhrasingForHyphenSeparatedTimes() {
         let processor = TranscriptionPostProcessor()
 

--- a/KeyVoxTests/Core/TranscriptionPostProcessorTests+LanguageHeuristics.swift
+++ b/KeyVoxTests/Core/TranscriptionPostProcessorTests+LanguageHeuristics.swift
@@ -55,6 +55,18 @@ extension TranscriptionPostProcessorTests {
         XCTAssertEqual(output, "Please visit www.keyvox.app for updates.")
     }
 
+    func testLowercasesBareWebsiteWithLongTopLevelDomain() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Please visit KEYVOX.PHOTOGRAPHY for updates.",
+            dictionaryEntries: [],
+            renderMode: .multiline
+        )
+
+        XCTAssertEqual(output, "Please visit keyvox.photography for updates.")
+    }
+
     func testCollapsesSingleCharacterSpamRun() {
         let processor = TranscriptionPostProcessor()
         let spam = String(repeating: "j", count: 140)


### PR DESCRIPTION
- move domain/prose disambiguation into WebsiteNormalizer
- delegate ambiguous domain checks from SentenceCapitalizationNormalizer
- add regression coverage for long-TLD domains and sentence-boundary behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved website/domain recognition to better handle extended and punycode top-level domains.
  * Enhanced sentence boundary and capitalization behavior so domains in running text are not split or mis-capitalized.
  * Added heuristics to avoid misinterpreting domain-like fragments adjacent to words.

* **Tests**
  * Added tests covering long top-level domains and capitalization/spacing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->