### PR TITLE
feat(sync): add macOS iCloud sync for dictionary and two settings

### DIFF
--- a/App/AppServiceRegistry.swift
+++ b/App/AppServiceRegistry.swift
@@ -7,10 +7,16 @@ final class AppServiceRegistry {
 
     let dictionaryStore: DictionaryStore
     let whisperService: WhisperService
+    let iCloudSyncCoordinator: KeyVoxiCloudSyncCoordinator
 
-    init(dictionaryStore: DictionaryStore, whisperService: WhisperService) {
+    init(
+        dictionaryStore: DictionaryStore,
+        whisperService: WhisperService,
+        iCloudSyncCoordinator: KeyVoxiCloudSyncCoordinator
+    ) {
         self.dictionaryStore = dictionaryStore
         self.whisperService = whisperService
+        self.iCloudSyncCoordinator = iCloudSyncCoordinator
     }
 
     private init(fileManager: FileManager = .default) {
@@ -31,6 +37,10 @@ final class AppServiceRegistry {
                     .path
                 return fileManager.fileExists(atPath: modelPath) ? modelPath : nil
             }
+        )
+        iCloudSyncCoordinator = KeyVoxiCloudSyncCoordinator(
+            appSettings: .shared,
+            dictionaryStore: dictionaryStore
         )
     }
 }

--- a/App/AppSettingsStore.swift
+++ b/App/AppSettingsStore.swift
@@ -174,6 +174,16 @@ final class AppSettingsStore: ObservableObject {
         selectedMicrophoneUID = persisted
     }
 
