### PR TITLE
fix(formatting): tighten paragraph and list boundary detection

### DIFF
--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternRunSelector.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternRunSelector.swift
@@ -18,6 +18,7 @@ public struct ListPatternRunSelector {
         static let sentenceBoundaryCharacterSet = CharacterSet(charactersIn: ".!?")
         static let maximumWordsForAmbiguousTwoItemFirstContent = 10
         static let maximumCharactersForAmbiguousTwoItemFirstContent = 80
+        static let ambiguousOpeningTokenCheckLimit = 2
     }
 
     public init() {}
@@ -127,7 +128,53 @@ public struct ListPatternRunSelector {
             return false
         }
 
+        guard hasCredibleAmbiguousItemOpening(firstItemText) else {
+            return false
+        }
+
         return true
+    }
+
+    private func hasCredibleAmbiguousItemOpening(_ text: String) -> Bool {
+        let nsText = text as NSString
+        let tagger = NSLinguisticTagger(tagSchemes: [.lexicalClass], options: 0)
+        tagger.string = text
+
+        var inspectedTokenCount = 0
+        var sawContentToken = false
+        let fullRange = NSRange(location: 0, length: nsText.length)
+
+        tagger.enumerateTags(
+            in: fullRange,
+            unit: .word,
+            scheme: .lexicalClass,
+            options: [.omitWhitespace, .omitPunctuation, .joinNames]
+        ) { tag, tokenRange, stop in
+            let token = nsText.substring(with: tokenRange)
+            guard token.rangeOfCharacter(from: .letters) != nil else { return }
+
+            inspectedTokenCount += 1
+            if lexicalClassCountsAsContent(tag) {
+                sawContentToken = true
+                stop.pointee = true
+                return
+            }
+
+            if inspectedTokenCount >= CadenceGuard.ambiguousOpeningTokenCheckLimit {
+                stop.pointee = true
+            }
+        }
+
+        return sawContentToken
+    }
+
+    private func lexicalClassCountsAsContent(_ tag: NSLinguisticTag?) -> Bool {
+        switch tag {
+        case .noun, .verb, .adjective, .adverb, .otherWord, .classifier, .idiom:
+            return true
+        default:
+            return false
+        }
     }
 
     // Prevent list detection from stretching across long prose spans between

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternTrailingSplitter.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternTrailingSplitter.swift
@@ -193,14 +193,20 @@ public struct ListPatternTrailingSplitter {
     }
 
     private func commaBoundaryCandidate(in text: String, languageCode: String?) -> SplitCandidate? {
-        guard let split = firstRegexSplit(text, pattern: #"(?i)^(.{8,}?),\s+(.+)$"#) else {
+        guard let split = firstRegexSplit(text, pattern: #"(?i)^(.+?),\s+(.+)$"#) else {
+            return nil
+        }
+        let shortNominalItem = looksLikeShortNominalItem(split.0)
+        let sentenceLikeTrailing = looksLikeSentenceStyleCommentary(split.1)
+        let supportsShortNominalSplit = shortNominalItem && (sentenceLikeTrailing || looksLikeContinuationStart(split.1))
+        guard split.0.count >= 8 || supportsShortNominalSplit else {
             return nil
         }
         return makeCandidate(
             item: split.0,
             trailing: split.1,
             score: 60,
-            minItemWords: 3,
+            minItemWords: supportsShortNominalSplit ? 2 : 3,
             requiresContinuationShape: true,
             languageCode: languageCode
         )
@@ -259,6 +265,66 @@ public struct ListPatternTrailingSplitter {
         ListPatternMarkerParser.hasLeadingListMarkerPrefix(in: text, languageCode: languageCode)
     }
 
+    private func looksLikeShortNominalItem(_ text: String) -> Bool {
+        let tokens = lexicalWordTags(in: text)
+        guard !tokens.isEmpty, tokens.count <= 3 else { return false }
+
+        var sawNominalContent = false
+        for (_, tag) in tokens {
+            switch tag {
+            case .noun, .adjective, .otherWord, .classifier, .idiom:
+                sawNominalContent = true
+            case .verb:
+                return false
+            default:
+                continue
+            }
+        }
+
+        return sawNominalContent
+    }
+
+    private func looksLikeSentenceStyleCommentary(_ text: String) -> Bool {
+        let tokens = lexicalWordTags(in: text)
+        guard tokens.count >= 4 else { return false }
+
+        let leadingWindow = tokens.prefix(6)
+        let hasVerb = leadingWindow.contains { _, tag in
+            tag == .verb
+        }
+        let hasClauseAnchor = leadingWindow.contains { _, tag in
+            switch tag {
+            case .pronoun, .noun, .otherWord:
+                return true
+            default:
+                return false
+            }
+        }
+
+        return hasVerb && hasClauseAnchor
+    }
+
+    private func lexicalWordTags(in text: String) -> [(String, NSLinguisticTag?)] {
+        let nsText = text as NSString
+        let range = NSRange(location: 0, length: nsText.length)
+        let tagger = NSLinguisticTagger(tagSchemes: [.lexicalClass], options: 0)
+        tagger.string = text
+
+        var result: [(String, NSLinguisticTag?)] = []
+        tagger.enumerateTags(
+            in: range,
+            unit: .word,
+            scheme: .lexicalClass,
+            options: [.omitWhitespace, .omitPunctuation, .joinNames]
+        ) { tag, tokenRange, _ in
+            let token = nsText.substring(with: tokenRange)
+            guard token.rangeOfCharacter(from: .letters) != nil else { return }
+            result.append((token, tag))
+        }
+
+        return result
+    }
+
     private func looksLikeContinuationStart(_ text: String) -> Bool {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
@@ -267,6 +333,10 @@ public struct ListPatternTrailingSplitter {
             of: #"^[\"'“”‘’\(\[\{]*[A-Z]"#,
             options: .regularExpression
         ) != nil {
+            return true
+        }
+
+        if looksLikeSentenceStyleCommentary(trimmed) {
             return true
         }
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/TerminalPunctuationNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/TerminalPunctuationNormalizer.swift
@@ -4,14 +4,24 @@ public struct TerminalPunctuationNormalizer {
     private static let terminalTimeRegex = try? NSRegularExpression(
         pattern: #"(?i)\b(?:[1-9]|1[0-2]):[0-5][0-9]\s(?:AM|PM)\s*$"#
     )
+    private static let terminalSentencePunctuationRegex = try? NSRegularExpression(
+        pattern: #"[.!?…][\"'”’\)\]\}]*\s*$"#
+    )
 
     public init() {}
+
+    func hasTerminalSentencePunctuation(_ text: String) -> Bool {
+        guard let regex = Self.terminalSentencePunctuationRegex else { return false }
+        let nsText = text as NSString
+        let range = NSRange(location: 0, length: nsText.length)
+        return regex.firstMatch(in: text, options: [], range: range) != nil
+    }
 
     public func appendTerminalPeriodIfEndingInFormattedTime(_ text: String) -> String {
         guard !text.isEmpty else { return text }
 
         // Respect existing terminal punctuation, including punctuation before closing quotes/brackets.
-        if text.range(of: #"[.!?…][\"'”’\)\]\}]*\s*$"#, options: .regularExpression) != nil {
+        if hasTerminalSentencePunctuation(text) {
             return text
         }
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Services/Whisper/WhisperService+TranscriptionCore.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Services/Whisper/WhisperService+TranscriptionCore.swift
@@ -3,6 +3,11 @@ import AVFoundation
 import KeyVoxWhisper
 
 extension WhisperService {
+    struct TranscribedChunk {
+        let text: String
+        let trailingBoundaryFrame: Int?
+    }
+
     public func transcribe(
         audioFrames: [Float],
         useDictionaryHintPrompt: Bool = true,
@@ -68,7 +73,7 @@ extension WhisperService {
                 #endif
 
                 var transcribedSegments: [Segment] = []
-                var chunkTexts: [String] = []
+                var transcribedChunks: [TranscribedChunk] = []
                 var detectedLanguageCode: String? = nil
                 var nonEmptyChunkTextCount = 0
 
@@ -100,8 +105,16 @@ extension WhisperService {
                         .map { $0.text }
                         .joined(separator: " ")
                     let normalizedChunkText = self.normalizeWhitespace(chunkText)
+                    let trailingBoundaryFrame = chunkIndex < (chunkResult.chunks.count - 1)
+                        ? chunk.endFrame
+                        : nil
+                    transcribedChunks.append(
+                        TranscribedChunk(
+                            text: normalizedChunkText,
+                            trailingBoundaryFrame: trailingBoundaryFrame
+                        )
+                    )
                     if !normalizedChunkText.isEmpty {
-                        chunkTexts.append(normalizedChunkText)
                         nonEmptyChunkTextCount += 1
                     }
                     #if DEBUG
@@ -128,10 +141,11 @@ extension WhisperService {
                     return
                 }
 
-                let paragraphSeparator = enableAutoParagraphs ? "\n\n" : " "
-                let text = chunkTexts
-                    .joined(separator: paragraphSeparator)
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let text = self.assembleTranscription(
+                    from: transcribedChunks,
+                    silenceBoundaryFrames: Set(chunkResult.silenceBoundaryFrames),
+                    enableAutoParagraphs: enableAutoParagraphs
+                )
                 let hasSegments = !transcribedSegments.isEmpty
                 let allSegmentsHighNoSpeech = hasSegments && transcribedSegments.allSatisfy {
                     $0.noSpeechProbability >= noSpeechSegmentProbabilityThreshold
@@ -380,6 +394,39 @@ extension WhisperService {
             .map { $0.text }
             .joined(separator: " ")
         return normalizeWhitespace(joinedText)
+    }
+
+    func assembleTranscription(
+        from chunks: [TranscribedChunk],
+        silenceBoundaryFrames: Set<Int>,
+        enableAutoParagraphs: Bool
+    ) -> String {
+        guard !chunks.isEmpty else { return "" }
+
+        let punctuationNormalizer = TerminalPunctuationNormalizer()
+        var assembled = ""
+        var lastNonEmptyChunkIndex: Int?
+
+        for (index, chunk) in chunks.enumerated() {
+            guard !chunk.text.isEmpty else { continue }
+
+            if let previousIndex = lastNonEmptyChunkIndex, !assembled.isEmpty {
+                let sawSilenceBoundary = enableAutoParagraphs && chunks[previousIndex..<index].contains {
+                    guard let boundaryFrame = $0.trailingBoundaryFrame else { return false }
+                    return silenceBoundaryFrames.contains(boundaryFrame)
+                }
+                let separator = sawSilenceBoundary &&
+                    punctuationNormalizer.hasTerminalSentencePunctuation(chunks[previousIndex].text)
+                    ? "\n\n"
+                    : " "
+                assembled += separator
+            }
+
+            assembled += chunk.text
+            lastNonEmptyChunkIndex = index
+        }
+
+        return assembled.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func normalizeWhitespace(_ text: String, preservingNewlines: Bool = false) -> String {

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests.swift
@@ -142,4 +142,19 @@ final class TranscriptionPostProcessorTests: XCTestCase {
 
         XCTAssertEqual(output, "It's only one of those two choices and you're not allowed to have it.")
     }
+
+    func testSplitsShortNominalListItemFromTrailingCommentary() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "It's either going to be one a dresser two a chair, and honestly I don't think you're going to pick wrong",
+            dictionaryEntries: [],
+            renderMode: .multiline
+        )
+
+        XCTAssertEqual(
+            output,
+            "It's either going to be:\n\n1. A dresser\n2. A chair\n\nAnd honestly I don't think you're going to pick wrong"
+        )
+    }
 }

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests.swift
@@ -130,4 +130,16 @@ final class TranscriptionPostProcessorTests: XCTestCase {
         XCTAssertTrue(output.contains("1. First item"))
         XCTAssertTrue(output.contains("2. Second item"))
     }
+
+    func testDoesNotFormatQuantifiedChoiceSentenceAsList() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "It's only one of those two choices and you're not allowed to have it.",
+            dictionaryEntries: [],
+            renderMode: .multiline
+        )
+
+        XCTAssertEqual(output, "It's only one of those two choices and you're not allowed to have it.")
+    }
 }

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
@@ -47,6 +47,18 @@ final class ListPatternDetectorTests: XCTestCase {
         XCTAssertTrue(detected?.trailingText == "and everything's done")
     }
 
+    func testSplitsShortNominalLastItemFromSentenceStyleCommentary() {
+        let detector = ListPatternDetector()
+        let text = "It's either going to be: one a dresser two a chair, and honestly I don't think you're going to pick wrong"
+
+        let detected = detector.detectList(in: text)
+
+        XCTAssertNotNil(detected)
+        XCTAssertEqual(detected?.items.map(\.spokenIndex), [1, 2])
+        XCTAssertEqual(detected?.items.map(\.content), ["A dresser", "A chair"])
+        XCTAssertEqual(detected?.trailingText, "and honestly I don't think you're going to pick wrong")
+    }
+
     func testPreservesCausalTransitionWhenSplittingLastItem() {
         let detector = ListPatternDetector()
         let text = "Today one get dog food two charge phone three call mom because we leave early"

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
@@ -308,6 +308,15 @@ final class ListPatternDetectorTests: XCTestCase {
         XCTAssertNil(detected)
     }
 
+    func testDoesNotDetectListFromQuantifiedChoiceSentence() {
+        let detector = ListPatternDetector()
+        let text = "It's only one of those two choices and you're not allowed to have it."
+
+        let detected = detector.detectList(in: text)
+
+        XCTAssertNil(detected)
+    }
+
     func testDetectsSecondMarkerWhenAttachedAfterEmailDomain() {
         let detector = ListPatternDetector()
         let text = "I have a couple of email addresses. Let me give them to you: 1. Dom at example.com2. Kathy at example.com"

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Services/WhisperServiceParagraphAssemblyTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Services/WhisperServiceParagraphAssemblyTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import KeyVoxCore
+
+@MainActor
+final class WhisperServiceParagraphAssemblyTests: XCTestCase {
+    func testAssembleTranscriptionInsertsParagraphAfterSilenceBoundaryAndTerminalPunctuation() {
+        let service = WhisperService()
+        let text = service.assembleTranscription(
+            from: [
+                .init(text: "First paragraph.", trailingBoundaryFrame: 32_000),
+                .init(text: "Second paragraph.", trailingBoundaryFrame: nil)
+            ],
+            silenceBoundaryFrames: [32_000],
+            enableAutoParagraphs: true
+        )
+
+        XCTAssertEqual(text, "First paragraph.\n\nSecond paragraph.")
+    }
+
+    func testAssembleTranscriptionKeepsMidSentenceSilenceBoundaryInline() {
+        let service = WhisperService()
+        let text = service.assembleTranscription(
+            from: [
+                .init(text: "This sentence keeps going", trailingBoundaryFrame: 32_000),
+                .init(text: "until it actually ends.", trailingBoundaryFrame: nil)
+            ],
+            silenceBoundaryFrames: [32_000],
+            enableAutoParagraphs: true
+        )
+
+        XCTAssertEqual(text, "This sentence keeps going until it actually ends.")
+    }
+
+    func testAssembleTranscriptionIgnoresFallbackOnlyBoundaryEvenWithTerminalPunctuation() {
+        let service = WhisperService()
+        let text = service.assembleTranscription(
+            from: [
+                .init(text: "Sentence one.", trailingBoundaryFrame: 32_000),
+                .init(text: "Sentence two.", trailingBoundaryFrame: nil)
+            ],
+            silenceBoundaryFrames: [],
+            enableAutoParagraphs: true
+        )
+
+        XCTAssertEqual(text, "Sentence one. Sentence two.")
+    }
+
+    func testAssembleTranscriptionPreservesParagraphAcrossEmptyChunkGap() {
+        let service = WhisperService()
+        let text = service.assembleTranscription(
+            from: [
+                .init(text: "Quoted sentence!\"", trailingBoundaryFrame: 16_000),
+                .init(text: "", trailingBoundaryFrame: 32_000),
+                .init(text: "New paragraph.", trailingBoundaryFrame: nil)
+            ],
+            silenceBoundaryFrames: [16_000, 32_000],
+            enableAutoParagraphs: true
+        )
+
+        XCTAssertEqual(text, "Quoted sentence!\"\n\nNew paragraph.")
+    }
+}


### PR DESCRIPTION
- only insert automatic paragraph breaks after silence boundaries when the preceding transcribed chunk ends with terminal punctuation so mid-sentence chunk joins stay inline
- extract sentence-ending punctuation checks into the terminal punctuation normalizer and assemble whisper chunk text with boundary-aware paragraph joining instead of blindly turning every chunk boundary into a paragraph break
- tighten ambiguous two-item spoken-list detection so quantified prose like "one of those two choices" is rejected without hardcoding marker words
- relax trailing list-commentary splitting for short nominal last items so phrases like "a chair, and honestly ..." can break into commentary using shape-based checks instead of a rigid length gate
- add focused whisper paragraph-assembly, list-detector, and transcription post-processor regression coverage for the new paragraph and list boundary cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fixed automatic paragraph segmentation option in transcription service.
  * Improved list detection for short nominal items with trailing commentary.

* **Bug Fixes**
  * Enhanced comma boundary parsing for more flexible list item splitting.
  * Strengthened ambiguity detection in two-item list patterns.

* **Tests**
  * Added comprehensive test coverage for list pattern detection and transcription paragraph assembly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->