### PR TITLE
pr: harden post-processing against dictionary, list, and four-digit number formatting false positives

### DIFF
--- a/Docs/CODEMAP.md
+++ b/Docs/CODEMAP.md
@@ -90,7 +90,7 @@ KeyVox/
 3. `Core/Audio/AudioRecorder.swift` captures live audio as mono float frames at 16kHz.
 4. `Core/Services/Whisper/WhisperAudioParagraphChunker.swift` detects long internal silence and computes conservative chunk boundaries.
 5. `Core/Services/Whisper/WhisperService.swift` transcribes each chunk through `KeyVoxWhisper` and stitches chunks with paragraph or space separators.
-6. `Core/Transcription/TranscriptionPostProcessor.swift` orchestrates dictionary correction, list formatting, and specialized normalization helpers under `Core/Normalization/`.
+6. `Core/Transcription/TranscriptionPostProcessor.swift` orchestrates dictionary correction, list formatting, and specialized normalization helpers under `Core/Normalization/`, including four-digit quantity grouping.
 7. `Core/Services/Paste/PasteService.swift` inserts text via Accessibility first, then menu-bar Paste fallback.
 8. `Core/Overlay/OverlayManager.swift` owns overlay lifecycle orchestration and delegates motion/persistence helpers.
 9. `Core/Overlay/AudioIndicatorDriver.swift` owns generic indicator timing, smoothing, stale-sample handling, and published timeline state.
@@ -139,7 +139,7 @@ KeyVox/
 - `Core/Transcription/DictationPromptEchoGuard.swift`
   - Post-transcription guard that suppresses likely dictionary-prompt echo output by treating repetitive prompt-like text as no-speech.
 - `Core/Transcription/TranscriptionPostProcessor.swift`
-  - Post-transcription orchestration (email pre-normalization, dictionary correction, idiom/colon/math/list passes, laughter/spam/time/email/website cleanup, then whitespace/capitalization/terminal-punctuation/all-caps finishing).
+  - Post-transcription orchestration (email pre-normalization, dictionary correction, idiom/colon/math/list passes, laughter/spam/time/email/website/four-digit grouping cleanup, then whitespace/capitalization/terminal-punctuation/all-caps finishing).
 - `Core/Normalization/TimeExpressionNormalizer.swift`
   - Isolated time-shape and meridiem normalization helper used by post-processing.
 - `Core/Normalization/MathExpressionNormalizer.swift`
@@ -235,6 +235,8 @@ KeyVox/
   - Provides spoken-colon normalization before list detection to stabilize `label colon value` phrasing into deterministic punctuation.
 - `Core/Normalization/CharacterSpamNormalizer.swift`
   - A model-noise guard that trims extreme repeated-character runs before downstream punctuation/capitalization finishing passes.
+- `Core/Normalization/ThousandsGroupingNormalizer.swift`
+  - Adds grouping separators to quantity-style four-digit numerals while preserving year-like references and protected date/version/phone shapes.
 - `Core/Normalization/AllCapsOverrideNormalizer.swift`
   - Final-stage output override that forces uppercase while preserving prior list/email/website/time formatting.
 - `Core/Language/Dictionary/Email/DictionaryEmailEntry.swift`

--- a/Docs/ENGINEERING.md
+++ b/Docs/ENGINEERING.md
@@ -29,7 +29,7 @@ KeyVox is organized by responsibility:
 - `Core/Transcription/`: Runtime state machine and the transcribe -> post-process -> paste orchestration boundary (`TranscriptionManager`, `DictationPipeline`, `TranscriptionPostProcessor`).
 - `Core/Audio/`: Recording, stream processing, silence classification, and threshold policy.
 - `Core/Language/Dictionary/` and `Core/Lists/`: Deterministic dictionary correction and list parsing/rendering, with matcher evaluation strategies organized under `Core/Language/Dictionary/Evaluation/` (`Helpers/`, `SplitJoin/`, and strategy files).
-- `Core/Normalization/`: Ordered pure normalization passes used by post-processing (email literal cleanup, colon/math, laughter/spam/time, website/domain casing, whitespace, capitalization, terminal punctuation, all-caps override) plus shared normalization utilities (for example URL/domain/email-safe capitalization guards).
+- `Core/Normalization/`: Ordered pure normalization stages used by post-processing: early literal cleanup, pre-list normalization, late cleanup, and final finishers. The individual passes remain small and composable, while the documented contract stays centered on stable ordering boundaries rather than every micro-pass. Shared normalization utilities (for example URL/domain/email-safe capitalization guards) also live here.
 - `Core/Services/`: Whisper inference (organized under `Core/Services/Whisper/`), paste/injection, and update/checking services.
 - `Core/Overlay/`: Floating overlay lifecycle, persistence, motion, and generic audio-indicator timing/state driving.
 - `Views/`: Onboarding/settings/warnings and presentation-only UI composition, including the proprietary logo system renderer.
@@ -52,16 +52,12 @@ For the full file-level map, see [`CODEMAP.md`](CODEMAP.md).
 
 1. `Core/Services/Whisper/WhisperAudioParagraphChunker.swift` computes conservative chunk boundaries from silence windows.
 2. `Core/Services/Whisper/WhisperService.swift` transcribes each chunk and stitches chunk text with `\n\n` when `autoParagraphsEnabled` is on (space-separated when off).