+    func applyCloudAutoParagraphsEnabled(_ value: Bool) {
+        guard autoParagraphsEnabled != value else { return }
+        autoParagraphsEnabled = value
+    }
+
+    func applyCloudListFormattingEnabled(_ value: Bool) {
+        guard listFormattingEnabled != value else { return }
+        listFormattingEnabled = value
+    }
+
     private func rolloverWordsCounterIfNeeded(referenceDate: Date) {
         let currentWeekStart = calendar.dateInterval(of: .weekOfYear, for: referenceDate)?.start ?? referenceDate
         guard !calendar.isDate(wordsThisWeekStart, inSameDayAs: currentWeekStart) else {

--- a/App/AppSettingsStore.swift
+++ b/App/AppSettingsStore.swift
@@ -179,6 +179,11 @@ final class AppSettingsStore: ObservableObject {
         autoParagraphsEnabled = value
     }
 
+    func applyCloudTriggerBinding(_ value: TriggerBinding) {
+        guard triggerBinding != value else { return }
+        triggerBinding = value
+    }
+
     func applyCloudListFormattingEnabled(_ value: Bool) {
         guard listFormattingEnabled != value else { return }
         listFormattingEnabled = value

--- a/App/KeyVoxApp.swift
+++ b/App/KeyVoxApp.swift
@@ -170,6 +170,7 @@ struct KeyVoxApp: App {
     @ObservedObject private var appSettings = AppSettingsStore.shared
     @ObservedObject private var windowManager = WindowManager.shared
     @ObservedObject private var downloader = ModelDownloader.shared
+    private let appServiceRegistry = AppServiceRegistry.shared
     private let onboardingStartupDelay: TimeInterval = 0.1
 
     nonisolated static func shouldUseAccessoryActivationPolicy(
@@ -202,6 +203,8 @@ struct KeyVoxApp: App {
         Task { @MainActor in
             AppUpdateService.shared.startUpdateTimer()
         }
+
+        _ = appServiceRegistry.iCloudSyncCoordinator
     }
     
     private var menuBarImage: Image {

--- a/App/UserDefaultsKeys.swift
+++ b/App/UserDefaultsKeys.swift
@@ -21,4 +21,10 @@ enum UserDefaultsKeys {
         static let wordsThisWeekCount = "KeyVox.App.WordsThisWeekCount"
         static let wordsThisWeekWeekStart = "KeyVox.App.WordsThisWeekWeekStart"
     }
+
+    enum iCloud {
+        static let dictionaryLastModifiedAt = "KeyVox.iCloud.DictionaryLastModifiedAt"
+        static let autoParagraphsLastModifiedAt = "KeyVox.iCloud.AutoParagraphsLastModifiedAt"
+        static let listFormattingLastModifiedAt = "KeyVox.iCloud.ListFormattingLastModifiedAt"
+    }
 }

--- a/App/UserDefaultsKeys.swift
+++ b/App/UserDefaultsKeys.swift
@@ -24,6 +24,7 @@ enum UserDefaultsKeys {
 
     enum iCloud {
         static let dictionaryLastModifiedAt = "KeyVox.iCloud.DictionaryLastModifiedAt"
+        static let triggerBindingLastModifiedAt = "KeyVox.iCloud.TriggerBindingLastModifiedAt"
         static let autoParagraphsLastModifiedAt = "KeyVox.iCloud.AutoParagraphsLastModifiedAt"
         static let listFormattingLastModifiedAt = "KeyVox.iCloud.ListFormattingLastModifiedAt"
     }

--- a/App/iCloud/KeyVoxiCloudKeys.swift
+++ b/App/iCloud/KeyVoxiCloudKeys.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum KeyVoxiCloudKeys {
+    static let dictionaryPayload = "kvx.dictionary.payload.v1"
+    static let dictionaryModifiedAt = "kvx.dictionary.modifiedAt.v1"
+    static let autoParagraphsEnabled = "kvx.settings.autoParagraphsEnabled.v1"
+    static let autoParagraphsModifiedAt = "kvx.settings.autoParagraphsModifiedAt.v1"
+    static let listFormattingEnabled = "kvx.settings.listFormattingEnabled.v1"
+    static let listFormattingModifiedAt = "kvx.settings.listFormattingModifiedAt.v1"
+}

--- a/App/iCloud/KeyVoxiCloudKeys.swift
+++ b/App/iCloud/KeyVoxiCloudKeys.swift
@@ -3,6 +3,8 @@ import Foundation
 enum KeyVoxiCloudKeys {
     static let dictionaryPayload = "kvx.dictionary.payload.v1"
     static let dictionaryModifiedAt = "kvx.dictionary.modifiedAt.v1"
+    static let triggerBinding = "kvx.settings.triggerBinding.v1"
+    static let triggerBindingModifiedAt = "kvx.settings.triggerBindingModifiedAt.v1"
     static let autoParagraphsEnabled = "kvx.settings.autoParagraphsEnabled.v1"
     static let autoParagraphsModifiedAt = "kvx.settings.autoParagraphsModifiedAt.v1"
     static let listFormattingEnabled = "kvx.settings.listFormattingEnabled.v1"

--- a/App/iCloud/KeyVoxiCloudPayloads.swift
+++ b/App/iCloud/KeyVoxiCloudPayloads.swift
@@ -1,0 +1,7 @@
+import Foundation
+import KeyVoxCore
+
+nonisolated struct KeyVoxDictionaryCloudPayload: Codable, Equatable {
+    let modifiedAt: Date
+    let entries: [DictionaryEntry]
+}

--- a/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
+++ b/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
@@ -27,6 +27,7 @@ final class KeyVoxiCloudSyncCoordinator {
     private var cancellables = Set<AnyCancellable>()
     private var externalChangeObserver: NSObjectProtocol?
     private var isApplyingRemoteDictionary = false
+    private var isApplyingRemoteTriggerBinding = false
     private var isApplyingRemoteAutoParagraphs = false
     private var isApplyingRemoteListFormatting = false
 
@@ -63,6 +64,11 @@ final class KeyVoxiCloudSyncCoordinator {
             applyRemoteDictionaryIfNewer()
         }
 
+        if changedKeys.contains(KeyVoxiCloudKeys.triggerBinding)
+            || changedKeys.contains(KeyVoxiCloudKeys.triggerBindingModifiedAt) {
+            applyRemoteTriggerBindingIfNewer()
+        }
+
         if changedKeys.contains(KeyVoxiCloudKeys.autoParagraphsEnabled)
             || changedKeys.contains(KeyVoxiCloudKeys.autoParagraphsModifiedAt) {
             applyRemoteAutoParagraphsIfNewer()
@@ -82,6 +88,16 @@ final class KeyVoxiCloudSyncCoordinator {
                 let modifiedAt = self.now()
                 self.setLocalDictionaryModifiedAt(modifiedAt)
                 self.pushDictionary(entries: entries, modifiedAt: modifiedAt)
+            }
+            .store(in: &cancellables)
+
+        appSettings.$triggerBinding
+            .dropFirst()
+            .sink { [weak self] value in
+                guard let self, !self.isApplyingRemoteTriggerBinding else { return }
+                let modifiedAt = self.now()
+                self.setLocalTriggerBindingModifiedAt(modifiedAt)
+                self.pushTriggerBinding(value, modifiedAt: modifiedAt)
             }
             .store(in: &cancellables)
 
@@ -129,6 +145,7 @@ final class KeyVoxiCloudSyncCoordinator {
 
     private func bootstrap() {
         bootstrapDictionary()
+        bootstrapTriggerBinding()
         bootstrapAutoParagraphs()
         bootstrapListFormatting()
     }
@@ -168,6 +185,19 @@ final class KeyVoxiCloudSyncCoordinator {
                 self?.applyRemoteAutoParagraphs(value: value, modifiedAt: modifiedAt)
             },
             defaultValue: true
+        )
+    }
+
+    private func bootstrapTriggerBinding() {
+        bootstrapSetting(
+            localValue: appSettings.triggerBinding.rawValue,
+            localModifiedAt: inferredLocalTriggerBindingModifiedAt(defaultValue: AppSettingsStore.TriggerBinding.rightOption.rawValue),
+            valueKey: KeyVoxiCloudKeys.triggerBinding,
+            modifiedAtKey: KeyVoxiCloudKeys.triggerBindingModifiedAt,
+            applyRemote: { [weak self] value, modifiedAt in
+                self?.applyRemoteTriggerBinding(rawValue: value, modifiedAt: modifiedAt)
+            },
+            defaultValue: AppSettingsStore.TriggerBinding.rightOption.rawValue
         )
     }
 
@@ -224,6 +254,49 @@ final class KeyVoxiCloudSyncCoordinator {
         }
     }
 
+    private func bootstrapSetting(
+        localValue: String,
+        localModifiedAt: Date?,
+        valueKey: String,
+        modifiedAtKey: String,
+        applyRemote: (String, Date) -> Void,
+        defaultValue: String
+    ) {
+        guard let remoteModifiedAt = ubiquitousStore.object(forKey: modifiedAtKey) as? Date else {
+            if let localModifiedAt {
+                pushSetting(localValue, valueKey: valueKey, modifiedAtKey: modifiedAtKey, modifiedAt: localModifiedAt)
+            } else if localValue != defaultValue {
+                let modifiedAt = now()
+                updateLocalSettingTimestamp(for: modifiedAtKey, value: modifiedAt)
+                pushSetting(localValue, valueKey: valueKey, modifiedAtKey: modifiedAtKey, modifiedAt: modifiedAt)
+            }
+            return
+        }
+
+        guard let remoteValue = ubiquitousStore.object(forKey: valueKey) as? String else {
+            return
+        }
+
+        guard let resolvedLocalModifiedAt = localModifiedAt else {
+            if localValue == defaultValue {
+                applyRemote(remoteValue, remoteModifiedAt)
+            } else {
+                let modifiedAt = now()
+                updateLocalSettingTimestamp(for: modifiedAtKey, value: modifiedAt)
+                pushSetting(localValue, valueKey: valueKey, modifiedAtKey: modifiedAtKey, modifiedAt: modifiedAt)
+            }
+            return
+        }
+
+        updateLocalSettingTimestamp(for: modifiedAtKey, value: resolvedLocalModifiedAt)
+
+        if remoteModifiedAt > resolvedLocalModifiedAt {
+            applyRemote(remoteValue, remoteModifiedAt)
+        } else if remoteModifiedAt < resolvedLocalModifiedAt {
+            pushSetting(localValue, valueKey: valueKey, modifiedAtKey: modifiedAtKey, modifiedAt: resolvedLocalModifiedAt)
+        }
+    }
+
     private func applyRemoteDictionaryIfNewer() {
         guard let payload = loadRemoteDictionaryPayload() else { return }
         let localModifiedAt = localDictionaryModifiedAt() ?? .distantPast
@@ -245,6 +318,34 @@ final class KeyVoxiCloudSyncCoordinator {
             print("[iCloudSync] Failed to apply remote dictionary payload: \(error)")
             #endif
         }
+    }
+
+    private func applyRemoteTriggerBindingIfNewer() {
+        guard
+            let remoteModifiedAt = ubiquitousStore.object(forKey: KeyVoxiCloudKeys.triggerBindingModifiedAt) as? Date,
+            let remoteValue = ubiquitousStore.object(forKey: KeyVoxiCloudKeys.triggerBinding) as? String
+        else {
+            return
+        }
+
+        let localModifiedAt = triggerBindingModifiedAt() ?? .distantPast
+        guard remoteModifiedAt > localModifiedAt else { return }
+        applyRemoteTriggerBinding(rawValue: remoteValue, modifiedAt: remoteModifiedAt)
+    }
+
+    private func applyRemoteTriggerBinding(rawValue: String, modifiedAt: Date) {
+        guard let binding = AppSettingsStore.TriggerBinding(rawValue: rawValue) else {
+            #if DEBUG
+            print("[iCloudSync] Ignoring invalid remote trigger binding: \(rawValue)")
+            #endif
+            return
+        }
+
+        isApplyingRemoteTriggerBinding = true
+        defer { isApplyingRemoteTriggerBinding = false }
+
+        appSettings.applyCloudTriggerBinding(binding)
+        setLocalTriggerBindingModifiedAt(modifiedAt)
     }
 
     private func applyRemoteAutoParagraphsIfNewer() {
@@ -314,6 +415,21 @@ final class KeyVoxiCloudSyncCoordinator {
         _ = ubiquitousStore.synchronize()
     }
 
+    private func pushSetting(_ value: String, valueKey: String, modifiedAtKey: String, modifiedAt: Date) {
+        ubiquitousStore.set(value, forKey: valueKey)
+        ubiquitousStore.set(modifiedAt, forKey: modifiedAtKey)
+        _ = ubiquitousStore.synchronize()
+    }
+
+    private func pushTriggerBinding(_ value: AppSettingsStore.TriggerBinding, modifiedAt: Date) {
+        pushSetting(
+            value.rawValue,
+            valueKey: KeyVoxiCloudKeys.triggerBinding,
+            modifiedAtKey: KeyVoxiCloudKeys.triggerBindingModifiedAt,
+            modifiedAt: modifiedAt
+        )
+    }
+
     private func loadRemoteDictionaryPayload() -> KeyVoxDictionaryCloudPayload? {
         guard let data = ubiquitousStore.data(forKey: KeyVoxiCloudKeys.dictionaryPayload) else {
             return nil
@@ -341,6 +457,14 @@ final class KeyVoxiCloudSyncCoordinator {
         defaults.object(forKey: UserDefaultsKeys.iCloud.autoParagraphsLastModifiedAt) as? Date
     }
 
+    private func triggerBindingModifiedAt() -> Date? {
+        defaults.object(forKey: UserDefaultsKeys.iCloud.triggerBindingLastModifiedAt) as? Date
+    }
+
+    private func setLocalTriggerBindingModifiedAt(_ value: Date) {
+        defaults.set(value, forKey: UserDefaultsKeys.iCloud.triggerBindingLastModifiedAt)
+    }
+
     private func setLocalAutoParagraphsModifiedAt(_ value: Date) {
         defaults.set(value, forKey: UserDefaultsKeys.iCloud.autoParagraphsLastModifiedAt)
     }
@@ -355,6 +479,8 @@ final class KeyVoxiCloudSyncCoordinator {
 
     private func updateLocalSettingTimestamp(for cloudModifiedAtKey: String, value: Date) {
         switch cloudModifiedAtKey {
+        case KeyVoxiCloudKeys.triggerBindingModifiedAt:
+            setLocalTriggerBindingModifiedAt(value)
         case KeyVoxiCloudKeys.autoParagraphsModifiedAt:
             setLocalAutoParagraphsModifiedAt(value)
         case KeyVoxiCloudKeys.listFormattingModifiedAt:
@@ -370,6 +496,10 @@ final class KeyVoxiCloudSyncCoordinator {
 
     private func inferredLocalAutoParagraphsModifiedAt(defaultValue: Bool) -> Date? {
         autoParagraphsModifiedAt() ?? (appSettings.autoParagraphsEnabled == defaultValue ? nil : now())
+    }
+
+    private func inferredLocalTriggerBindingModifiedAt(defaultValue: String) -> Date? {
+        triggerBindingModifiedAt() ?? (appSettings.triggerBinding.rawValue == defaultValue ? nil : now())
     }
 
     private func inferredLocalListFormattingModifiedAt(defaultValue: Bool) -> Date? {

--- a/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
+++ b/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
@@ -1,0 +1,379 @@
+import Foundation
+import Combine
+import KeyVoxCore
+
+protocol KeyVoxiCloudKeyValueStoring: AnyObject {
+    var notificationObject: AnyObject? { get }
+    func object(forKey key: String) -> Any?
+    func data(forKey key: String) -> Data?
+    func bool(forKey key: String) -> Bool
+    func set(_ value: Any?, forKey key: String)
+    @discardableResult func synchronize() -> Bool
+}
+
+extension NSUbiquitousKeyValueStore: KeyVoxiCloudKeyValueStoring {
+    var notificationObject: AnyObject? { self }
+}
+
+@MainActor
+final class KeyVoxiCloudSyncCoordinator {
+    private let ubiquitousStore: any KeyVoxiCloudKeyValueStoring
+    private let notificationCenter: NotificationCenter
+    private let appSettings: AppSettingsStore
+    private let dictionaryStore: DictionaryStore
+    private let defaults: UserDefaults
+    private let now: () -> Date
+
+    private var cancellables = Set<AnyCancellable>()
+    private var externalChangeObserver: NSObjectProtocol?
+    private var isApplyingRemoteDictionary = false
+    private var isApplyingRemoteAutoParagraphs = false
+    private var isApplyingRemoteListFormatting = false
+
+    init(
+        ubiquitousStore: any KeyVoxiCloudKeyValueStoring = NSUbiquitousKeyValueStore.default,
+        notificationCenter: NotificationCenter = .default,
+        appSettings: AppSettingsStore,
+        dictionaryStore: DictionaryStore,
+        defaults: UserDefaults = .standard,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.ubiquitousStore = ubiquitousStore
+        self.notificationCenter = notificationCenter
+        self.appSettings = appSettings
+        self.dictionaryStore = dictionaryStore
+        self.defaults = defaults
+        self.now = now
+
+        setupObservers()
+        registerForExternalChanges()
+        _ = ubiquitousStore.synchronize()
+        bootstrap()
+    }
+
+    deinit {
+        if let externalChangeObserver {
+            notificationCenter.removeObserver(externalChangeObserver)
+        }
+    }
+
+    func processExternalChanges(for changedKeys: [String]) {
+        if changedKeys.contains(KeyVoxiCloudKeys.dictionaryPayload)
+            || changedKeys.contains(KeyVoxiCloudKeys.dictionaryModifiedAt) {
+            applyRemoteDictionaryIfNewer()
+        }
+
+        if changedKeys.contains(KeyVoxiCloudKeys.autoParagraphsEnabled)
+            || changedKeys.contains(KeyVoxiCloudKeys.autoParagraphsModifiedAt) {
+            applyRemoteAutoParagraphsIfNewer()
+        }
+
+        if changedKeys.contains(KeyVoxiCloudKeys.listFormattingEnabled)
+            || changedKeys.contains(KeyVoxiCloudKeys.listFormattingModifiedAt) {
+            applyRemoteListFormattingIfNewer()
+        }
+    }
+
+    private func setupObservers() {
+        dictionaryStore.$entries
+            .dropFirst()
+            .sink { [weak self] entries in
+                guard let self, !self.isApplyingRemoteDictionary else { return }
+                let modifiedAt = self.now()
+                self.setLocalDictionaryModifiedAt(modifiedAt)
+                self.pushDictionary(entries: entries, modifiedAt: modifiedAt)
+            }
+            .store(in: &cancellables)
+
+        appSettings.$autoParagraphsEnabled
+            .dropFirst()
+            .sink { [weak self] value in
+                guard let self, !self.isApplyingRemoteAutoParagraphs else { return }
+                let modifiedAt = self.now()
+                self.setLocalAutoParagraphsModifiedAt(modifiedAt)
+                self.pushSetting(value, valueKey: KeyVoxiCloudKeys.autoParagraphsEnabled, modifiedAtKey: KeyVoxiCloudKeys.autoParagraphsModifiedAt, modifiedAt: modifiedAt)
+            }
+            .store(in: &cancellables)
+
+        appSettings.$listFormattingEnabled
+            .dropFirst()
+            .sink { [weak self] value in
+                guard let self, !self.isApplyingRemoteListFormatting else { return }
+                let modifiedAt = self.now()
+                self.setLocalListFormattingModifiedAt(modifiedAt)
+                self.pushSetting(value, valueKey: KeyVoxiCloudKeys.listFormattingEnabled, modifiedAtKey: KeyVoxiCloudKeys.listFormattingModifiedAt, modifiedAt: modifiedAt)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func registerForExternalChanges() {
+        guard let notificationObject = ubiquitousStore.notificationObject else { return }
+        externalChangeObserver = notificationCenter.addObserver(
+            forName: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+            object: notificationObject,
+            queue: nil
+        ) { [weak self] notification in
+            guard
+                let self,
+                let userInfo = notification.userInfo,
+                let changedKeys = userInfo[NSUbiquitousKeyValueStoreChangedKeysKey] as? [String]
+            else {
+                return
+            }
+
+            Task { @MainActor in
+                self.processExternalChanges(for: changedKeys)
+            }
+        }
+    }
+
+    private func bootstrap() {
+        bootstrapDictionary()
+        bootstrapAutoParagraphs()
+        bootstrapListFormatting()
+    }
+
+    private func bootstrapDictionary() {
+        let localEntries = dictionaryStore.entries
+        let localModifiedAt = inferredLocalDictionaryModifiedAt()
+        let remotePayload = loadRemoteDictionaryPayload()
+
+        switch (localEntries.isEmpty, remotePayload) {
+        case (true, nil):
+            return
+        case (false, nil):
+            let modifiedAt = localModifiedAt ?? now()
+            setLocalDictionaryModifiedAt(modifiedAt)
+            pushDictionary(entries: localEntries, modifiedAt: modifiedAt)
+        case (true, .some(let payload)):
+            applyRemoteDictionary(payload)
+        case (false, .some(let payload)):
+            let modifiedAt = localModifiedAt ?? now()
+            setLocalDictionaryModifiedAt(modifiedAt)
+            if payload.modifiedAt > modifiedAt {
+                applyRemoteDictionary(payload)
+            } else if payload.modifiedAt < modifiedAt {
+                pushDictionary(entries: localEntries, modifiedAt: modifiedAt)
+            }
+        }
+    }
+
+    private func bootstrapAutoParagraphs() {
+        bootstrapSetting(
+            localValue: appSettings.autoParagraphsEnabled,
+            localModifiedAt: inferredLocalAutoParagraphsModifiedAt(defaultValue: true),
+            valueKey: KeyVoxiCloudKeys.autoParagraphsEnabled,
+            modifiedAtKey: KeyVoxiCloudKeys.autoParagraphsModifiedAt,
+            applyRemote: { [weak self] value, modifiedAt in
+                self?.applyRemoteAutoParagraphs(value: value, modifiedAt: modifiedAt)
+            },
+            defaultValue: true
+        )
+    }
+
+    private func bootstrapListFormatting() {
+        bootstrapSetting(
+            localValue: appSettings.listFormattingEnabled,
+            localModifiedAt: inferredLocalListFormattingModifiedAt(defaultValue: true),
+            valueKey: KeyVoxiCloudKeys.listFormattingEnabled,
+            modifiedAtKey: KeyVoxiCloudKeys.listFormattingModifiedAt,
+            applyRemote: { [weak self] value, modifiedAt in
+                self?.applyRemoteListFormatting(value: value, modifiedAt: modifiedAt)
+            },
+            defaultValue: true
+        )
+    }
+
+    private func bootstrapSetting(
+        localValue: Bool,
+        localModifiedAt: Date?,
+        valueKey: String,
+        modifiedAtKey: String,
+        applyRemote: (Bool, Date) -> Void,
+        defaultValue: Bool
+    ) {
+        guard let remoteModifiedAt = ubiquitousStore.object(forKey: modifiedAtKey) as? Date else {
+            if let localModifiedAt {
+                pushSetting(localValue, valueKey: valueKey, modifiedAtKey: modifiedAtKey, modifiedAt: localModifiedAt)
+            } else if localValue != defaultValue {
+                let modifiedAt = now()
+                updateLocalSettingTimestamp(for: modifiedAtKey, value: modifiedAt)
+                pushSetting(localValue, valueKey: valueKey, modifiedAtKey: modifiedAtKey, modifiedAt: modifiedAt)
+            }
+            return
+        }
+
+        let remoteValue = ubiquitousStore.bool(forKey: valueKey)
+        if localModifiedAt == nil {
+            if localValue == defaultValue {
+                applyRemote(remoteValue, remoteModifiedAt)
+            } else {
+                let modifiedAt = now()
+                updateLocalSettingTimestamp(for: modifiedAtKey, value: modifiedAt)
+                pushSetting(localValue, valueKey: valueKey, modifiedAtKey: modifiedAtKey, modifiedAt: modifiedAt)
+            }
+            return
+        }
+
+        let resolvedLocalModifiedAt = localModifiedAt!
+        updateLocalSettingTimestamp(for: modifiedAtKey, value: resolvedLocalModifiedAt)
+
+        if remoteModifiedAt > resolvedLocalModifiedAt {
+            applyRemote(remoteValue, remoteModifiedAt)
+        } else if remoteModifiedAt < resolvedLocalModifiedAt {
+            pushSetting(localValue, valueKey: valueKey, modifiedAtKey: modifiedAtKey, modifiedAt: resolvedLocalModifiedAt)
+        }
+    }
+
+    private func applyRemoteDictionaryIfNewer() {
+        guard let payload = loadRemoteDictionaryPayload() else { return }
+        let localModifiedAt = localDictionaryModifiedAt() ?? .distantPast
+        guard payload.modifiedAt > localModifiedAt else { return }
+        applyRemoteDictionary(payload)
+    }
+
+    private func applyRemoteDictionary(_ payload: KeyVoxDictionaryCloudPayload) {
+        isApplyingRemoteDictionary = true
+        defer { isApplyingRemoteDictionary = false }
+
+        do {
+            if dictionaryStore.entries != payload.entries {
+                try dictionaryStore.replaceAll(entries: payload.entries)
+            }
+            setLocalDictionaryModifiedAt(payload.modifiedAt)
+        } catch {
+            #if DEBUG
+            print("[iCloudSync] Failed to apply remote dictionary payload: \(error)")
+            #endif
+        }
+    }
+
+    private func applyRemoteAutoParagraphsIfNewer() {
+        guard
+            let remoteModifiedAt = ubiquitousStore.object(forKey: KeyVoxiCloudKeys.autoParagraphsModifiedAt) as? Date
+        else {
+            return
+        }
+
+        let localModifiedAt = autoParagraphsModifiedAt() ?? .distantPast
+        guard remoteModifiedAt > localModifiedAt else { return }
+        applyRemoteAutoParagraphs(
+            value: ubiquitousStore.bool(forKey: KeyVoxiCloudKeys.autoParagraphsEnabled),
+            modifiedAt: remoteModifiedAt
+        )
+    }
+
+    private func applyRemoteAutoParagraphs(value: Bool, modifiedAt: Date) {
+        isApplyingRemoteAutoParagraphs = true
+        defer { isApplyingRemoteAutoParagraphs = false }
+
+        appSettings.applyCloudAutoParagraphsEnabled(value)
+        setLocalAutoParagraphsModifiedAt(modifiedAt)
+    }
+
+    private func applyRemoteListFormattingIfNewer() {
+        guard
+            let remoteModifiedAt = ubiquitousStore.object(forKey: KeyVoxiCloudKeys.listFormattingModifiedAt) as? Date
+        else {
+            return
+        }
+
+        let localModifiedAt = listFormattingModifiedAt() ?? .distantPast
+        guard remoteModifiedAt > localModifiedAt else { return }
+        applyRemoteListFormatting(
+            value: ubiquitousStore.bool(forKey: KeyVoxiCloudKeys.listFormattingEnabled),
+            modifiedAt: remoteModifiedAt
+        )
+    }
+
+    private func applyRemoteListFormatting(value: Bool, modifiedAt: Date) {
+        isApplyingRemoteListFormatting = true
+        defer { isApplyingRemoteListFormatting = false }
+
+        appSettings.applyCloudListFormattingEnabled(value)
+        setLocalListFormattingModifiedAt(modifiedAt)
+    }
+
+    private func pushDictionary(entries: [DictionaryEntry], modifiedAt: Date) {
+        let payload = KeyVoxDictionaryCloudPayload(modifiedAt: modifiedAt, entries: entries)
+
+        do {
+            let data = try JSONEncoder().encode(payload)
+            ubiquitousStore.set(data, forKey: KeyVoxiCloudKeys.dictionaryPayload)
+            ubiquitousStore.set(modifiedAt, forKey: KeyVoxiCloudKeys.dictionaryModifiedAt)
+            _ = ubiquitousStore.synchronize()
+        } catch {
+            #if DEBUG
+            print("[iCloudSync] Failed to encode dictionary payload: \(error)")
+            #endif
+        }
+    }
+
+    private func pushSetting(_ value: Bool, valueKey: String, modifiedAtKey: String, modifiedAt: Date) {
+        ubiquitousStore.set(value, forKey: valueKey)
+        ubiquitousStore.set(modifiedAt, forKey: modifiedAtKey)
+        _ = ubiquitousStore.synchronize()
+    }
+
+    private func loadRemoteDictionaryPayload() -> KeyVoxDictionaryCloudPayload? {
+        guard let data = ubiquitousStore.data(forKey: KeyVoxiCloudKeys.dictionaryPayload) else {
+            return nil
+        }
+
+        do {
+            return try JSONDecoder().decode(KeyVoxDictionaryCloudPayload.self, from: data)
+        } catch {
+            #if DEBUG
+            print("[iCloudSync] Failed to decode remote dictionary payload: \(error)")
+            #endif
+            return nil
+        }
+    }
+
+    private func localDictionaryModifiedAt() -> Date? {
+        defaults.object(forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt) as? Date
+    }
+
+    private func setLocalDictionaryModifiedAt(_ value: Date) {
+        defaults.set(value, forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt)
+    }
+
+    private func autoParagraphsModifiedAt() -> Date? {
+        defaults.object(forKey: UserDefaultsKeys.iCloud.autoParagraphsLastModifiedAt) as? Date
+    }
+
+    private func setLocalAutoParagraphsModifiedAt(_ value: Date) {
+        defaults.set(value, forKey: UserDefaultsKeys.iCloud.autoParagraphsLastModifiedAt)
+    }
+
+    private func listFormattingModifiedAt() -> Date? {
+        defaults.object(forKey: UserDefaultsKeys.iCloud.listFormattingLastModifiedAt) as? Date
+    }
+
+    private func setLocalListFormattingModifiedAt(_ value: Date) {
+        defaults.set(value, forKey: UserDefaultsKeys.iCloud.listFormattingLastModifiedAt)
+    }
+
+    private func updateLocalSettingTimestamp(for cloudModifiedAtKey: String, value: Date) {
+        switch cloudModifiedAtKey {
+        case KeyVoxiCloudKeys.autoParagraphsModifiedAt:
+            setLocalAutoParagraphsModifiedAt(value)
+        case KeyVoxiCloudKeys.listFormattingModifiedAt:
+            setLocalListFormattingModifiedAt(value)
+        default:
+            break
+        }
+    }
+
+    private func inferredLocalDictionaryModifiedAt() -> Date? {
+        localDictionaryModifiedAt() ?? (dictionaryStore.entries.isEmpty ? nil : now())
+    }
+
+    private func inferredLocalAutoParagraphsModifiedAt(defaultValue: Bool) -> Date? {
+        autoParagraphsModifiedAt() ?? (appSettings.autoParagraphsEnabled == defaultValue ? nil : now())
+    }
+
+    private func inferredLocalListFormattingModifiedAt(defaultValue: Bool) -> Date? {
+        listFormattingModifiedAt() ?? (appSettings.listFormattingEnabled == defaultValue ? nil : now())
+    }
+}

--- a/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
+++ b/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
@@ -233,7 +233,9 @@ final class KeyVoxiCloudSyncCoordinator {
             return
         }
 
-        let remoteValue = ubiquitousStore.bool(forKey: valueKey)
+        guard let remoteValue = ubiquitousStore.object(forKey: valueKey) as? Bool else {
+            return
+        }
         guard let resolvedLocalModifiedAt = localModifiedAt else {
             if localValue == defaultValue {
                 applyRemote(remoteValue, remoteModifiedAt)
@@ -350,7 +352,8 @@ final class KeyVoxiCloudSyncCoordinator {
 
     private func applyRemoteAutoParagraphsIfNewer() {
         guard
-            let remoteModifiedAt = ubiquitousStore.object(forKey: KeyVoxiCloudKeys.autoParagraphsModifiedAt) as? Date
+            let remoteModifiedAt = ubiquitousStore.object(forKey: KeyVoxiCloudKeys.autoParagraphsModifiedAt) as? Date,
+            let remoteValue = ubiquitousStore.object(forKey: KeyVoxiCloudKeys.autoParagraphsEnabled) as? Bool
         else {
             return
         }
@@ -358,7 +361,7 @@ final class KeyVoxiCloudSyncCoordinator {
         let localModifiedAt = autoParagraphsModifiedAt() ?? .distantPast
         guard remoteModifiedAt > localModifiedAt else { return }
         applyRemoteAutoParagraphs(
-            value: ubiquitousStore.bool(forKey: KeyVoxiCloudKeys.autoParagraphsEnabled),
+            value: remoteValue,
             modifiedAt: remoteModifiedAt
         )
     }
@@ -373,7 +376,8 @@ final class KeyVoxiCloudSyncCoordinator {
 
     private func applyRemoteListFormattingIfNewer() {
         guard
-            let remoteModifiedAt = ubiquitousStore.object(forKey: KeyVoxiCloudKeys.listFormattingModifiedAt) as? Date
+            let remoteModifiedAt = ubiquitousStore.object(forKey: KeyVoxiCloudKeys.listFormattingModifiedAt) as? Date,
+            let remoteValue = ubiquitousStore.object(forKey: KeyVoxiCloudKeys.listFormattingEnabled) as? Bool
         else {
             return
         }
@@ -381,7 +385,7 @@ final class KeyVoxiCloudSyncCoordinator {
         let localModifiedAt = listFormattingModifiedAt() ?? .distantPast
         guard remoteModifiedAt > localModifiedAt else { return }
         applyRemoteListFormatting(
-            value: ubiquitousStore.bool(forKey: KeyVoxiCloudKeys.listFormattingEnabled),
+            value: remoteValue,
             modifiedAt: remoteModifiedAt
         )
     }

--- a/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
+++ b/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
@@ -111,17 +111,17 @@ final class KeyVoxiCloudSyncCoordinator {
         externalChangeObserver = notificationCenter.addObserver(
             forName: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
             object: notificationObject,
-            queue: nil
+            queue: .main
         ) { [weak self] notification in
             guard
-                let self,
                 let userInfo = notification.userInfo,
                 let changedKeys = userInfo[NSUbiquitousKeyValueStoreChangedKeysKey] as? [String]
             else {
                 return
             }
 
-            Task { @MainActor in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
                 self.processExternalChanges(for: changedKeys)
             }
         }
@@ -204,7 +204,7 @@ final class KeyVoxiCloudSyncCoordinator {
         }
 
         let remoteValue = ubiquitousStore.bool(forKey: valueKey)
-        if localModifiedAt == nil {
+        guard let resolvedLocalModifiedAt = localModifiedAt else {
             if localValue == defaultValue {
                 applyRemote(remoteValue, remoteModifiedAt)
             } else {
@@ -215,7 +215,6 @@ final class KeyVoxiCloudSyncCoordinator {
             return
         }
 
-        let resolvedLocalModifiedAt = localModifiedAt!
         updateLocalSettingTimestamp(for: modifiedAtKey, value: resolvedLocalModifiedAt)
 
         if remoteModifiedAt > resolvedLocalModifiedAt {

--- a/KeyVox.xcodeproj/project.pbxproj
+++ b/KeyVox.xcodeproj/project.pbxproj
@@ -108,6 +108,10 @@
 		D16000112FA2000100AA0001 /* SettingsView+ModelSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16000012FA2000100AA0001 /* SettingsView+ModelSection.swift */; };
 		D17000112FA3000100AA0001 /* AppServiceRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17000012FA3000100AA0001 /* AppServiceRegistry.swift */; };
 		D17000212FA3000100AA0001 /* KeyVoxCore in Frameworks */ = {isa = PBXBuildFile; productRef = D17000312FA3000100AA0001 /* KeyVoxCore */; };
+		E18000112FA4000100AA0001 /* KeyVoxiCloudKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18000012FA4000100AA0001 /* KeyVoxiCloudKeys.swift */; };
+		E18000122FA4000100AA0001 /* KeyVoxiCloudPayloads.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18000022FA4000100AA0001 /* KeyVoxiCloudPayloads.swift */; };
+		E18000132FA4000100AA0001 /* KeyVoxiCloudSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18000032FA4000100AA0001 /* KeyVoxiCloudSyncCoordinator.swift */; };
+		E18000142FA4000100AA0001 /* KeyVoxiCloudSyncCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18000052FA4000100AA0001 /* KeyVoxiCloudSyncCoordinatorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -222,6 +226,10 @@
 		D15000012FA1000100AA0001 /* LoginItemController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemController.swift; sourceTree = "<group>"; };
 		D16000012FA2000100AA0001 /* SettingsView+ModelSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsView+ModelSection.swift"; sourceTree = "<group>"; };
 		D17000012FA3000100AA0001 /* AppServiceRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServiceRegistry.swift; sourceTree = "<group>"; };
+		E18000012FA4000100AA0001 /* KeyVoxiCloudKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyVoxiCloudKeys.swift; sourceTree = "<group>"; };
+		E18000022FA4000100AA0001 /* KeyVoxiCloudPayloads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyVoxiCloudPayloads.swift; sourceTree = "<group>"; };
+		E18000032FA4000100AA0001 /* KeyVoxiCloudSyncCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyVoxiCloudSyncCoordinator.swift; sourceTree = "<group>"; };
+		E18000052FA4000100AA0001 /* KeyVoxiCloudSyncCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyVoxiCloudSyncCoordinatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -266,6 +274,7 @@
 		8E6D05C52F3C51C9003BD458 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				E18000042FA4000100AA0001 /* iCloud */,
 				9E5000012F4F000100AA0001 /* AppSettingsStore.swift */,
 				D17000012FA3000100AA0001 /* AppServiceRegistry.swift */,
 				D15000012FA1000100AA0001 /* LoginItemController.swift */,
@@ -499,6 +508,7 @@
 			children = (
 				AB2000342F60000100AA0001 /* AppSettingsStoreTests.swift */,
 				AB2000232F60000100AA0001 /* KeyVoxAppActivationPolicyTests.swift */,
+				E18000052FA4000100AA0001 /* KeyVoxiCloudSyncCoordinatorTests.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -566,6 +576,16 @@
 				8E4B085E2F45407E00C5DB85 /* TranscriptionManager.swift */,
 			);
 			path = Transcription;
+			sourceTree = "<group>";
+		};
+		E18000042FA4000100AA0001 /* iCloud */ = {
+			isa = PBXGroup;
+			children = (
+				E18000012FA4000100AA0001 /* KeyVoxiCloudKeys.swift */,
+				E18000022FA4000100AA0001 /* KeyVoxiCloudPayloads.swift */,
+				E18000032FA4000100AA0001 /* KeyVoxiCloudSyncCoordinator.swift */,
+			);
+			path = iCloud;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -710,6 +730,9 @@
 				8EC700022F42000100C70001 /* WarningOverlayView.swift in Sources */,
 				8EC700032F42000100C70001 /* WarningManager.swift in Sources */,
 				9E5000112F4F000100AA0001 /* AppSettingsStore.swift in Sources */,
+				E18000112FA4000100AA0001 /* KeyVoxiCloudKeys.swift in Sources */,
+				E18000122FA4000100AA0001 /* KeyVoxiCloudPayloads.swift in Sources */,
+				E18000132FA4000100AA0001 /* KeyVoxiCloudSyncCoordinator.swift in Sources */,
 				D17000112FA3000100AA0001 /* AppServiceRegistry.swift in Sources */,
 				D15000112FA1000100AA0001 /* LoginItemController.swift in Sources */,
 				8E57FB8A2F3C9B6100935A26 /* UserDefaultsKeys.swift in Sources */,
@@ -763,6 +786,7 @@
 				AB3000042F60000100AA0001 /* OverlayFlingPhysicsTests.swift in Sources */,
 				AB3000122F60000100AA0001 /* WarningKindTests.swift in Sources */,
 				AB3000342F60000100AA0001 /* AppSettingsStoreTests.swift in Sources */,
+				E18000142FA4000100AA0001 /* KeyVoxiCloudSyncCoordinatorTests.swift in Sources */,
 				AB3000132F60000100AA0001 /* AppUpdateLogicTests.swift in Sources */,
 				AB3000142F60000100AA0001 /* PasteServiceListRenderModeTests.swift in Sources */,
 				AB3000152F60000100AA0001 /* PasteFailureRecoveryPolicyTests.swift in Sources */,
@@ -973,8 +997,8 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = Resources/KeyVox.entitlements;
-				CODE_SIGN_IDENTITY = "Developer ID Application";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = U7YT4DBC54;

--- a/KeyVoxTests/App/AppSettingsStoreTests.swift
+++ b/KeyVoxTests/App/AppSettingsStoreTests.swift
@@ -151,6 +151,32 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.selectedMicrophoneUID, "builtin-mic")
     }
 
+    func testApplyCloudAutoParagraphsEnabledPersistsValue() {
+        let (defaults, suiteName) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let calendar = makeCalendar()
+        let now = makeDate(calendar: calendar, year: 2026, month: 2, day: 17)
+        let store = AppSettingsStore(defaults: defaults, calendar: calendar, now: { now })
+
+        store.applyCloudAutoParagraphsEnabled(false)
+
+        XCTAssertFalse(store.autoParagraphsEnabled)
+        XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.autoParagraphsEnabled) as? Bool, false)
+    }
+
+    func testApplyCloudListFormattingEnabledPersistsValue() {
+        let (defaults, suiteName) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let calendar = makeCalendar()
+        let now = makeDate(calendar: calendar, year: 2026, month: 2, day: 17)
+        let store = AppSettingsStore(defaults: defaults, calendar: calendar, now: { now })
+
+        store.applyCloudListFormattingEnabled(false)
+
+        XCTAssertFalse(store.listFormattingEnabled)
+        XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.listFormattingEnabled) as? Bool, false)
+    }
+
     private func makeIsolatedDefaults() -> (UserDefaults, String) {
         let suiteName = "AppSettingsStoreTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
+++ b/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
@@ -28,7 +28,7 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
     func testCloudDictionarySeedsEmptyLocal() throws {
         let remoteDate = makeDate(year: 2026, month: 3, day: 8, hour: 10)
         let harness = try makeHarness(now: remoteDate)
-        harness.cloudStore.seedDictionary(entries: [
+        try harness.cloudStore.seedDictionary(entries: [
             DictionaryEntry(id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!, phrase: "Dom Esposito"),
         ], modifiedAt: remoteDate)
 
@@ -45,7 +45,7 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         let harness = try makeHarness(now: remoteDate)
         try harness.dictionaryStore.add(phrase: "Old Local Phrase")
         harness.defaults.set(localDate, forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt)
-        harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "New Remote Phrase")], modifiedAt: remoteDate)
+        try harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "New Remote Phrase")], modifiedAt: remoteDate)
 
         let coordinator = makeCoordinator(harness: harness)
         _ = coordinator
@@ -59,7 +59,7 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         let harness = try makeHarness(now: localDate)
         try harness.dictionaryStore.add(phrase: "Latest Local Phrase")
         harness.defaults.set(localDate, forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt)
-        harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "Older Remote Phrase")], modifiedAt: remoteDate)
+        try harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "Older Remote Phrase")], modifiedAt: remoteDate)
 
         let coordinator = makeCoordinator(harness: harness)
         _ = coordinator
@@ -86,7 +86,7 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         let harness = try makeHarness(now: remoteDate)
         try harness.dictionaryStore.add(phrase: "Local Phrase")
         harness.defaults.set(localDate, forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt)
-        harness.cloudStore.seedDictionary(entries: [
+        try harness.cloudStore.seedDictionary(entries: [
             DictionaryEntry(phrase: " Cueboard "),
             DictionaryEntry(phrase: "cueboard"),
         ], modifiedAt: remoteDate)
@@ -107,8 +107,15 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         let coordinator = makeCoordinator(harness: harness)
         _ = coordinator
 
+        let dictionaryPushed = expectation(description: "Dictionary change pushed to cloud")
+        harness.cloudStore.onSet = { key in
+            if key == KeyVoxiCloudKeys.dictionaryPayload {
+                dictionaryPushed.fulfill()
+            }
+        }
+
         try harness.dictionaryStore.add(phrase: "MiGo Platform")
-        await Task.yield()
+        await fulfillment(of: [dictionaryPushed], timeout: 1.0)
 
         let payload = try XCTUnwrap(harness.cloudStore.dictionaryPayload())
         XCTAssertEqual(payload.entries.map(\.phrase), ["MiGo Platform"])
@@ -118,7 +125,7 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
     func testRemoteDictionaryApplyDoesNotLoopPush() throws {
         let remoteDate = makeDate(year: 2026, month: 3, day: 11, hour: 9)
         let harness = try makeHarness(now: remoteDate)
-        harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "Remote Only")], modifiedAt: remoteDate)
+        try harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "Remote Only")], modifiedAt: remoteDate)
         harness.cloudStore.resetSetCounts()
 
         let coordinator = makeCoordinator(harness: harness)
@@ -146,8 +153,15 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         let coordinator = makeCoordinator(harness: harness)
         _ = coordinator
 
+        let listFormattingPushed = expectation(description: "List formatting pushed to cloud")
+        harness.cloudStore.onSet = { key in
+            if key == KeyVoxiCloudKeys.listFormattingModifiedAt {
+                listFormattingPushed.fulfill()
+            }
+        }
+
         harness.appSettings.listFormattingEnabled = false
-        await Task.yield()
+        await fulfillment(of: [listFormattingPushed], timeout: 1.0)
 
         XCTAssertEqual(harness.cloudStore.object(forKey: KeyVoxiCloudKeys.listFormattingEnabled) as? Bool, false)
         XCTAssertEqual(harness.cloudStore.object(forKey: KeyVoxiCloudKeys.listFormattingModifiedAt) as? Date, now)
@@ -257,9 +271,9 @@ private final class InMemoryUbiquitousKeyValueStore: KeyVoxiCloudKeyValueStoring
     }
 
     @MainActor
-    func seedDictionary(entries: [DictionaryEntry], modifiedAt: Date) {
+    func seedDictionary(entries: [DictionaryEntry], modifiedAt: Date) throws {
         let payload = KeyVoxDictionaryCloudPayload(modifiedAt: modifiedAt, entries: entries)
-        storage[KeyVoxiCloudKeys.dictionaryPayload] = try! JSONEncoder().encode(payload)
+        storage[KeyVoxiCloudKeys.dictionaryPayload] = try JSONEncoder().encode(payload)
         storage[KeyVoxiCloudKeys.dictionaryModifiedAt] = modifiedAt
     }
 

--- a/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
+++ b/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
@@ -1,0 +1,240 @@
+import Foundation
+import XCTest
+@testable import KeyVox
+@testable import KeyVoxCore
+
+@MainActor
+final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
+    func testLocalDictionarySeedsEmptyCloud() async throws {
+        let harness = try makeHarness(now: makeDate(year: 2026, month: 3, day: 7, hour: 12))
+        try harness.dictionaryStore.add(phrase: "Cueboard")
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+        await Task.yield()
+
+        let payload = try XCTUnwrap(harness.cloudStore.dictionaryPayload())
+        XCTAssertEqual(payload.entries.map(\.phrase), ["Cueboard"])
+        XCTAssertEqual(payload.modifiedAt, makeDate(year: 2026, month: 3, day: 7, hour: 12))
+    }
+
+    func testCloudDictionarySeedsEmptyLocal() throws {
+        let remoteDate = makeDate(year: 2026, month: 3, day: 8, hour: 10)
+        let harness = try makeHarness(now: remoteDate)
+        harness.cloudStore.seedDictionary(entries: [
+            DictionaryEntry(id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!, phrase: "Dom Esposito"),
+        ], modifiedAt: remoteDate)
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        XCTAssertEqual(harness.dictionaryStore.entries.map(\.phrase), ["Dom Esposito"])
+        XCTAssertEqual(harness.defaults.object(forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt) as? Date, remoteDate)
+    }
+
+    func testNewerCloudDictionaryWinsOverLocal() throws {
+        let localDate = makeDate(year: 2026, month: 3, day: 7, hour: 8)
+        let remoteDate = makeDate(year: 2026, month: 3, day: 9, hour: 8)
+        let harness = try makeHarness(now: remoteDate)
+        try harness.dictionaryStore.add(phrase: "Old Local Phrase")
+        harness.defaults.set(localDate, forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt)
+        harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "New Remote Phrase")], modifiedAt: remoteDate)
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        XCTAssertEqual(harness.dictionaryStore.entries.map(\.phrase), ["New Remote Phrase"])
+    }
+
+    func testOlderCloudDictionaryIsIgnored() throws {
+        let localDate = makeDate(year: 2026, month: 3, day: 10, hour: 8)
+        let remoteDate = makeDate(year: 2026, month: 3, day: 9, hour: 8)
+        let harness = try makeHarness(now: localDate)
+        try harness.dictionaryStore.add(phrase: "Latest Local Phrase")
+        harness.defaults.set(localDate, forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt)
+        harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "Older Remote Phrase")], modifiedAt: remoteDate)
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        XCTAssertEqual(harness.dictionaryStore.entries.map(\.phrase), ["Latest Local Phrase"])
+    }
+
+    func testMalformedCloudDictionaryIsIgnored() throws {
+        let localDate = makeDate(year: 2026, month: 3, day: 10, hour: 8)
+        let harness = try makeHarness(now: localDate)
+        try harness.dictionaryStore.add(phrase: "Local Phrase")
+        harness.defaults.set(localDate, forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt)
+        harness.cloudStore.seedRaw(Data("broken".utf8), forKey: KeyVoxiCloudKeys.dictionaryPayload)
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        XCTAssertEqual(harness.dictionaryStore.entries.map(\.phrase), ["Local Phrase"])
+    }
+
+    func testLocalDictionaryChangePushesCloud() async throws {
+        let now = makeDate(year: 2026, month: 3, day: 7, hour: 15)
+        let harness = try makeHarness(now: now)
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        try harness.dictionaryStore.add(phrase: "MiGo Platform")
+        await Task.yield()
+
+        let payload = try XCTUnwrap(harness.cloudStore.dictionaryPayload())
+        XCTAssertEqual(payload.entries.map(\.phrase), ["MiGo Platform"])
+        XCTAssertEqual(payload.modifiedAt, now)
+    }
+
+    func testRemoteDictionaryApplyDoesNotLoopPush() throws {
+        let remoteDate = makeDate(year: 2026, month: 3, day: 11, hour: 9)
+        let harness = try makeHarness(now: remoteDate)
+        harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "Remote Only")], modifiedAt: remoteDate)
+        harness.cloudStore.resetSetCounts()
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        XCTAssertEqual(harness.dictionaryStore.entries.map(\.phrase), ["Remote Only"])
+        XCTAssertEqual(harness.cloudStore.setCount(forKey: KeyVoxiCloudKeys.dictionaryPayload), 0)
+    }
+
+    func testNewerCloudAutoParagraphsAppliesLocally() {
+        let remoteDate = makeDate(year: 2026, month: 3, day: 12, hour: 9)
+        let harness = try! makeHarness(now: remoteDate)
+        harness.cloudStore.seedValue(false, forKey: KeyVoxiCloudKeys.autoParagraphsEnabled)
+        harness.cloudStore.seedValue(remoteDate, forKey: KeyVoxiCloudKeys.autoParagraphsModifiedAt)
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        XCTAssertFalse(harness.appSettings.autoParagraphsEnabled)
+    }
+
+    func testLocalListFormattingChangePushesCloud() async throws {
+        let now = makeDate(year: 2026, month: 3, day: 12, hour: 12)
+        let harness = try makeHarness(now: now)
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        harness.appSettings.listFormattingEnabled = false
+        await Task.yield()
+
+        XCTAssertEqual(harness.cloudStore.object(forKey: KeyVoxiCloudKeys.listFormattingEnabled) as? Bool, false)
+        XCTAssertEqual(harness.cloudStore.object(forKey: KeyVoxiCloudKeys.listFormattingModifiedAt) as? Date, now)
+    }
+
+    private func makeCoordinator(harness: Harness) -> KeyVoxiCloudSyncCoordinator {
+        KeyVoxiCloudSyncCoordinator(
+            ubiquitousStore: harness.cloudStore,
+            notificationCenter: harness.notificationCenter,
+            appSettings: harness.appSettings,
+            dictionaryStore: harness.dictionaryStore,
+            defaults: harness.defaults,
+            now: harness.now
+        )
+    }
+
+    private func makeHarness(now: Date) throws -> Harness {
+        let suiteName = "KeyVoxiCloudSyncCoordinatorTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("KeyVoxiCloudSyncCoordinatorTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+
+        let appSettings = AppSettingsStore(defaults: defaults, now: { now })
+        let dictionaryStore = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
+
+        return Harness(
+            defaults: defaults,
+            appSettings: appSettings,
+            dictionaryStore: dictionaryStore,
+            cloudStore: InMemoryUbiquitousKeyValueStore(),
+            notificationCenter: NotificationCenter(),
+            now: { now }
+        )
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int, hour: Int) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour
+        ).date!
+    }
+}
+
+private struct Harness {
+    let defaults: UserDefaults
+    let appSettings: AppSettingsStore
+    let dictionaryStore: DictionaryStore
+    let cloudStore: InMemoryUbiquitousKeyValueStore
+    let notificationCenter: NotificationCenter
+    let now: () -> Date
+}
+
+private final class InMemoryUbiquitousKeyValueStore: KeyVoxiCloudKeyValueStoring {
+    var notificationObject: AnyObject? { nil }
+
+    private var storage: [String: Any] = [:]
+    private var setCounts: [String: Int] = [:]
+
+    func object(forKey key: String) -> Any? {
+        storage[key]
+    }
+
+    func data(forKey key: String) -> Data? {
+        storage[key] as? Data
+    }
+
+    func bool(forKey key: String) -> Bool {
+        storage[key] as? Bool ?? false
+    }
+
+    func set(_ value: Any?, forKey key: String) {
+        storage[key] = value
+        setCounts[key, default: 0] += 1
+    }
+
+    func synchronize() -> Bool {
+        true
+    }
+
+    @MainActor
+    func seedDictionary(entries: [DictionaryEntry], modifiedAt: Date) {
+        let payload = KeyVoxDictionaryCloudPayload(modifiedAt: modifiedAt, entries: entries)
+        storage[KeyVoxiCloudKeys.dictionaryPayload] = try! JSONEncoder().encode(payload)
+        storage[KeyVoxiCloudKeys.dictionaryModifiedAt] = modifiedAt
+    }
+
+    func seedValue(_ value: Any, forKey key: String) {
+        storage[key] = value
+    }
+
+    func seedRaw(_ value: Any, forKey key: String) {
+        storage[key] = value
+    }
+
+    @MainActor
+    func dictionaryPayload() throws -> KeyVoxDictionaryCloudPayload? {
+        guard let data = storage[KeyVoxiCloudKeys.dictionaryPayload] as? Data else { return nil }
+        return try JSONDecoder().decode(KeyVoxDictionaryCloudPayload.self, from: data)
+    }
+
+    func setCount(forKey key: String) -> Int {
+        setCounts[key, default: 0]
+    }
+
+    func resetSetCounts() {
+        setCounts = [:]
+    }
+}

