### PR TITLE
fix(dictionary): prevent compressed-tail 3-token fallback false-positive rewrites

### DIFF
--- a/Core/Language/Dictionary/Evaluation/DictionaryMatcher+ThreeTokenEvaluation.swift
+++ b/Core/Language/Dictionary/Evaluation/DictionaryMatcher+ThreeTokenEvaluation.swift
@@ -182,9 +182,17 @@ extension DictionaryMatcher {
             let candidateFirst = candidate.tokens[0]
             let candidateSecond = candidate.tokens[1]
             guard candidateSecond.count >= observedTail.count else { continue }
-            guard observedFirst == candidateFirst
-                || (observedFirst.count <= ThreeTokenEvaluationConstants.shortObservedFirstMaximumLength
-                    && !lexicon.isCommonWord(baseTokenForCommonWordGuard(observedFirst))) else { continue }
+            let hasShortAnchorMatch =
+                observedFirst.count >= 2
+                && candidateFirst.count >= 4
+                && observedFirst.first == candidateFirst.first
+                && observedFirst.last == candidateFirst.last
+            let allowsShortObservedFirstFallback =
+                observedFirst.count <= ThreeTokenEvaluationConstants.shortObservedFirstMaximumLength
+                && !lexicon.isCommonWord(baseTokenForCommonWordGuard(observedFirst))
+                && (candidateFirst.hasPrefix(observedFirst)
+                    || hasShortAnchorMatch)
+            guard observedFirst == candidateFirst || allowsShortObservedFirstFallback else { continue }
 
             let firstTextSimilarity = scorer.similarity(lhs: observedFirst, rhs: candidateFirst)
             let firstPhoneticSimilarity = scorer.similarity(

--- a/KeyVoxTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/KeyVoxTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -84,6 +84,14 @@ final class DictionaryMatcherTests: XCTestCase {
         XCTAssertEqual(result.text, "Dom Esposito.")
     }
 
+    func testCompressedTailFallbackDoesNotRewriteUnrelatedThreeTokenSpan() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "Dom Esposito")])
+
+        let result = matcher.apply(to: "Do not respond to me.")
+        XCTAssertEqual(result.text, "Do not respond to me.")
+    }
+
     func testCorrectsStylizedSingleTokenNameNearMissWithRuntimeLexicon() {
         let matcher = makeRuntimeMatcher()
         matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "AirRack")])


### PR DESCRIPTION
- tighten short-token first-token fallback in compressed-tail matching to require structural anchoring (prefix or first/last-char match), and add a regression test to ensure unrelated prose spans are not rewritten into dictionary phrases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced dictionary matching to recognize a wider range of text patterns, enabling more effective text replacements.

* **Tests**
  * Added test to ensure improved matching logic doesn't cause unintended text replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->