-3. `EmailAddressNormalizer` runs first (email literal case + punctuation/sentence-boundary cleanup).
-4. Dictionary correction applies custom-word adherence via `DictionaryMatcher`, including dictionary-backed spoken/literal email recovery.
-5. Lightweight idiom normalization runs (`hole in one` -> `hole-in-one`), then `ColonNormalizer` converts spoken/delimiter colon phrases before list parsing.
-6. `MathExpressionNormalizer` converts high-confidence spoken math into deterministic symbol form while preserving protected URL/email/code/time/date/version spans.
-7. List formatting applies numeric list rendering when confidence gates pass.
-8. Dedicated laughter normalization (`LaughterNormalizer`) and repeated-character spam cleanup (`CharacterSpamNormalizer`) run, then time normalization (`TimeExpressionNormalizer`) and final email boundary repair.
-9. `WebsiteNormalizer` applies domain casing normalization after email/time cleanup.
-10. Normalization helpers apply render-mode whitespace, capitalization guards (including URL/domain/email and technical-token safety checks), and terminal-time punctuation completion.
-11. `AllCapsOverrideNormalizer` applies a final uppercase override when Caps Lock mode is active.
-12. Final text is inserted via the paste service.
+3. Early literal cleanup runs first: `EmailAddressNormalizer` repairs email literal casing/punctuation boundaries before downstream matching, then dictionary correction applies custom-word adherence via `DictionaryMatcher`, including dictionary-backed spoken/literal email recovery.
+4. Pre-list normalization prepares deterministic structure: lightweight idiom normalization (`hole in one` -> `hole-in-one`), `ColonNormalizer`, and `MathExpressionNormalizer` run before list parsing so structural markers stabilize early.
+5. List formatting applies numeric list rendering when confidence gates pass.
+6. Late cleanup normalizes residual model output after list rendering: `LaughterNormalizer`, `CharacterSpamNormalizer`, `TimeExpressionNormalizer`, final email boundary repair, `WebsiteNormalizer`, and `ThousandsGroupingNormalizer`.
+7. Final finishers apply render-mode whitespace cleanup, capitalization guards (including URL/domain/email and technical-token safety checks), terminal-time punctuation completion, and the optional `AllCapsOverrideNormalizer`.
+8. Final text is inserted via the paste service.
 
 ## Update Feed and Release Checks
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinScoring.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinScoring.swift
@@ -26,6 +26,8 @@ private enum SplitJoinScoringConstants {
     static let stylizedAnchoredPhoneticMinimum = 0.60
     static let stylizedAnchoredBlendedMinimum = 0.48
     static let stylizedAnchoredThreshold = 0.44
+    static let stylizedAnchoredTailGuardMinimumSecondTokenLength = 4
+    static let stylizedAnchoredTailGuardMinimumSimilarity = 0.55
 
     static let blendedTextWeight = 0.6
     static let blendedPhoneticWeight = 0.4
@@ -210,11 +212,16 @@ extension DictionaryMatcher {
                 window: window,
                 candidateToken: candidateToken
             ),
+            hasAnchoredStylizedTailGuardEvidence(
+                window: window,
+                candidateToken: candidateToken
+            ),
             similarity.text >= SplitJoinScoringConstants.stylizedAnchoredTextMinimum,
             similarity.phonetic >= SplitJoinScoringConstants.stylizedAnchoredPhoneticMinimum,
             similarity.blended >= SplitJoinScoringConstants.stylizedAnchoredBlendedMinimum {
                 // Additional guarded lane for cases where Whisper splits a stylized
-                // proper name into two spoken words (e.g., "air axe").
+                // proper name into two spoken words while the remaining tail still
+                // resembles the stylized ending.
                 effectiveThreshold = min(effectiveThreshold, SplitJoinScoringConstants.stylizedAnchoredThreshold)
             }
         }
@@ -323,5 +330,30 @@ extension DictionaryMatcher {
         }
 
         return (bestText, bestPhonetic, bestBlended)