--- a/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
+++ b/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
@@ -9,9 +9,16 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         let harness = try makeHarness(now: makeDate(year: 2026, month: 3, day: 7, hour: 12))
         try harness.dictionaryStore.add(phrase: "Cueboard")
 
+        let dictionaryPushed = expectation(description: "Dictionary pushed to cloud")
+        harness.cloudStore.onSet = { key in
+            if key == KeyVoxiCloudKeys.dictionaryPayload {
+                dictionaryPushed.fulfill()
+            }
+        }
+
         let coordinator = makeCoordinator(harness: harness)
         _ = coordinator
-        await Task.yield()
+        await fulfillment(of: [dictionaryPushed], timeout: 1.0)
 
         let payload = try XCTUnwrap(harness.cloudStore.dictionaryPayload())
         XCTAssertEqual(payload.entries.map(\.phrase), ["Cueboard"])
@@ -73,6 +80,27 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.dictionaryStore.entries.map(\.phrase), ["Local Phrase"])
     }
 
+    func testLossyCloudDictionarySnapshotIsIgnored() throws {
+        let localDate = makeDate(year: 2026, month: 3, day: 10, hour: 8)
+        let remoteDate = makeDate(year: 2026, month: 3, day: 11, hour: 8)
+        let harness = try makeHarness(now: remoteDate)
+        try harness.dictionaryStore.add(phrase: "Local Phrase")
+        harness.defaults.set(localDate, forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt)
+        harness.cloudStore.seedDictionary(entries: [
+            DictionaryEntry(phrase: " Cueboard "),
+            DictionaryEntry(phrase: "cueboard"),
+        ], modifiedAt: remoteDate)
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        XCTAssertEqual(harness.dictionaryStore.entries.map(\.phrase), ["Local Phrase"])
+        XCTAssertEqual(
+            harness.defaults.object(forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt) as? Date,
+            localDate
+        )
+    }
+
     func testLocalDictionaryChangePushesCloud() async throws {
         let now = makeDate(year: 2026, month: 3, day: 7, hour: 15)
         let harness = try makeHarness(now: now)
@@ -100,9 +128,9 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.cloudStore.setCount(forKey: KeyVoxiCloudKeys.dictionaryPayload), 0)
     }
 
