### PR TITLE
fix(dictionary): block stylized single-token false positives on long prefix matches

### DIFF
--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
@@ -94,10 +94,12 @@ extension DictionaryMatcher {
         )
 
         var best: Candidate?
+        var bestObservedNormalized: String?
         var secondBestScore = 0.0
 
         for candidate in candidates {
             var bestForCandidate: Candidate?
+            var bestObservedNormalizedForCandidate: String?
             for form in observedForms {
                 let baseScore = scorer.score(
                     observedText: form.normalized,
@@ -163,9 +165,11 @@ extension DictionaryMatcher {
                 if let currentBestForCandidate = bestForCandidate {
                     if candidateScore.score.final > currentBestForCandidate.score.final {
                         bestForCandidate = candidateScore
+                        bestObservedNormalizedForCandidate = form.normalized
                     }
                 } else {
                     bestForCandidate = candidateScore
+                    bestObservedNormalizedForCandidate = form.normalized
                 }
             }
 
@@ -174,15 +178,17 @@ extension DictionaryMatcher {
                 if bestForCandidate.score.final > currentBest.score.final {
                     secondBestScore = currentBest.score.final
                     best = bestForCandidate
+                    bestObservedNormalized = bestObservedNormalizedForCandidate
                 } else if bestForCandidate.score.final > secondBestScore {
                     secondBestScore = bestForCandidate.score.final
                 }
             } else {
                 best = bestForCandidate
+                bestObservedNormalized = bestObservedNormalizedForCandidate
             }
         }
 
-        guard let best else { return nil }
+        guard let best, let bestObservedNormalized else { return nil }
 
         let exactMatch = observedNormalized == best.entry.normalizedPhrase
 
@@ -269,7 +275,7 @@ extension DictionaryMatcher {
 
             if stylizedSingleTokenEntry,
                !hasStylizedLongPrefixTailGuardEvidence(
-                    observed: observedToken.normalized,
+                    observed: bestObservedNormalized,
                     candidate: candidateToken
                ) {
                 stats.rejectedLowScore += 1

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
@@ -267,6 +267,15 @@ extension DictionaryMatcher {
                 return nil
             }
 
+            if stylizedSingleTokenEntry,
+               !hasStylizedLongPrefixTailGuardEvidence(
+                    observed: observedToken.normalized,
+                    candidate: candidateToken
+               ) {
+                stats.rejectedLowScore += 1
+                return nil
+            }
+
             if isCommonWord {
                 if hasStructuralContext {
                     effectiveThreshold = min(

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationStylizedHelpers.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationStylizedHelpers.swift
@@ -9,6 +9,8 @@ private enum EvaluationStylizedConstants {
     static let strongFallbackSimilarityMinimum = 0.88
     static let moderateFallbackTextMinimum = 0.42
     static let moderateFallbackSimilarityMinimum = 0.66
+    static let longPrefixTailGuardMinimumSharedPrefixLength = 4
+    static let longPrefixTailGuardMinimumSimilarity = 0.55
 }
 
 extension DictionaryMatcher {
@@ -104,5 +106,33 @@ extension DictionaryMatcher {
         }
 
         return true
+    }
+
+    func hasStylizedLongPrefixTailGuardEvidence(
+        observed: String,
+        candidate: String
+    ) -> Bool {
+        guard observed.count > candidate.count else { return true }
+
+        let sharedPrefixLength = sharedPrefixLength(lhs: observed, rhs: candidate)
+        guard sharedPrefixLength >= EvaluationStylizedConstants.longPrefixTailGuardMinimumSharedPrefixLength else {
+            return true
+        }
+
+        let observedTail = String(observed.dropFirst(sharedPrefixLength))
+        let candidateTail = String(candidate.dropFirst(sharedPrefixLength))
+        guard !candidateTail.isEmpty else { return false }
+
+        let observedTailPhonetic = encoder.scoringSignature(for: observedTail, lexicon: lexicon)
+        let candidateTailPhonetic = encoder.scoringSignature(for: candidateTail, lexicon: lexicon)
+        let textSimilarity = scorer.similarity(lhs: observedTail, rhs: candidateTail)
+        let phoneticSimilarity = scorer.similarity(lhs: observedTailPhonetic, rhs: candidateTailPhonetic)
+
+        return max(textSimilarity, phoneticSimilarity)
+            >= EvaluationStylizedConstants.longPrefixTailGuardMinimumSimilarity
+    }
+
+    private func sharedPrefixLength(lhs: String, rhs: String) -> Int {
+        zip(lhs, rhs).prefix { $0 == $1 }.count
     }
 }

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -76,6 +76,14 @@ final class DictionaryMatcherTests: XCTestCase {
         XCTAssertEqual(result.text, "My app is called KeyVox.")
     }
 
+    func testRuntimeMatcherDoesNotRewriteOrdinaryMergedTokenPrefixIntoStylizedSingleTokenBrand() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "KeyVox")])
+
+        let result = matcher.apply(to: "KeyValue Storage")
+        XCTAssertEqual(result.text, "KeyValue Storage")
+    }
+
     func testCorrectsTwoTokenNameNearMissWithRuntimeLexicon() {
         let matcher = makeRuntimeMatcher()
         matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "Dom Esposito")])


### PR DESCRIPTION
- add a structural tail guard for stylized single-token replacements when a longer observed token only matches on a shared prefix
- reject low-signal runtime corrections like "KeyValue" -> "KeyVox" while preserving valid stylized near-miss fixes
- add a regression covering ordinary merged-token prose that must not rewrite into a stylized brand entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for stylized single-token matches — more low-confidence candidates are now rejected to reduce incorrect rewrites.

* **Tests**
  * Added coverage ensuring merged-token prefixes are not rewritten into stylized single-token brands, preserving expected input text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->