+    }
+
+    private func hasAnchoredStylizedTailGuardEvidence(window: [Token], candidateToken: String) -> Bool {
+        guard window.count == 2 else { return false }
+
+        let observedPrefix = window[0].normalized
+        guard candidateToken.hasPrefix(observedPrefix) else { return false }
+
+        let observedTail = window[1].normalized
+        guard observedTail.count >= SplitJoinScoringConstants.stylizedAnchoredTailGuardMinimumSecondTokenLength else {
+            return true
+        }
+
+        // Long ordinary words are the riskiest anchored split-join false positives,
+        // so require the unmatched tail to still resemble the brand tail.
+        let candidateTail = String(candidateToken.dropFirst(observedPrefix.count))
+        guard !candidateTail.isEmpty else { return false }
+
+        let observedTailPhonetic = encoder.scoringSignature(for: observedTail, lexicon: lexicon)
+        let candidateTailPhonetic = encoder.scoringSignature(for: candidateTail, lexicon: lexicon)
+        let textSimilarity = scorer.similarity(lhs: observedTail, rhs: candidateTail)
+        let phoneticSimilarity = scorer.similarity(lhs: observedTailPhonetic, rhs: candidateTailPhonetic)
+
+        return max(textSimilarity, phoneticSimilarity)
+            >= SplitJoinScoringConstants.stylizedAnchoredTailGuardMinimumSimilarity
     }
 }

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternDetector.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternDetector.swift
@@ -123,13 +123,21 @@ public struct ListPatternDetector {
     }
 
     private func normalizeTerminalPunctuation(in text: String) -> String {
-        guard wordCount(in: text) <= 2 else {
-            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let withoutStructuralDelimiter = text
+            .replacingOccurrences(
+                of: #"[\"'”’\)\]\}]*[,;:]+[\"'”’\)\]\}]*$"#,
+                with: "",
+                options: .regularExpression
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard wordCount(in: withoutStructuralDelimiter) <= 2 else {
+            return withoutStructuralDelimiter
         }
 
-        return text
+        return withoutStructuralDelimiter
             .replacingOccurrences(
-                of: #"[\"'”’\)\]\}]*[.,;:!?…]+[\"'”’\)\]\}]*$"#,
+                of: #"[\"'”’\)\]\}]*[.!?…]+[\"'”’\)\]\}]*$"#,
                 with: "",
                 options: .regularExpression
             )

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternDetector.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternDetector.swift
@@ -42,6 +42,15 @@ public struct ListPatternDetector {
             }
 
             let rawContent = nsText.substring(with: NSRange(location: marker.contentStart, length: end - marker.contentStart))
+            if index + 1 < bestRun.count,
+               !markerHasExplicitDelimiter(marker, in: nsText, languageCode: languageCode),
+               !markerHasExplicitDelimiter(bestRun[index + 1], in: nsText, languageCode: languageCode),
+               !hasCredibleUndelimitedIntermediateItemContent(rawContent) {
+                #if DEBUG
+                logDetector("reject reason=intermediate_item_too_short item=\(debugTextSummary(rawContent))")
+                #endif
+                return nil
+            }
             let content: String
             if index == bestRun.count - 1 {
                 let split = trailingSplitter.splitLastItemAndTrailing(rawContent, languageCode: languageCode)
@@ -128,6 +137,30 @@ public struct ListPatternDetector {
         var capitalized = text
         capitalized.replaceSubrange(firstLetter...firstLetter, with: String(text[firstLetter]).uppercased())
         return capitalized
+    }
+
+    private func hasCredibleUndelimitedIntermediateItemContent(_ raw: String) -> Bool {
+        let cleaned = raw
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let wordCount = cleaned.split(whereSeparator: \.isWhitespace).count
+        if wordCount >= 2 {
+            return true
+        }
+
+        let letterCount = cleaned.unicodeScalars.reduce(into: 0) { count, scalar in
+            if CharacterSet.letters.contains(scalar) {
+                count += 1
+            }
+        }
+        return letterCount >= 3
+    }
+
+    private func markerHasExplicitDelimiter(_ marker: ListPatternMarker, in nsText: NSString, languageCode: String?) -> Bool {
+        let spanLength = max(0, marker.contentStart - marker.markerTokenStart)
+        guard spanLength > 0 else { return false }
+        let span = nsText.substring(with: NSRange(location: marker.markerTokenStart, length: spanLength))
+        return ListPatternMarkerParser.hasExplicitDelimitedMarkerPrefix(in: span, languageCode: languageCode)
     }
 
     #if DEBUG

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternDetector.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternDetector.swift
@@ -110,7 +110,7 @@ public struct ListPatternDetector {
             .replacingOccurrences(of: "(?i)[\\s,:-]*(and|then|next)$", with: "", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
-        cleaned = stripTerminalPunctuation(in: cleaned)
+        cleaned = normalizeTerminalPunctuation(in: cleaned)
 
         guard cleaned.count >= 2 else { return nil }
         guard cleaned.rangeOfCharacter(from: .letters) != nil else { return nil }
@@ -122,14 +122,22 @@ public struct ListPatternDetector {
         return capitalizeFirstLetter(in: cleaned)
     }
 
-    private func stripTerminalPunctuation(in text: String) -> String {
-        text
+    private func normalizeTerminalPunctuation(in text: String) -> String {
+        guard wordCount(in: text) <= 2 else {
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return text
             .replacingOccurrences(
                 of: #"[\"'”’\)\]\}]*[.,;:!?…]+[\"'”’\)\]\}]*$"#,
                 with: "",
                 options: .regularExpression
             )
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func wordCount(in text: String) -> Int {
+        text.split(whereSeparator: \.isWhitespace).count
     }
 
     private func capitalizeFirstLetter(in text: String) -> String {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternTrailingSplitter.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternTrailingSplitter.swift
@@ -206,7 +206,7 @@ public struct ListPatternTrailingSplitter {
             item: split.0,
             trailing: split.1,
             score: 60,
-            minItemWords: supportsShortNominalSplit ? 2 : 3,
+            minItemWords: supportsShortNominalSplit ? 1 : 3,
             requiresContinuationShape: true,
             languageCode: languageCode
         )
@@ -268,6 +268,13 @@ public struct ListPatternTrailingSplitter {
     private func looksLikeShortNominalItem(_ text: String) -> Bool {
         let tokens = lexicalWordTags(in: text)
         guard !tokens.isEmpty, tokens.count <= 3 else { return false }
+
+        if tokens.count == 1,
+           let (token, _) = tokens.first,
+           token.rangeOfCharacter(from: .letters) != nil,
+           token.count >= 3 {
+            return true
+        }
 
         var sawNominalContent = false
         for (_, tag) in tokens {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/MathExpressionNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/MathExpressionNormalizer.swift
@@ -66,6 +66,10 @@ public struct MathExpressionNormalizer {
         pattern: #"\b\d+(?:\.\d+){2,}\b"#,
         options: []
     )
+    private static let protectedPhoneRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b(?:\d{3}\s*-\s*)?\d{3}\s*-\s*\d{4}\b"#,
+        options: []
+    )
     private static let protectedCompactHyphenatedNumericRegex: NSRegularExpression? = try? NSRegularExpression(
         pattern: #"\b\d{1,4}(?:-\d{1,4}){2,}\b"#,
         options: []
@@ -304,6 +308,7 @@ public struct MathExpressionNormalizer {
         protected.append(contentsOf: ranges(matching: Self.protectedMalformedTimeWithDaypartRegex, in: text))
         protected.append(contentsOf: ranges(matching: Self.protectedDateRegex, in: text))
         protected.append(contentsOf: ranges(matching: Self.protectedVersionRegex, in: text))
+        protected.append(contentsOf: ranges(matching: Self.protectedPhoneRegex, in: text))
         protected.append(contentsOf: compactHyphenatedNumericRanges(in: text))
         return protected
     }

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
@@ -1,10 +1,11 @@
 import Foundation
+import NaturalLanguage
 
 public struct ThousandsGroupingNormalizer {
     private struct LexicalToken {
         let text: String
         let range: NSRange
-        let tag: NSLinguisticTag?
+        let tag: NLTag?
     }
 
     private static let candidateRegex: NSRegularExpression? = try? NSRegularExpression(
@@ -92,18 +93,22 @@ public struct ThousandsGroupingNormalizer {
     }
 
     private func lexicalTokens(in line: String, range: NSRange) -> [LexicalToken] {
-        let tagger = NSLinguisticTagger(tagSchemes: [.lexicalClass], options: 0)
+        guard let stringRange = Range(range, in: line) else { return [] }
+
+        let tagger = NLTagger(tagSchemes: [.lexicalClass])
         tagger.string = line
 
         var tokens: [LexicalToken] = []
         tagger.enumerateTags(
-            in: range,
+            in: stringRange,
             unit: .word,
             scheme: .lexicalClass,
             options: [.omitWhitespace, .omitPunctuation]
-        ) { tag, tokenRange, _ in
-            let token = (line as NSString).substring(with: tokenRange)
-            tokens.append(LexicalToken(text: token, range: tokenRange, tag: tag))
+        ) { tag, tokenRange in
+            let token = String(line[tokenRange])
+            let nsTokenRange = NSRange(tokenRange, in: line)
+            tokens.append(LexicalToken(text: token, range: nsTokenRange, tag: tag))
+            return true
         }
         return tokens
     }

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+public struct ThousandsGroupingNormalizer {
+    private struct LexicalToken {
+        let text: String
+        let range: NSRange
+        let tag: NSLinguisticTag?
+    }
+
+    private static let candidateRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b\d{4}\b"#,
+        options: []
+    )
+    private static let isoDateRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b\d{4}-\d{2}-\d{2}\b"#,
+        options: []
+    )
+    private static let slashedOrHyphenatedDateRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b"#,
+        options: []
+    )
+    private static let versionRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b\d+(?:\.\d+){1,}\b"#,
+        options: []
+    )
+    private static let phoneRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b\d{3}-\d{3}-\d{4}\b"#,
+        options: []
+    )
+    private static let compactHyphenatedNumericRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b\d{1,4}(?:-\d{1,4}){2,}\b"#,
+        options: []
+    )
+    private static let plausibleYearRange = 1000...2999
+    private static let groupingFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.numberStyle = .decimal
+        formatter.groupingSeparator = ","
+        formatter.usesGroupingSeparator = true
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }()
+
+    public init() {}
+
+    public func normalize(in text: String) -> String {
+        guard !text.isEmpty else { return text }
+        guard text.rangeOfCharacter(from: .decimalDigits) != nil else { return text }
+
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        let normalizedLines = lines.map(normalizeLine(_:))
+        return normalizedLines.joined(separator: "\n")
+    }
+
+    private func normalizeLine(_ line: String) -> String {
+        guard let candidateRegex = Self.candidateRegex else { return line }
+
+        let nsLine = line as NSString
+        let fullRange = NSRange(location: 0, length: nsLine.length)
+        let matches = candidateRegex.matches(in: line, options: [], range: fullRange)
+        guard !matches.isEmpty else { return line }
+
+        let protectedRanges = protectedRanges(in: line, fullRange: fullRange)
+        let lexicalTokens = lexicalTokens(in: line, range: fullRange)
+        let mutable = NSMutableString(string: line)
+
+        for match in matches.reversed() {
+            let range = match.range
+            guard !protectedRanges.contains(where: { NSIntersectionRange($0, range).length > 0 }) else { continue }
+
+            let digits = nsLine.substring(with: range)
+            guard let value = Int(digits) else { continue }
+            guard shouldGroup(value: value, range: range, tokens: lexicalTokens) else { continue }
+            guard let replacement = Self.groupingFormatter.string(from: NSNumber(value: value)) else { continue }
+            mutable.replaceCharacters(in: range, with: replacement)
+        }
+
+        return mutable as String
+    }
+
+    private func protectedRanges(in line: String, fullRange: NSRange) -> [NSRange] {
+        [
+            Self.isoDateRegex,
+            Self.slashedOrHyphenatedDateRegex,
+            Self.versionRegex,
+            Self.phoneRegex,
+            Self.compactHyphenatedNumericRegex,
+        ]
+        .compactMap { $0 }
+        .flatMap { $0.matches(in: line, options: [], range: fullRange).map(\.range) }
+    }
+
+    private func lexicalTokens(in line: String, range: NSRange) -> [LexicalToken] {
+        let tagger = NSLinguisticTagger(tagSchemes: [.lexicalClass], options: 0)
+        tagger.string = line
+
+        var tokens: [LexicalToken] = []
+        tagger.enumerateTags(
+            in: range,
+            unit: .word,
+            scheme: .lexicalClass,
+            options: [.omitWhitespace, .omitPunctuation]
+        ) { tag, tokenRange, _ in
+            let token = (line as NSString).substring(with: tokenRange)
+            tokens.append(LexicalToken(text: token, range: tokenRange, tag: tag))
+        }
+        return tokens
+    }
+
+    private func shouldGroup(value: Int, range: NSRange, tokens: [LexicalToken]) -> Bool {
+        if !Self.plausibleYearRange.contains(value) {
+            return true
+        }
+
+        guard let tokenIndex = tokens.firstIndex(where: { NSEqualRanges($0.range, range) }) else {
+            return true
+        }
+
+        let previous = tokenIndex > 0 ? tokens[tokenIndex - 1] : nil
+        let next = tokenIndex + 1 < tokens.count ? tokens[tokenIndex + 1] : nil
+        let secondNext = tokenIndex + 2 < tokens.count ? tokens[tokenIndex + 2] : nil
+
+        if isLikelyYearReference(
+            value: value,
+            previous: previous,
+            next: next,
+            secondNext: secondNext
+        ) {
+            return false
+        }
+
+        return true
+    }
+
+    private func isLikelyYearReference(
+        value: Int,
+        previous: LexicalToken?,
+        next: LexicalToken?,
+        secondNext: LexicalToken?
+    ) -> Bool {
+        guard Self.plausibleYearRange.contains(value) else { return false }
+
+        if next == nil, previous == nil {
+            return false
+        }
+
+        if let nextTag = next?.tag,
+           [.verb, .pronoun, .determiner, .conjunction].contains(nextTag) {
+            return true
+        }
+
+        if previous?.tag == .preposition, next?.tag == .interjection {
+            return true
+        }
+
+        if next == nil, previous?.tag == .adverb {
+            return true
+        }
+
+        if next?.tag == .preposition {
+            if let secondNextTag = secondNext?.tag,
+               [.pronoun, .determiner].contains(secondNextTag) {
+                return false
+            }
+
+            if previous?.tag == .preposition {
+                return true
+            }
+        }
+
+        if previous == nil, next?.tag == .noun {
+            return true
+        }
+
+        if next == nil,
+           let previousTag = previous?.tag,
+           [.noun, .determiner, .preposition].contains(previousTag) {
+            return true
+        }
+
+        if previous?.tag == .determiner, next?.tag == .noun {
+            return true
+        }
+
+        if previous?.tag == .noun, next?.tag == .noun {
+            return true
+        }
+
+        return false
+    }
+}

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
@@ -33,7 +33,7 @@ public struct ThousandsGroupingNormalizer {
         options: []
     )
     private static let plausibleYearRange = 1000...2999
-    private static let groupingFormatter: NumberFormatter = {
+    private static func makeGroupingFormatter() -> NumberFormatter {
         let formatter = NumberFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.numberStyle = .decimal
@@ -41,7 +41,7 @@ public struct ThousandsGroupingNormalizer {
         formatter.usesGroupingSeparator = true
         formatter.maximumFractionDigits = 0
         return formatter
-    }()
+    }
 
     public init() {}
 
@@ -64,6 +64,7 @@ public struct ThousandsGroupingNormalizer {
 
         let protectedRanges = protectedRanges(in: line, fullRange: fullRange)
         let lexicalTokens = lexicalTokens(in: line, range: fullRange)
+        let groupingFormatter = Self.makeGroupingFormatter()
         let mutable = NSMutableString(string: line)
 
         for match in matches.reversed() {
@@ -73,7 +74,7 @@ public struct ThousandsGroupingNormalizer {
             let digits = nsLine.substring(with: range)
             guard let value = Int(digits) else { continue }
             guard shouldGroup(value: value, range: range, tokens: lexicalTokens) else { continue }
-            guard let replacement = Self.groupingFormatter.string(from: NSNumber(value: value)) else { continue }
+            guard let replacement = groupingFormatter.string(from: NSNumber(value: value)) else { continue }
             mutable.replaceCharacters(in: range, with: replacement)
         }
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
@@ -49,12 +49,13 @@ public struct ThousandsGroupingNormalizer {
         guard !text.isEmpty else { return text }
         guard text.rangeOfCharacter(from: .decimalDigits) != nil else { return text }
 
+        let groupingFormatter = Self.makeGroupingFormatter()
         let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        let normalizedLines = lines.map(normalizeLine(_:))
+        let normalizedLines = lines.map { normalizeLine($0, groupingFormatter: groupingFormatter) }
         return normalizedLines.joined(separator: "\n")
     }
 
-    private func normalizeLine(_ line: String) -> String {
+    private func normalizeLine(_ line: String, groupingFormatter: NumberFormatter) -> String {
         guard let candidateRegex = Self.candidateRegex else { return line }
 
         let nsLine = line as NSString
@@ -64,7 +65,6 @@ public struct ThousandsGroupingNormalizer {
 
         let protectedRanges = protectedRanges(in: line, fullRange: fullRange)
         let lexicalTokens = lexicalTokens(in: line, range: fullRange)
-        let groupingFormatter = Self.makeGroupingFormatter()
         let mutable = NSMutableString(string: line)
 
         for match in matches.reversed() {
@@ -119,8 +119,8 @@ public struct ThousandsGroupingNormalizer {
             return true
         }
 
-        guard let tokenIndex = tokens.firstIndex(where: { NSEqualRanges($0.range, range) }) else {
-            return true
+        guard let tokenIndex = resolvedTokenIndex(for: range, in: tokens) else {
+            return false
         }
 
         let previous = tokenIndex > 0 ? tokens[tokenIndex - 1] : nil
@@ -137,6 +137,18 @@ public struct ThousandsGroupingNormalizer {
         }
 
         return true
+    }
+
+    private func resolvedTokenIndex(for range: NSRange, in tokens: [LexicalToken]) -> Int? {
+        if let exactMatch = tokens.firstIndex(where: { NSEqualRanges($0.range, range) }) {
+            return exactMatch
+        }
+
+        return tokens.firstIndex { token in
+            NSIntersectionRange(token.range, range).length > 0 ||
+            NSLocationInRange(range.location, token.range) ||
+            NSLocationInRange(token.range.location, range)
+        }
     }
 
     private func isLikelyYearReference(

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
@@ -6,6 +6,7 @@ public struct ThousandsGroupingNormalizer {
         let text: String
         let range: NSRange
         let tag: NLTag?
+        let lemma: String?
     }
 
     private static let candidateRegex: NSRegularExpression? = try? NSRegularExpression(
@@ -17,7 +18,7 @@ public struct ThousandsGroupingNormalizer {
         options: []
     )
     private static let slashedOrHyphenatedDateRegex: NSRegularExpression? = try? NSRegularExpression(
-        pattern: #"\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b"#,
+        pattern: #"\b(?:\d{4}[/-]\d{1,2}[/-]\d{1,2}|\d{1,2}[/-]\d{1,2}[/-]\d{2,4})\b"#,
         options: []
     )
     private static let versionRegex: NSRegularExpression? = try? NSRegularExpression(
@@ -96,7 +97,7 @@ public struct ThousandsGroupingNormalizer {
     private func lexicalTokens(in line: String, range: NSRange) -> [LexicalToken] {
         guard let stringRange = Range(range, in: line) else { return [] }
 
-        let tagger = NLTagger(tagSchemes: [.lexicalClass])
+        let tagger = NLTagger(tagSchemes: [.lexicalClass, .lemma])
         tagger.string = line
 
         var tokens: [LexicalToken] = []
@@ -108,7 +109,8 @@ public struct ThousandsGroupingNormalizer {
         ) { tag, tokenRange in
             let token = String(line[tokenRange])
             let nsTokenRange = NSRange(tokenRange, in: line)
-            tokens.append(LexicalToken(text: token, range: nsTokenRange, tag: tag))
+            let lemma = tagger.tag(at: tokenRange.lowerBound, unit: .word, scheme: .lemma).0?.rawValue
+            tokens.append(LexicalToken(text: token, range: nsTokenRange, tag: tag, lemma: lemma))
             return true
         }
         return tokens
@@ -187,17 +189,25 @@ public struct ThousandsGroupingNormalizer {
             }
         }
 
-        if previous == nil, next?.tag == .noun {
-            return true
-        }
-
         if next == nil,
            let previousTag = previous?.tag,
            [.noun, .determiner, .preposition].contains(previousTag) {
             return true
         }
 
+        if previous == nil, next?.tag == .noun {
+            if isPluralInflectedNoun(next), secondNext?.tag == .verb {
+                return false
+            }
+
+            return true
+        }
+
         if previous?.tag == .determiner, next?.tag == .noun {
+            if isPluralInflectedNoun(next), secondNext?.tag == .verb {
+                return false
+            }
+
             return true
         }
 
@@ -206,5 +216,10 @@ public struct ThousandsGroupingNormalizer {
         }
 
         return false
+    }
+
+    private func isPluralInflectedNoun(_ token: LexicalToken?) -> Bool {
+        guard let token, token.tag == .noun, let lemma = token.lemma else { return false }
+        return token.text.compare(lemma, options: [.caseInsensitive, .diacriticInsensitive]) != .orderedSame
     }
 }

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
@@ -25,7 +25,7 @@ public struct ThousandsGroupingNormalizer {
         options: []
     )
     private static let phoneRegex: NSRegularExpression? = try? NSRegularExpression(
-        pattern: #"\b\d{3}-\d{3}-\d{4}\b"#,
+        pattern: #"\b(?:\d{3}\s*-\s*)?\d{3}\s*-\s*\d{4}\b"#,
         options: []
     )
     private static let compactHyphenatedNumericRegex: NSRegularExpression? = try? NSRegularExpression(

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Transcription/TranscriptionPostProcessor.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Transcription/TranscriptionPostProcessor.swift
@@ -8,6 +8,7 @@ public final class TranscriptionPostProcessor {
     private let characterSpamNormalizer = CharacterSpamNormalizer()
     private let timeExpressionNormalizer = TimeExpressionNormalizer()
     private let mathExpressionNormalizer = MathExpressionNormalizer()
+    private let thousandsGroupingNormalizer = ThousandsGroupingNormalizer()
     private let colonNormalizer = ColonNormalizer()
     private let allCapsOverrideNormalizer = AllCapsOverrideNormalizer()
     private let whitespaceNormalizer = WhitespaceNormalizer()
@@ -103,7 +104,11 @@ public final class TranscriptionPostProcessor {
         #if DEBUG
         logPipelineStage("websiteNormalizedOutput", websiteNormalizedOutput)
         #endif
-        let whitespaceNormalized = whitespaceNormalizer.normalize(websiteNormalizedOutput, renderMode: renderMode)
+        let groupedNumericOutput = thousandsGroupingNormalizer.normalize(in: websiteNormalizedOutput)
+        #if DEBUG
+        logPipelineStage("groupedNumericOutput", groupedNumericOutput)
+        #endif
+        let whitespaceNormalized = whitespaceNormalizer.normalize(groupedNumericOutput, renderMode: renderMode)
         #if DEBUG
         logPipelineStage("whitespaceNormalized", whitespaceNormalized)
         #endif

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+MathNormalization.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+MathNormalization.swift
@@ -313,6 +313,18 @@ extension TranscriptionPostProcessorTests {
         XCTAssertEqual(output, "Call me at 480-555-5555.")
     }
 
+    func testPreservesLocalHyphenatedPhoneNumber() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "555-1234",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "555-1234")
+    }
+
     func testPreservesCompactHyphenatedDateWithShortLeadingSegment() {
         let processor = TranscriptionPostProcessor()
 

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+NumericGrouping.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+NumericGrouping.swift
@@ -87,4 +87,16 @@ extension TranscriptionPostProcessorTests {
 
         XCTAssertEqual(output, "I can't remember when that was. I think it was maybe 1993.")
     }
+
+    func testDoesNotGroupLocalPhoneNumberTailAfterHyphenSpacing() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "555-1234",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "555-1234")
+    }
 }

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+NumericGrouping.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+NumericGrouping.swift
@@ -88,6 +88,33 @@ extension TranscriptionPostProcessorTests {
         XCTAssertEqual(output, "I can't remember when that was. I think it was maybe 1993.")
     }
 
+    func testPreservesYearFirstSlashedDatesWhileFormattingQuantities() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "The deadline is 2026/02/19 and we shipped 5600 units.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "The deadline is 2026/02/19 and we shipped 5,600 units.")
+    }
+
+    func testFormatsQuantityLikePluralNounPhrasesAtSentenceStartAndAfterDeterminer() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "2000 units shipped yesterday. The 2000 units were backordered.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(
+            output,
+            "2,000 units shipped yesterday. The 2,000 units were backordered."
+        )
+    }
+
     func testDoesNotGroupLocalPhoneNumberTailAfterHyphenSpacing() {
         let processor = TranscriptionPostProcessor()
 

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+NumericGrouping.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+NumericGrouping.swift
@@ -1,0 +1,90 @@
+import Foundation
+import XCTest
+@testable import KeyVoxCore
+
+@MainActor
+extension TranscriptionPostProcessorTests {
+    func testFormatsStandaloneFourDigitQuantitiesBelowTenThousand() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "5600 2000 4000 9300 2100",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "5,600 2,000 4,000 9,300 2,100")
+    }
+
+    func testFormatsFourDigitQuantitiesInSentenceWhilePreservingYearReferences() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "I shipped 5600 units in 2025 and 9300 units in 2026",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "I shipped 5,600 units in 2025 and 9,300 units in 2026")
+    }
+
+    func testPreservesYearModifiersWhileFormattingFourDigitQuantities() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "The 2025 roadmap replaced the 2026 plan after 2100 tickets came in",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "The 2025 roadmap replaced the 2026 plan after 2,100 tickets came in")
+    }
+
+    func testFormatsPartitiveFourDigitQuantitiesWithoutTreatingThemAsYears() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Can you give me about 2000 of them? I need 1000 of them.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Can you give me about 2,000 of them? I need 1,000 of them.")
+    }
+
+    func testPreservesYearReferenceBeforeConfirmationPhrase() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Yeah, that came out in 2001, right?",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Yeah, that came out in 2001, right?")
+    }
+
+    func testFormatsQuantityBeforeConfirmationPhrase() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "I need 1000, right?",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "I need 1,000, right?")
+    }
+
+    func testPreservesUncertainSentenceFinalYearReference() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "I can't remember when that was. I think it was maybe 1993.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "I can't remember when that was. I think it was maybe 1993.")
+    }
+}

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -60,6 +60,14 @@ final class DictionaryMatcherTests: XCTestCase {
         XCTAssertEqual(result.text, "My app is called KeyVox.")
     }
 
+    func testDoesNotCollapseOrdinaryTwoWordPhraseIntoAnchoredStylizedSplitJoinMatch() {
+        let matcher = makeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "KeyVox")])
+
+        let result = matcher.apply(to: "I added key value storage.")
+        XCTAssertEqual(result.text, "I added key value storage.")
+    }
+
     func testCorrectsStylizedSingleTokenBrandNearMissWithRuntimeLexicon() {
         let matcher = makeRuntimeMatcher()
         matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "KeyVox")])

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
@@ -65,4 +65,19 @@ final class ListFormattingEngineTests: XCTestCase {
             "I need to go to the store today to pick up some things:\n\n1. Apples\n2. Oranges\n3. Bananas\n\nAnd then I need to go to Target to buy some clothes."
         )
     }