-    func testNewerCloudAutoParagraphsAppliesLocally() {
+    func testNewerCloudAutoParagraphsAppliesLocally() throws {
         let remoteDate = makeDate(year: 2026, month: 3, day: 12, hour: 9)
-        let harness = try! makeHarness(now: remoteDate)
+        let harness = try makeHarness(now: remoteDate)
         harness.cloudStore.seedValue(false, forKey: KeyVoxiCloudKeys.autoParagraphsEnabled)
         harness.cloudStore.seedValue(remoteDate, forKey: KeyVoxiCloudKeys.autoParagraphsModifiedAt)
 
@@ -149,14 +177,23 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         let appSettings = AppSettingsStore(defaults: defaults, now: { now })
         let dictionaryStore = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
 
-        return Harness(
+        let harness = Harness(
             defaults: defaults,
             appSettings: appSettings,
             dictionaryStore: dictionaryStore,
             cloudStore: InMemoryUbiquitousKeyValueStore(),
             notificationCenter: NotificationCenter(),
-            now: { now }
+            now: { now },
+            baseDirectoryURL: base,
+            defaultsSuiteName: suiteName
         )
+
+        addTeardownBlock { [harness] in
+            try? harness.removeTemporaryDirectory()
+            harness.defaults.removePersistentDomain(forName: harness.defaultsSuiteName)
+        }
+
+        return harness
     }
 
     private func makeDate(year: Int, month: Int, day: Int, hour: Int) -> Date {
@@ -180,6 +217,14 @@ private struct Harness {
     let cloudStore: InMemoryUbiquitousKeyValueStore
     let notificationCenter: NotificationCenter
     let now: () -> Date
+    let baseDirectoryURL: URL
+    let defaultsSuiteName: String
+
+    func removeTemporaryDirectory() throws {
+        if FileManager.default.fileExists(atPath: baseDirectoryURL.path) {
+            try FileManager.default.removeItem(at: baseDirectoryURL)
+        }
+    }
 }
 
 private final class InMemoryUbiquitousKeyValueStore: KeyVoxiCloudKeyValueStoring {
@@ -187,6 +232,7 @@ private final class InMemoryUbiquitousKeyValueStore: KeyVoxiCloudKeyValueStoring
 
     private var storage: [String: Any] = [:]
     private var setCounts: [String: Int] = [:]
+    var onSet: ((String) -> Void)?
 
     func object(forKey key: String) -> Any? {
         storage[key]
@@ -203,6 +249,7 @@ private final class InMemoryUbiquitousKeyValueStore: KeyVoxiCloudKeyValueStoring
     func set(_ value: Any?, forKey key: String) {
         storage[key] = value
         setCounts[key, default: 0] += 1
+        onSet?(key)
     }
 
     func synchronize() -> Bool {

--- a/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
+++ b/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
@@ -147,6 +147,18 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         XCTAssertFalse(harness.appSettings.autoParagraphsEnabled)
     }
 
+    func testNewerCloudTriggerBindingAppliesLocally() throws {
+        let remoteDate = makeDate(year: 2026, month: 3, day: 12, hour: 10)
+        let harness = try makeHarness(now: remoteDate)
+        harness.cloudStore.seedValue(AppSettingsStore.TriggerBinding.leftCommand.rawValue, forKey: KeyVoxiCloudKeys.triggerBinding)
+        harness.cloudStore.seedValue(remoteDate, forKey: KeyVoxiCloudKeys.triggerBindingModifiedAt)
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        XCTAssertEqual(harness.appSettings.triggerBinding, .leftCommand)
+    }
+
     func testLocalListFormattingChangePushesCloud() async throws {
         let now = makeDate(year: 2026, month: 3, day: 12, hour: 12)
         let harness = try makeHarness(now: now)
@@ -165,6 +177,29 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(harness.cloudStore.object(forKey: KeyVoxiCloudKeys.listFormattingEnabled) as? Bool, false)
         XCTAssertEqual(harness.cloudStore.object(forKey: KeyVoxiCloudKeys.listFormattingModifiedAt) as? Date, now)
+    }
+
+    func testLocalTriggerBindingChangePushesCloud() async throws {
+        let now = makeDate(year: 2026, month: 3, day: 12, hour: 13)
+        let harness = try makeHarness(now: now)
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        let triggerBindingPushed = expectation(description: "Trigger binding pushed to cloud")
+        harness.cloudStore.onSet = { key in
+            if key == KeyVoxiCloudKeys.triggerBindingModifiedAt {
+                triggerBindingPushed.fulfill()
+            }
+        }
+
+        harness.appSettings.triggerBinding = .leftControl
+        await fulfillment(of: [triggerBindingPushed], timeout: 1.0)
+
+        XCTAssertEqual(
+            harness.cloudStore.object(forKey: KeyVoxiCloudKeys.triggerBinding) as? String,
+            AppSettingsStore.TriggerBinding.leftControl.rawValue
+        )
+        XCTAssertEqual(harness.cloudStore.object(forKey: KeyVoxiCloudKeys.triggerBindingModifiedAt) as? Date, now)
     }
 
     private func makeCoordinator(harness: Harness) -> KeyVoxiCloudSyncCoordinator {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryStore.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryStore.swift
@@ -89,6 +89,12 @@ public final class DictionaryStore: ObservableObject {
         }
     }
 
+    public func replaceAll(entries newEntries: [DictionaryEntry]) throws {
+        let candidateEntries = sanitizedEntries(newEntries)
+        try persistAfterMutation(candidateEntries)
+        entries = candidateEntries
+    }
+
     public func whisperHintPrompt(maxEntries: Int = 200, maxChars: Int = 1200) -> String {
         let candidates = entries
             .map(\.phrase)
@@ -270,5 +276,22 @@ public final class DictionaryStore: ObservableObject {
 
     private func dedupeKey(for phrase: String) -> String {
         DictionaryTextNormalization.normalizedPhrase(normalizeInput(phrase))
+    }
+
+    private func sanitizedEntries(_ sourceEntries: [DictionaryEntry]) -> [DictionaryEntry] {
+        var seenKeys = Set<String>()
+        var result: [DictionaryEntry] = []
+
+        for entry in sourceEntries {
+            let cleanedPhrase = normalizeInput(entry.phrase)
+            guard !cleanedPhrase.isEmpty else { continue }
+
+            let key = dedupeKey(for: cleanedPhrase)
+            guard seenKeys.insert(key).inserted else { continue }
+
+            result.append(DictionaryEntry(id: entry.id, phrase: cleanedPhrase))
+        }
+
+        return result
     }
 }

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryStore.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryStore.swift
@@ -4,6 +4,7 @@ import Combine
 public enum DictionaryStoreError: LocalizedError, Equatable {
     case emptyPhrase
     case duplicatePhrase
+    case invalidSnapshotImport
     case saveFailed
 
     public var errorDescription: String? {
@@ -12,6 +13,8 @@ public enum DictionaryStoreError: LocalizedError, Equatable {
             return "Please enter a word or phrase."
         case .duplicatePhrase:
             return "That word is already in your dictionary."
+        case .invalidSnapshotImport:
+            return "The synced dictionary data was invalid and could not be applied."
         case .saveFailed:
             return "Couldn't save dictionary to disk. Please try again."
         }
@@ -90,7 +93,7 @@ public final class DictionaryStore: ObservableObject {
     }
 
     public func replaceAll(entries newEntries: [DictionaryEntry]) throws {
-        let candidateEntries = sanitizedEntries(newEntries)
+        let candidateEntries = try validatedSnapshotEntries(newEntries)
         try persistAfterMutation(candidateEntries)
         entries = candidateEntries
     }
@@ -276,6 +279,21 @@ public final class DictionaryStore: ObservableObject {
 
     private func dedupeKey(for phrase: String) -> String {
         DictionaryTextNormalization.normalizedPhrase(normalizeInput(phrase))
+    }
+
+    private func validatedSnapshotEntries(_ sourceEntries: [DictionaryEntry]) throws -> [DictionaryEntry] {
+        let sanitized = sanitizedEntries(sourceEntries)
+        guard sanitized.count == sourceEntries.count else {
+            throw DictionaryStoreError.invalidSnapshotImport
+        }
+
+        for (original, cleaned) in zip(sourceEntries, sanitized) {
+            guard original.id == cleaned.id, original.phrase == cleaned.phrase else {
+                throw DictionaryStoreError.invalidSnapshotImport
+            }
+        }
+
+        return sanitized
     }
 
     private func sanitizedEntries(_ sourceEntries: [DictionaryEntry]) -> [DictionaryEntry] {

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryStoreTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryStoreTests.swift
@@ -170,6 +170,56 @@ final class DictionaryStoreTests: XCTestCase {
         }
     }
 
+    func testReplaceAllPersistsSanitizedSnapshot() throws {
+        try withTemporaryDirectory { root in
+            let base = root.appendingPathComponent("KeyVox", isDirectory: true)
+            let store = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
+
+            try store.replaceAll(entries: [
+                DictionaryEntry(id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!, phrase: " Cueboard "),
+                DictionaryEntry(id: UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!, phrase: "cueboard"),
+                DictionaryEntry(id: UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")!, phrase: "  "),
+                DictionaryEntry(id: UUID(uuidString: "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD")!, phrase: "MiGo    Platform"),
+            ])
+
+            XCTAssertEqual(store.entries.map(\.phrase), ["Cueboard", "MiGo Platform"])
+            XCTAssertEqual(
+                store.entries.map(\.id.uuidString),
+                [
+                    "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+                    "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD",
+                ]
+            )
+
+            let reloaded = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
+            XCTAssertEqual(reloaded.entries.map(\.phrase), ["Cueboard", "MiGo Platform"])
+        }
+    }
+
+    func testReplaceAllFailedSaveLeavesExistingEntriesUntouched() throws {
+        try withTemporaryDirectory { root in
+            let base = root.appendingPathComponent("KeyVox", isDirectory: true)
+            let writer = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
+            try writer.add(phrase: "Dom Esposito")
+
+            let failingManager = FailingDirectoryFileManager()
+            let failingStore = DictionaryStore(fileManager: failingManager, baseDirectoryURL: base)
+            failingManager.shouldFailCreateDirectory = true
+
+            do {
+                try failingStore.replaceAll(entries: [
+                    DictionaryEntry(phrase: "Cueboard"),
+                    DictionaryEntry(phrase: "MiGo Platform"),
+                ])
+                XCTFail("Expected replaceAll save failure")
+            } catch let error as DictionaryStoreError {
+                XCTAssertEqual(error, .saveFailed)
+            }
+
+            XCTAssertEqual(failingStore.entries.map(\.phrase), ["Dom Esposito"])
+        }
+    }
+
     func testCorruptBothFilesTriggersQuarantineAndReset() throws {
         try withTemporaryDirectory { root in
             let base = root.appendingPathComponent("KeyVox", isDirectory: true)

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryStoreTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryStoreTests.swift
@@ -170,16 +170,14 @@ final class DictionaryStoreTests: XCTestCase {
         }
     }
 
-    func testReplaceAllPersistsSanitizedSnapshot() throws {
+    func testReplaceAllPersistsCleanSnapshot() throws {
         try withTemporaryDirectory { root in
             let base = root.appendingPathComponent("KeyVox", isDirectory: true)
             let store = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
 
             try store.replaceAll(entries: [
-                DictionaryEntry(id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!, phrase: " Cueboard "),
-                DictionaryEntry(id: UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!, phrase: "cueboard"),
-                DictionaryEntry(id: UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")!, phrase: "  "),
-                DictionaryEntry(id: UUID(uuidString: "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD")!, phrase: "MiGo    Platform"),
+                DictionaryEntry(id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!, phrase: "Cueboard"),
+                DictionaryEntry(id: UUID(uuidString: "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD")!, phrase: "MiGo Platform"),
             ])
 
             XCTAssertEqual(store.entries.map(\.phrase), ["Cueboard", "MiGo Platform"])
@@ -193,6 +191,26 @@ final class DictionaryStoreTests: XCTestCase {
 
             let reloaded = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
             XCTAssertEqual(reloaded.entries.map(\.phrase), ["Cueboard", "MiGo Platform"])
+        }
+    }
+
+    func testReplaceAllRejectsLossySnapshot() throws {
+        try withTemporaryDirectory { root in
+            let base = root.appendingPathComponent("KeyVox", isDirectory: true)
+            let store = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
+
+            do {
+                try store.replaceAll(entries: [
+                    DictionaryEntry(id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!, phrase: " Cueboard "),
+                    DictionaryEntry(id: UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!, phrase: "cueboard"),
+                    DictionaryEntry(id: UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")!, phrase: "  "),
+                ])
+                XCTFail("Expected lossy snapshot import failure")
+            } catch let error as DictionaryStoreError {
+                XCTAssertEqual(error, .invalidSnapshotImport)
+            }
+
+            XCTAssertTrue(store.entries.isEmpty)
         }
     }
 

--- a/Resources/KeyVox.entitlements
+++ b/Resources/KeyVox.entitlements
@@ -2,11 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.device.microphone</key>
-	<true/>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array/>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.microphone</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
- add app-owned iCloud sync primitives under `App/iCloud`, including versioned KVS keys, dictionary payload types, and a long-lived `KeyVoxiCloudSyncCoordinator`
- sync exactly three pieces of state on macOS through `NSUbiquitousKeyValueStore`: dictionary entries, `autoParagraphsEnabled`, and `listFormattingEnabled`
- add the macOS iCloud entitlements needed for Key-Value Storage support
- implement bootstrap-from-either-side behavior with newest-wins timestamps so local state can seed empty cloud state and newer cloud state can hydrate local state without requiring app relaunch
- suppress loopback during remote applies and ignore malformed cloud payloads so sync stays durable and fail-safe
- add `DictionaryStore.replaceAll(entries:)` as the canonical bulk import path for cloud dictionary snapshots, preserving normalization, dedupe, and atomic persistence behavior
- add explicit cloud-apply helpers in `AppSettingsStore` for the two synced settings and track local freshness timestamps in `UserDefaults`
- wire the sync coordinator into `AppServiceRegistry` and app startup so sync stays active for the full app lifetime
- add test coverage for sync bootstrap, conflict handling, malformed payloads, loop suppression, dictionary bulk replace, and cloud-applied settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iCloud synchronization for dictionary data, trigger binding, auto-paragraphs, and list formatting.
  * Settings and dictionary entries now automatically reconcile and stay synced across devices on startup and changes.

* **Tests**
  * New test coverage added for sync behavior and settings persistence.

* **Chores**
  * App entitlements updated to enable iCloud key-value storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->