+
+    func testPreservesTerminalPunctuationOnlyForLongerListItems() {
+        let engine = ListFormattingEngine()
+        let text = """
+        1. Write the full summary.
+        2. Walk dog.
+        3. Double-check the release notes!
+        """
+
+        let output = engine.formatIfNeeded(text, renderMode: .multiline)
+        XCTAssertEqual(
+            output,
+            "1. Write the full summary.\n2. Walk dog\n3. Double-check the release notes!"
+        )
+    }
 }

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
@@ -80,4 +80,12 @@ final class ListFormattingEngineTests: XCTestCase {
             "1. Write the full summary.\n2. Walk dog\n3. Double-check the release notes!"
         )
     }
+
+    func testStripsStructuralCommaFromLongerSpokenListItem() {
+        let engine = ListFormattingEngine()
+        let text = "Need two things one write the full summary, two walk dog"
+
+        let output = engine.formatIfNeeded(text, renderMode: .multiline)
+        XCTAssertEqual(output, "Need two things:\n\n1. Write the full summary\n2. Walk dog")
+    }
 }

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
@@ -37,4 +37,32 @@ final class ListFormattingEngineTests: XCTestCase {
         let output = engine.formatIfNeeded(text, renderMode: .multiline)
         XCTAssertEqual(output, text)
     }
+
+    func testSplitsSingleWordLastItemFromCommaThenContinuation() {
+        let engine = ListFormattingEngine()
+        let text = """
+        I need to go to the store today to pick up some things:
+
+        1. Apples
+        2. Oranges
+        3. Bananas, and then I need to go to Target to buy some clothes
+        """
+
+        let output = engine.formatIfNeeded(text, renderMode: .multiline)
+        XCTAssertEqual(
+            output,
+            "I need to go to the store today to pick up some things:\n\n1. Apples\n2. Oranges\n3. Bananas\n\nAnd then I need to go to Target to buy some clothes"
+        )
+    }
+
+    func testSplitsSpokenMarkerLastItemFromCommaThenContinuation() {
+        let engine = ListFormattingEngine()
+        let text = "I need to go to the store today to pick up some things. One, apples, two, oranges, three, bananas, and then I need to go to Target to buy some clothes."
+
+        let output = engine.formatIfNeeded(text, renderMode: .multiline)
+        XCTAssertEqual(
+            output,
+            "I need to go to the store today to pick up some things:\n\n1. Apples\n2. Oranges\n3. Bananas\n\nAnd then I need to go to Target to buy some clothes."
+        )
+    }
 }

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
@@ -27,4 +27,14 @@ final class ListFormattingEngineTests: XCTestCase {
         let output = engine.formatIfNeeded(text, renderMode: .multiline)
         XCTAssertTrue(output == "Need to do this:\n\n1. Buy groceries\n2. Walk dog\n4. Call mom")
     }
+
+    func testLeavesUncertainNumericRangeInProseUnchanged() {
+        let engine = ListFormattingEngine()
+        let text = """
+        One thing real quickly, and that is just to adjust the size of the individual keys. Maybe like, I don't know two or three points taller. Something like that.
+        """
+
+        let output = engine.formatIfNeeded(text, renderMode: .multiline)
+        XCTAssertEqual(output, text)
+    }
 }

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
@@ -258,6 +258,16 @@ final class ListPatternDetectorTests: XCTestCase {
         XCTAssertNil(detected)
     }
 
+    func testDoesNotDetectListFromUncertainNumericRangeInProse() {
+        let detector = ListPatternDetector()
+        let text = """
+        One thing real quickly, and that is just to adjust the size of the individual keys. Maybe like, I don't know two or three points taller. Something like that.
+        """
+
+        let detected = detector.detectList(in: text)
+        XCTAssertNil(detected)
+    }
+
     func testDetectsExplicitTwoItemListAfterColonEvenWhenItemOneIsLong() {
         let detector = ListPatternDetector()
         let text = """

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
@@ -192,6 +192,34 @@ final class ListPatternDetectorTests: XCTestCase {
         )
     }
 
+    func testSplitsShortNominalLastItemFromCommaThenContinuation() {
+        let detector = ListPatternDetector()
+        let text = """
+        I need to go to the store today to pick up some things:
+
+        1. Apples
+        2. Oranges
+        3. Bananas, and then I need to go to Target to buy some clothes
+        """
+
+        let detected = detector.detectList(in: text)
+        XCTAssertNotNil(detected)
+        XCTAssertEqual(detected?.items.map(\.spokenIndex), [1, 2, 3])
+        XCTAssertEqual(detected?.items.map(\.content), ["Apples", "Oranges", "Bananas"])
+        XCTAssertEqual(detected?.trailingText, "and then I need to go to Target to buy some clothes")
+    }
+
+    func testSplitsSpokenMarkerLastItemFromCommaThenContinuation() {
+        let detector = ListPatternDetector()
+        let text = "I need to go to the store today to pick up some things. One, apples, two, oranges, three, bananas, and then I need to go to Target to buy some clothes."
+
+        let detected = detector.detectList(in: text)
+        XCTAssertNotNil(detected)
+        XCTAssertEqual(detected?.items.map(\.spokenIndex), [1, 2, 3])
+        XCTAssertEqual(detected?.items.map(\.content), ["Apples", "Oranges", "Bananas"])
+        XCTAssertEqual(detected?.trailingText, "and then I need to go to Target to buy some clothes.")
+    }
+
     func testDoesNotLetBecauseSplitHideEarlierSentenceBoundary() {
         let detector = ListPatternDetector()
         let text = """

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
@@ -267,6 +267,19 @@ final class ListPatternDetectorTests: XCTestCase {
         ])
     }
 
+    func testStripsStructuralCommaFromLongerSpokenListItem() {
+        let detector = ListPatternDetector()
+        let text = "Need two things one write the full summary, two walk dog"
+
+        let detected = detector.detectList(in: text)
+        XCTAssertNotNil(detected)
+        XCTAssertEqual(detected?.items.map(\.spokenIndex), [1, 2])
+        XCTAssertEqual(detected?.items.map(\.content), [
+            "Write the full summary",
+            "Walk dog",
+        ])
+    }
+
     func testKeepsFormattingWhenSpokenNumberSkipsAhead() {
         let detector = ListPatternDetector()
         let text = "Today one buy groceries two walk dog four call mom five charge phone"

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
@@ -147,7 +147,7 @@ final class ListPatternDetectorTests: XCTestCase {
         let detected = detector.detectList(in: text)
         XCTAssertTrue(detected != nil)
         XCTAssertTrue(detected?.items.map(\.spokenIndex) == [1, 2, 3])
-        XCTAssertTrue(detected?.items.last?.content == "There's no way out of here")
+        XCTAssertTrue(detected?.items.last?.content == "There's no way out of here.")
         XCTAssertTrue(
             detected?.trailingText
                 == "After all that, I'm going to have to do something with my brain\n\nBecause now it's raining outside and I can't take my dog to go to the bathroom."
@@ -185,7 +185,7 @@ final class ListPatternDetectorTests: XCTestCase {
         let detected = detector.detectList(in: text)
         XCTAssertTrue(detected != nil)
         XCTAssertTrue(detected?.items.map(\.spokenIndex) == [2, 3])
-        XCTAssertTrue(detected?.items.last?.content == "There's no way out of here")
+        XCTAssertTrue(detected?.items.last?.content == "There's no way out of here.")
         XCTAssertTrue(
             detected?.trailingText
                 == "After all that, I'm going to have to do something with my brain\n\nBecause now it's raining outside and I can't take my dog to go to the bathroom."
@@ -232,14 +232,14 @@ final class ListPatternDetectorTests: XCTestCase {
         let detected = detector.detectList(in: text)
         XCTAssertTrue(detected != nil)
         XCTAssertTrue(detected?.items.map(\.spokenIndex) == [1, 2])
-        XCTAssertTrue(detected?.items.last?.content == "Get some groceries")
+        XCTAssertTrue(detected?.items.last?.content == "Get some groceries.")
         XCTAssertTrue(
             detected?.trailingText
                 == "There's really nothing else to do, but just talk a little bit more and hope this splits things out right\n\nBecause I'm just trying to make it work."
         )
     }
 
-    func testCapitalizesItemsAndStripsTerminalPunctuation() {
+    func testStripsTerminalPunctuationFromShortListItems() {
         let detector = ListPatternDetector()
         let text = "one buy groceries, two walk dog."
 
@@ -247,6 +247,24 @@ final class ListPatternDetectorTests: XCTestCase {
         XCTAssertTrue(detected != nil)
         XCTAssertTrue(detected?.items.map(\.spokenIndex) == [1, 2])
         XCTAssertTrue(detected?.items.map(\.content) == ["Buy groceries", "Walk dog"])
+    }
+
+    func testPreservesTerminalPunctuationForLongerListItems() {
+        let detector = ListPatternDetector()
+        let text = """
+        1. Write the full summary.
+        2. Walk dog.
+        3. Double-check the release notes!
+        """
+
+        let detected = detector.detectList(in: text)
+        XCTAssertNotNil(detected)
+        XCTAssertEqual(detected?.items.map(\.spokenIndex), [1, 2, 3])
+        XCTAssertEqual(detected?.items.map(\.content), [
+            "Write the full summary.",
+            "Walk dog",
+            "Double-check the release notes!",
+        ])
     }
 
     func testKeepsFormattingWhenSpokenNumberSkipsAhead() {
@@ -322,7 +340,7 @@ final class ListPatternDetectorTests: XCTestCase {
         XCTAssertNotNil(detected)
         XCTAssertEqual(detected?.items.map(\.spokenIndex), [1, 2, 3])
         XCTAssertEqual(detected?.items.map(\.content), [
-            "This first item is intentionally long. It has multiple sentences because someone is explaining context before they continue the list. They keep talking for a while to set things up and it goes on longer than a normal list item would",
+            "This first item is intentionally long. It has multiple sentences because someone is explaining context before they continue the list. They keep talking for a while to set things up and it goes on longer than a normal list item would.",
             "Cueboard",
             "KeyVox",
         ])


### PR DESCRIPTION
## Summary
This branch tightens several deterministic post-processing paths in `KeyVoxCore` to reduce false positives without weakening the valid formatting/correction cases we still want to preserve.

It covers three main areas:
1. Dictionary matching for stylized split-join brand corrections
2. List detection and trailing list-item formatting
3. Four-digit quantity grouping for sub-10,000 numerals

## What changed

### Dictionary matcher
- Added a tail-similarity guard to the anchored stylized split-join scoring path in `DictionaryMatcher+SplitJoinScoring.swift`.
- This keeps valid Whisper-style split brand corrections working, but blocks false positives where ordinary prose gets collapsed into a stylized dictionary term.
- Added a regression for the `"key value"` style false positive so generic two-word prose does not get rewritten into a branded token.

### List detection and formatting
- Hardened ambiguous undelimited marker detection in `ListPatternDetector.swift` so short low-content spans between spoken numbers do not get promoted into lists.
- This prevents prose like `"two or three points taller"` from being misread as numbered list cadence.
- Improved last-item trailing split behavior so short nominal final items like `"Bananas"` can cleanly separate from trailing commentary such as `", and then I need..."`.
- Re-enabled terminal punctuation for longer list items while still stripping terminal punctuation from very short one- and two-word items, which keeps short nominal items clean without flattening sentence-like list entries.
- Added detector and rendering regressions for:
  - uncertain numeric-range prose that should stay prose
  - explicit-number and spoken-marker lists with trailing commentary after the last item
  - mixed short/long list items where longer entries should retain terminal punctuation

### Four-digit quantity grouping
- Added a dedicated `ThousandsGroupingNormalizer` and wired it into `TranscriptionPostProcessor` after website normalization and before final whitespace/casing cleanup.
- The new pass formats quantity-like four-digit numerals such as `5600` -> `5,600`.
- Year-like references remain ungrouped, including conversational year phrasing and sentence-final uncertainty/confirmation shapes.
- Protected ranges prevent grouping inside date/version/phone/compact hyphenated numeric formats.
- Added regressions covering:
  - standalone quantity sequences
  - mixed quantity/year sentences
  - partitive quantity phrases like `2000 of them`
  - confirmation phrases like `2001, right?`
  - uncertain year references like `maybe 1993`

### Documentation
- Updated `Docs/CODEMAP.md` to include the new numeric grouping pass.
- Refined `Docs/ENGINEERING.md` so normalization is documented as stable ordered stages instead of an ever-growing list of micro-passes.

## Why
These changes reduce brittle output transformations in three places users actually notice:
- branded dictionary corrections should not rewrite ordinary prose
- prose with incidental spoken numbers should not become lists
- quantities below 10,000 should read naturally with grouping, while years should remain untouched

## Testing
- Added regression coverage across dictionary, list detector, list formatting, and transcription post-processing tests
- Verified with:
  `swift test --package-path Packages/KeyVoxCore --scratch-path /tmp/keyvoxcore-tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic thousands grouping for four-digit+ numeric sequences in transcriptions, while preserving years, dates, versions, and phone-like spans.

* **Bug Fixes**
  * Improved list detection and punctuation handling for varied item lengths and comma-boundary cases.
  * Tighter matching heuristics for certain stylized anchored token cases.
  * Ensured local hyphenated phone numbers are preserved from normalization.

* **Tests**
  * Added coverage for numeric grouping, list formatting, matcher behavior, and phone-number protections.

* **Documentation**
  * Updated processing pipeline docs to reflect staged normalization and the new grouping stage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->