### PR TITLE
feat(app): move weekly word tracking into a dedicated synced stats subsystem

### DIFF
--- a/App/AppServiceRegistry.swift
+++ b/App/AppServiceRegistry.swift
@@ -7,15 +7,21 @@ final class AppServiceRegistry {
 
     let dictionaryStore: DictionaryStore
     let whisperService: WhisperService
+    let weeklyWordStatsStore: WeeklyWordStatsStore
+    let weeklyWordStatsCloudSync: WeeklyWordStatsCloudSync
     let iCloudSyncCoordinator: KeyVoxiCloudSyncCoordinator
 
     init(
         dictionaryStore: DictionaryStore,
         whisperService: WhisperService,
+        weeklyWordStatsStore: WeeklyWordStatsStore,
+        weeklyWordStatsCloudSync: WeeklyWordStatsCloudSync,
         iCloudSyncCoordinator: KeyVoxiCloudSyncCoordinator
     ) {
         self.dictionaryStore = dictionaryStore
         self.whisperService = whisperService
+        self.weeklyWordStatsStore = weeklyWordStatsStore
+        self.weeklyWordStatsCloudSync = weeklyWordStatsCloudSync
         self.iCloudSyncCoordinator = iCloudSyncCoordinator
     }
 
@@ -37,6 +43,10 @@ final class AppServiceRegistry {
                     .path
                 return fileManager.fileExists(atPath: modelPath) ? modelPath : nil
             }
+        )
+        weeklyWordStatsStore = WeeklyWordStatsStore()
+        weeklyWordStatsCloudSync = WeeklyWordStatsCloudSync(
+            weeklyWordStatsStore: weeklyWordStatsStore
         )
         iCloudSyncCoordinator = KeyVoxiCloudSyncCoordinator(
             appSettings: .shared,

--- a/App/AppSettingsStore.swift
+++ b/App/AppSettingsStore.swift
@@ -88,32 +88,16 @@ final class AppSettingsStore: ObservableObject {
         }
     }
 
-    @Published var wordsThisWeek: Int {
-        didSet {
-            defaults.set(wordsThisWeek, forKey: UserDefaultsKeys.App.wordsThisWeekCount)
-        }
-    }
-
     private let defaults: UserDefaults
-    private let calendar: Calendar
-    private let now: () -> Date
     private let defaultSoundVolume: Double = 0.1
-    private var wordsThisWeekStart: Date
 
     // Keep teardown explicit to avoid synthesized deinit runtime issues in test host.
     deinit {}
 
     init(
-        defaults: UserDefaults = .standard,
-        calendar: Calendar = .current,
-        now: @escaping () -> Date = Date.init
+        defaults: UserDefaults = .standard
     ) {
         self.defaults = defaults
-        self.calendar = calendar
-        self.now = now
-
-        let nowDate = now()
-        let currentWeekStart = calendar.dateInterval(of: .weekOfYear, for: nowDate)?.start ?? nowDate
 
         hasCompletedOnboarding = defaults.bool(forKey: UserDefaultsKeys.hasCompletedOnboarding)
 
@@ -137,35 +121,6 @@ final class AppSettingsStore: ObservableObject {
         selectedMicrophoneUID = defaults.string(forKey: UserDefaultsKeys.selectedMicrophoneUID) ?? ""
         updateAlertLastShown = defaults.object(forKey: UserDefaultsKeys.App.updateAlertLastShown) as? Date
         updateAlertSnoozedUntil = defaults.object(forKey: UserDefaultsKeys.App.updateAlertSnoozedUntil) as? Date
-
-        let storedWeekStart = defaults.object(forKey: UserDefaultsKeys.App.wordsThisWeekWeekStart) as? Date
-        let storedCount = defaults.object(forKey: UserDefaultsKeys.App.wordsThisWeekCount) as? NSNumber
-        if let storedWeekStart, calendar.isDate(storedWeekStart, inSameDayAs: currentWeekStart) {
-            wordsThisWeekStart = storedWeekStart
-            wordsThisWeek = max(0, storedCount?.intValue ?? 0)
-        } else {
-            wordsThisWeekStart = currentWeekStart
-            wordsThisWeek = 0
-            defaults.set(currentWeekStart, forKey: UserDefaultsKeys.App.wordsThisWeekWeekStart)
-            defaults.set(0, forKey: UserDefaultsKeys.App.wordsThisWeekCount)
-        }
-    }
-
-    func recordSpokenWords(from text: String, at date: Date? = nil) {
-        let referenceDate = date ?? now()
-        rolloverWordsCounterIfNeeded(referenceDate: referenceDate)
-
-        let count = text
-            .split(whereSeparator: \.isWhitespace)
-            .count
-        guard count > 0 else { return }
-
-        wordsThisWeek += count
-    }
-
-    func refreshWeeklyWordCounterIfNeeded(referenceDate: Date? = nil) {
-        let evaluatedDate = referenceDate ?? now()
-        rolloverWordsCounterIfNeeded(referenceDate: evaluatedDate)
     }
 
     func refreshSelectedMicrophoneFromDefaults() {
@@ -187,16 +142,5 @@ final class AppSettingsStore: ObservableObject {
     func applyCloudListFormattingEnabled(_ value: Bool) {
         guard listFormattingEnabled != value else { return }
         listFormattingEnabled = value
-    }
-
-    private func rolloverWordsCounterIfNeeded(referenceDate: Date) {
-        let currentWeekStart = calendar.dateInterval(of: .weekOfYear, for: referenceDate)?.start ?? referenceDate
-        guard !calendar.isDate(wordsThisWeekStart, inSameDayAs: currentWeekStart) else {
-            return
-        }
-
-        wordsThisWeekStart = currentWeekStart
-        wordsThisWeek = 0
-        defaults.set(currentWeekStart, forKey: UserDefaultsKeys.App.wordsThisWeekWeekStart)
     }
 }

--- a/App/UserDefaultsKeys.swift
+++ b/App/UserDefaultsKeys.swift
@@ -18,8 +18,8 @@ enum UserDefaultsKeys {
     enum App {
         static let updateAlertLastShown = "KeyVox.App.UpdateAlertLastShown"
         static let updateAlertSnoozedUntil = "KeyVox.App.UpdateAlertSnoozedUntil"
-        static let wordsThisWeekCount = "KeyVox.App.WordsThisWeekCount"
-        static let wordsThisWeekWeekStart = "KeyVox.App.WordsThisWeekWeekStart"
+        static let weeklyWordStatsPayload = "KeyVox.App.WeeklyWordStatsPayload"
+        static let weeklyWordStatsInstallationID = "KeyVox.App.WeeklyWordStatsInstallationID"
     }
 
     enum iCloud {

--- a/App/WeeklyWordStatsStore.swift
+++ b/App/WeeklyWordStatsStore.swift
@@ -25,7 +25,7 @@ final class WeeklyWordStatsStore: ObservableObject {
 
     init(
         defaults: UserDefaults = .standard,
-        calendar: Calendar = .current,
+        calendar: Calendar = makeCanonicalWeekCalendar(),
         now: @escaping () -> Date = Date.init,
         installationIDGenerator: @escaping () -> String = { UUID().uuidString }
     ) {
@@ -110,4 +110,11 @@ final class WeeklyWordStatsStore: ObservableObject {
     private static func weekStart(for date: Date, calendar: Calendar) -> Date {
         calendar.dateInterval(of: .weekOfYear, for: date)?.start ?? date
     }
+}
+
+nonisolated private func makeCanonicalWeekCalendar() -> Calendar {
+    var calendar = Calendar(identifier: .iso8601)
+    calendar.locale = Locale(identifier: "en_US_POSIX")
+    calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+    return calendar
 }

--- a/App/WeeklyWordStatsStore.swift
+++ b/App/WeeklyWordStatsStore.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Combine
+
+@MainActor
+final class WeeklyWordStatsStore: ObservableObject {
+    static let shared = WeeklyWordStatsStore()
+
+    @Published private(set) var snapshot: WeeklyWordStatsPayload
+
+    var combinedWordCount: Int {
+        snapshot.combinedWordCount
+    }
+
+    internal var installationID: String {
+        localInstallationID
+    }
+
+    private let defaults: UserDefaults
+    private let calendar: Calendar
+    private let now: () -> Date
+    private let installationIDGenerator: () -> String
+    private let localInstallationID: String
+
+    deinit {}
+
+    init(
+        defaults: UserDefaults = .standard,
+        calendar: Calendar = .current,
+        now: @escaping () -> Date = Date.init,
+        installationIDGenerator: @escaping () -> String = { UUID().uuidString }
+    ) {
+        self.defaults = defaults
+        self.calendar = calendar
+        self.now = now
+        self.installationIDGenerator = installationIDGenerator
+
+        let nowDate = now()
+        let currentWeekStart = Self.weekStart(for: nowDate, calendar: calendar)
+
+        if let existingInstallationID = defaults.string(forKey: UserDefaultsKeys.App.weeklyWordStatsInstallationID),
+           !existingInstallationID.isEmpty {
+            localInstallationID = existingInstallationID
+        } else {
+            let generatedInstallationID = installationIDGenerator()
+            localInstallationID = generatedInstallationID
+            defaults.set(generatedInstallationID, forKey: UserDefaultsKeys.App.weeklyWordStatsInstallationID)
+        }
+
+        if
+            let data = defaults.data(forKey: UserDefaultsKeys.App.weeklyWordStatsPayload),
+            let storedSnapshot = try? JSONDecoder().decode(WeeklyWordStatsPayload.self, from: data),
+            calendar.isDate(storedSnapshot.weekStart, inSameDayAs: currentWeekStart)
+        {
+            snapshot = storedSnapshot.sanitized()
+        } else {
+            snapshot = WeeklyWordStatsPayload.empty(weekStart: currentWeekStart, modifiedAt: nowDate)
+            persistSnapshot()
+        }
+    }
+
+    func recordSpokenWords(from text: String, at date: Date? = nil) {
+        let referenceDate = date ?? now()
+        refreshWeeklyWordStatsIfNeeded(referenceDate: referenceDate)
+
+        let count = text.split(whereSeparator: \.isWhitespace).count
+        guard count > 0 else { return }
+
+        var deviceWordCounts = snapshot.deviceWordCounts
+        deviceWordCounts[localInstallationID, default: 0] += count
+
+        setSnapshot(
+            WeeklyWordStatsPayload(
+                weekStart: Self.weekStart(for: referenceDate, calendar: calendar),
+                modifiedAt: referenceDate,
+                deviceWordCounts: deviceWordCounts
+            )
+        )
+    }
+
+    func refreshWeeklyWordStatsIfNeeded(referenceDate: Date? = nil) {
+        let evaluatedDate = referenceDate ?? now()
+        let currentWeekStart = Self.weekStart(for: evaluatedDate, calendar: calendar)
+        guard !calendar.isDate(snapshot.weekStart, inSameDayAs: currentWeekStart) else { return }
+
+        setSnapshot(
+            WeeklyWordStatsPayload.empty(
+                weekStart: currentWeekStart,
+                modifiedAt: evaluatedDate
+            )
+        )
+    }
+
+    internal func applySynchronizedSnapshot(_ snapshot: WeeklyWordStatsPayload) {
+        setSnapshot(snapshot)
+    }
+
+    private func setSnapshot(_ newSnapshot: WeeklyWordStatsPayload) {
+        let sanitizedSnapshot = newSnapshot.sanitized()
+        guard snapshot != sanitizedSnapshot else { return }
+        snapshot = sanitizedSnapshot
+        persistSnapshot()
+    }
+
+    private func persistSnapshot() {
+        if let data = try? JSONEncoder().encode(snapshot) {
+            defaults.set(data, forKey: UserDefaultsKeys.App.weeklyWordStatsPayload)
+        }
+    }
+
+    private static func weekStart(for date: Date, calendar: Calendar) -> Date {
+        calendar.dateInterval(of: .weekOfYear, for: date)?.start ?? date
+    }
+}

--- a/App/WeeklyWordStatsStore.swift
+++ b/App/WeeklyWordStatsStore.swift
@@ -79,7 +79,7 @@ final class WeeklyWordStatsStore: ObservableObject {
 
     func refreshWeeklyWordStatsIfNeeded(referenceDate: Date? = nil) {
         let evaluatedDate = referenceDate ?? now()
-        let currentWeekStart = Self.weekStart(for: evaluatedDate, calendar: calendar)
+        let currentWeekStart = currentWeekStart(for: evaluatedDate)
         guard !calendar.isDate(snapshot.weekStart, inSameDayAs: currentWeekStart) else { return }
 
         setSnapshot(
@@ -91,6 +91,9 @@ final class WeeklyWordStatsStore: ObservableObject {
     }
 
     internal func applySynchronizedSnapshot(_ snapshot: WeeklyWordStatsPayload) {
+        guard calendar.isDate(snapshot.weekStart, inSameDayAs: currentWeekStart(for: now())) else {
+            return
+        }
         setSnapshot(snapshot)
     }
 
@@ -105,6 +108,10 @@ final class WeeklyWordStatsStore: ObservableObject {
         if let data = try? JSONEncoder().encode(snapshot) {
             defaults.set(data, forKey: UserDefaultsKeys.App.weeklyWordStatsPayload)
         }
+    }
+
+    private func currentWeekStart(for date: Date) -> Date {
+        Self.weekStart(for: date, calendar: calendar)
     }
 
     private static func weekStart(for date: Date, calendar: Calendar) -> Date {

--- a/App/WeeklyWordStatsStore.swift
+++ b/App/WeeklyWordStatsStore.swift
@@ -105,8 +105,13 @@ final class WeeklyWordStatsStore: ObservableObject {
     }
 
     private func persistSnapshot() {
-        if let data = try? JSONEncoder().encode(snapshot) {
+        do {
+            let data = try JSONEncoder().encode(snapshot)
             defaults.set(data, forKey: UserDefaultsKeys.App.weeklyWordStatsPayload)
+        } catch {
+            print(
+                "[WeeklyWordStatsStore] Failed to encode weekly word stats payload for key \(UserDefaultsKeys.App.weeklyWordStatsPayload): \(error)"
+            )
         }
     }
 

--- a/App/iCloud/KeyVoxiCloudKeys.swift
+++ b/App/iCloud/KeyVoxiCloudKeys.swift
@@ -3,6 +3,8 @@ import Foundation
 enum KeyVoxiCloudKeys {
     static let dictionaryPayload = "kvx.dictionary.payload.v1"
     static let dictionaryModifiedAt = "kvx.dictionary.modifiedAt.v1"
+    static let weeklyWordStatsPayload = "kvx.weeklyWordStats.payload.v1"
+    static let weeklyWordStatsModifiedAt = "kvx.weeklyWordStats.modifiedAt.v1"
     static let triggerBinding = "kvx.settings.triggerBinding.v1"
     static let triggerBindingModifiedAt = "kvx.settings.triggerBindingModifiedAt.v1"
     static let autoParagraphsEnabled = "kvx.settings.autoParagraphsEnabled.v1"

--- a/App/iCloud/KeyVoxiCloudPayloads.swift
+++ b/App/iCloud/KeyVoxiCloudPayloads.swift
@@ -5,3 +5,36 @@ nonisolated struct KeyVoxDictionaryCloudPayload: Codable, Equatable {
     let modifiedAt: Date
     let entries: [DictionaryEntry]
 }
+
+nonisolated struct WeeklyWordStatsPayload: Codable, Equatable {
+    let weekStart: Date
+    let modifiedAt: Date
+    let deviceWordCounts: [String: Int]
+
+    var combinedWordCount: Int {
+        deviceWordCounts.values.reduce(0, +)
+    }
+
+    var isEmpty: Bool {
+        deviceWordCounts.isEmpty
+    }
+
+    func sanitized() -> WeeklyWordStatsPayload {
+        WeeklyWordStatsPayload(
+            weekStart: weekStart,
+            modifiedAt: modifiedAt,
+            deviceWordCounts: deviceWordCounts.reduce(into: [:]) { partialResult, element in
+                guard element.value > 0 else { return }
+                partialResult[element.key] = element.value
+            }
+        )
+    }
+
+    static func empty(weekStart: Date, modifiedAt: Date) -> WeeklyWordStatsPayload {
+        WeeklyWordStatsPayload(
+            weekStart: weekStart,
+            modifiedAt: modifiedAt,
+            deviceWordCounts: [:]
+        )
+    }
+}

--- a/App/iCloud/WeeklyWordStatsCloudSync.swift
+++ b/App/iCloud/WeeklyWordStatsCloudSync.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Combine
+
+@MainActor
+final class WeeklyWordStatsCloudSync {
+    private let ubiquitousStore: any KeyVoxiCloudKeyValueStoring
+    private let notificationCenter: NotificationCenter
+    private let weeklyWordStatsStore: WeeklyWordStatsStore
+    private let now: () -> Date
+
+    private var cancellables = Set<AnyCancellable>()
+    private var externalChangeObserver: NSObjectProtocol?
+    private var isApplyingRemoteSnapshot = false
+
+    init(
+        ubiquitousStore: any KeyVoxiCloudKeyValueStoring = NSUbiquitousKeyValueStore.default,
+        notificationCenter: NotificationCenter = .default,
+        weeklyWordStatsStore: WeeklyWordStatsStore,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.ubiquitousStore = ubiquitousStore
+        self.notificationCenter = notificationCenter
+        self.weeklyWordStatsStore = weeklyWordStatsStore
+        self.now = now
+
+        setupObservers()
+        registerForExternalChanges()
+        _ = ubiquitousStore.synchronize()
+        bootstrap()
+    }
+
+    deinit {
+        if let externalChangeObserver {
+            notificationCenter.removeObserver(externalChangeObserver)
+        }
+    }
+
+    func processExternalChanges(for changedKeys: [String]) {
+        if changedKeys.contains(KeyVoxiCloudKeys.weeklyWordStatsPayload)
+            || changedKeys.contains(KeyVoxiCloudKeys.weeklyWordStatsModifiedAt) {
+            resolve(remoteSnapshot: loadRemoteSnapshot())
+        }
+    }
+
+    private func setupObservers() {
+        weeklyWordStatsStore.$snapshot
+            .dropFirst()
+            .sink { [weak self] snapshot in
+                guard let self, !self.isApplyingRemoteSnapshot else { return }
+                self.resolve(localSnapshot: snapshot, remoteSnapshot: self.loadRemoteSnapshot())
+            }
+            .store(in: &cancellables)
+    }
+
+    private func registerForExternalChanges() {
+        guard let notificationObject = ubiquitousStore.notificationObject else { return }
+        externalChangeObserver = notificationCenter.addObserver(
+            forName: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+            object: notificationObject,
+            queue: .main
+        ) { [weak self] notification in
+            guard
+                let userInfo = notification.userInfo,
+                let changedKeys = userInfo[NSUbiquitousKeyValueStoreChangedKeysKey] as? [String]
+            else {
+                return
+            }
+
+            Task { @MainActor [weak self] in
+                self?.processExternalChanges(for: changedKeys)
+            }
+        }
+    }
+
+    private func bootstrap() {
+        resolve(remoteSnapshot: loadRemoteSnapshot())
+    }
+
+    private func resolve(remoteSnapshot: WeeklyWordStatsPayload?) {
+        resolve(localSnapshot: weeklyWordStatsStore.snapshot, remoteSnapshot: remoteSnapshot)
+    }
+
+    private func resolve(localSnapshot: WeeklyWordStatsPayload, remoteSnapshot: WeeklyWordStatsPayload?) {
+        guard let remoteSnapshot else {
+            if !localSnapshot.isEmpty {
+                push(snapshot: localSnapshot)
+            }
+            return
+        }
+
+        if remoteSnapshot.weekStart > localSnapshot.weekStart {
+            applyRemoteSnapshot(remoteSnapshot)
+            return
+        }
+
+        if remoteSnapshot.weekStart < localSnapshot.weekStart {
+            push(snapshot: localSnapshot)
+            return
+        }
+
+        let mergedSnapshot = mergedSnapshot(local: localSnapshot, remote: remoteSnapshot)
+        let snapshotsAlreadyConverged =
+            mergedSnapshot.deviceWordCounts == localSnapshot.deviceWordCounts
+            && mergedSnapshot.deviceWordCounts == remoteSnapshot.deviceWordCounts
+
+        guard !snapshotsAlreadyConverged else { return }
+
+        applyRemoteSnapshot(mergedSnapshot)
+        push(snapshot: mergedSnapshot)
+    }
+
+    private func mergedSnapshot(local: WeeklyWordStatsPayload, remote: WeeklyWordStatsPayload) -> WeeklyWordStatsPayload {
+        var mergedCounts = local.deviceWordCounts
+
+        for (deviceID, remoteCount) in remote.deviceWordCounts {
+            mergedCounts[deviceID] = max(mergedCounts[deviceID] ?? 0, remoteCount)
+        }
+
+        return WeeklyWordStatsPayload(
+            weekStart: local.weekStart,
+            modifiedAt: now(),
+            deviceWordCounts: mergedCounts
+        ).sanitized()
+    }
+
+    private func applyRemoteSnapshot(_ snapshot: WeeklyWordStatsPayload) {
+        isApplyingRemoteSnapshot = true
+        defer { isApplyingRemoteSnapshot = false }
+        weeklyWordStatsStore.applySynchronizedSnapshot(snapshot)
+    }
+
+    private func push(snapshot: WeeklyWordStatsPayload) {
+        do {
+            let data = try JSONEncoder().encode(snapshot)
+            ubiquitousStore.set(data, forKey: KeyVoxiCloudKeys.weeklyWordStatsPayload)
+            ubiquitousStore.set(snapshot.modifiedAt, forKey: KeyVoxiCloudKeys.weeklyWordStatsModifiedAt)
+            _ = ubiquitousStore.synchronize()
+        } catch {
+            #if DEBUG
+            print("[WeeklyWordStatsCloudSync] Failed to encode weekly word stats payload: \(error)")
+            #endif
+        }
+    }
+
+    private func loadRemoteSnapshot() -> WeeklyWordStatsPayload? {
+        guard let data = ubiquitousStore.data(forKey: KeyVoxiCloudKeys.weeklyWordStatsPayload) else {
+            return nil
+        }
+
+        do {
+            return try JSONDecoder().decode(WeeklyWordStatsPayload.self, from: data).sanitized()
+        } catch {
+            #if DEBUG
+            print("[WeeklyWordStatsCloudSync] Failed to decode weekly word stats payload: \(error)")
+            #endif
+            return nil
+        }
+    }
+}

--- a/Core/Transcription/TranscriptionManager.swift
+++ b/Core/Transcription/TranscriptionManager.swift
@@ -21,6 +21,7 @@ class TranscriptionManager: ObservableObject {
     private let audioRecorder: AudioRecorder
     private let whisperService: WhisperService
     private let dictionaryStore: DictionaryStore
+    private let weeklyWordStatsStore: WeeklyWordStatsStore
     private let postProcessor: TranscriptionPostProcessor
     private lazy var dictationPipeline = DictationPipeline(
         transcriptionProvider: whisperService,
@@ -41,7 +42,7 @@ class TranscriptionManager: ObservableObject {
             PasteService.shared.preferredListRenderModeForFocusedElement()
         },
         recordSpokenWords: { [weak self] text in
-            self?.appSettings.recordSpokenWords(from: text)
+            self?.weeklyWordStatsStore.recordSpokenWords(from: text)
         },
         pasteText: { text in
             PasteService.shared.pasteText(text)
@@ -79,6 +80,7 @@ class TranscriptionManager: ObservableObject {
         self.audioRecorder = audioRecorder
         self.whisperService = serviceRegistry.whisperService
         self.dictionaryStore = serviceRegistry.dictionaryStore
+        self.weeklyWordStatsStore = serviceRegistry.weeklyWordStatsStore
         self.postProcessor = postProcessor
         cachedCapsLockIsOn = keyboardMonitor.isCapsLockOn
         setupBindings()

--- a/Docs/CODEMAP.md
+++ b/Docs/CODEMAP.md
@@ -437,13 +437,19 @@ KeyVox/
 ## Persistence & Defaults
 
 - Centralized persisted preferences owner: `App/AppSettingsStore.swift`
-  - trigger binding, auto paragraphs toggle, sound enable/volume, selected microphone UID, onboarding completion, update prompt timestamps, weekly word counters
+  - trigger binding, auto paragraphs toggle, sound enable/volume, selected microphone UID, onboarding completion, update prompt timestamps
+- Shared app-owned runtime registry: `App/AppServiceRegistry.swift`
+  - retains the dedicated weekly stats store/sync subsystem separately from the general iCloud settings coordinator
 - Preference key catalog: `App/UserDefaultsKeys.swift`
 - Paragraph style preference key: `KeyVox.AutoParagraphsEnabled`
 - Audio-device initialization marker: `KeyVox.HasInitializedMicrophoneDefault` (owned in `Core/AudioDeviceManager.swift`)
-- Weekly word-counter keys:
-  - `KeyVox.App.WordsThisWeekCount`
-  - `KeyVox.App.WordsThisWeekWeekStart`
+- Weekly word stats owner: `App/WeeklyWordStatsStore.swift`
+  - persists a stable installation identifier plus the current-week usage snapshot and local rollover behavior
+- Weekly word stats iCloud sync: `App/iCloud/WeeklyWordStatsCloudSync.swift`
+  - syncs the weekly stats payload through iCloud KVS and merges same-week per-device totals deterministically
+- Weekly word stats local keys:
+  - `KeyVox.App.WeeklyWordStatsPayload`
+  - `KeyVox.App.WeeklyWordStatsInstallationID`
 - Overlay placement:
   - preferred display key: `KeyVox.RecordingOverlayPreferredDisplayKey`
   - origins by display map: `KeyVox.RecordingOverlayOriginsByDisplay`

--- a/Docs/CODEMAP.md
+++ b/Docs/CODEMAP.md
@@ -1,5 +1,5 @@
 # KeyVox Code Map
-**Last Updated: 2026-03-08**
+**Last Updated: 2026-03-10**
 
 ## Project Overview
 
@@ -35,7 +35,9 @@ KeyVox/
 ├── App/
 │   ├── KeyVoxApp.swift
 │   ├── AppSettingsStore.swift
+│   ├── AppServiceRegistry.swift
 │   ├── LoginItemController.swift
+│   ├── WeeklyWordStatsStore.swift
 │   └── UserDefaultsKeys.swift
 ├── Core/
 │   ├── KeyboardMonitor.swift
@@ -106,8 +108,17 @@ KeyVox/
   - Owns onboarding/settings windows via `WindowManager`.
   - Cancels app termination once to close Settings first when the Settings window is visible.
 - `App/AppSettingsStore.swift`
-  - Centralized persisted user-preference owner (`triggerBinding`, `autoParagraphsEnabled`, sound settings, onboarding, selected microphone, update prompt timestamps, weekly word count).
+  - Centralized persisted user-preference owner (`triggerBinding`, `autoParagraphsEnabled`, sound settings, onboarding, selected microphone, update prompt timestamps).
   - Single in-memory observable source consumed by settings UI and runtime managers.
+- `App/AppServiceRegistry.swift`
+  - Retains shared runtime services and app-owned sync helpers.
+  - Owns the dedicated weekly stats store/sync subsystem separately from the general iCloud settings coordinator.
+- `App/WeeklyWordStatsStore.swift`
+  - Dedicated local weekly-usage store for combined weekly word count plus hidden per-installation contribution totals.
+  - Persists a stable installation identifier, current-week snapshot, and rollover behavior outside `AppSettingsStore`.
+- `App/iCloud/WeeklyWordStatsCloudSync.swift`
+  - Dedicated iCloud KVS sync helper for weekly word stats only.
+  - Merges same-week per-device totals deterministically and keeps `KeyVoxiCloudSyncCoordinator` focused on dictionary/settings sync.
 - `App/UserDefaultsKeys.swift`
   - Single source of truth for app preference keys.
 - `Views/OnboardingView.swift`
@@ -134,6 +145,7 @@ KeyVox/
   - Routes transcribe -> post-process -> paste through internal `DictationPipeline` for boundary-testability.
   - Handles hands-free lock mode and escape cancellation.
   - Chooses list render mode (`multiline` vs `singleLineInline`) from focused target context before post-processing.
+  - Records spoken-word totals through `WeeklyWordStatsStore` instead of the general app settings store.
 - `Core/Transcription/DictationPipeline.swift`
   - Boundary helper for transcribe -> post-process -> paste orchestration with injected dependencies for smoke/integration tests.
 - `Core/Transcription/DictationPromptEchoGuard.swift`

--- a/Docs/ENGINEERING.md
+++ b/Docs/ENGINEERING.md
@@ -2,7 +2,7 @@
 
 This document contains implementation and maintainer-focused details that are intentionally kept out of the top-level README.
 
-**Last Updated: 2026-03-08**
+**Last Updated: 2026-03-10**
 
 ## Design Philosophy
 
@@ -25,7 +25,8 @@ Convenience must never come at the cost of trust.
 
 KeyVox is organized by responsibility:
 
-- `App/`: App lifecycle and persisted settings ownership (`KeyVoxApp`, `AppSettingsStore`).
+- `App/`: App lifecycle plus persisted app-owned state and registries (`KeyVoxApp`, `AppSettingsStore`, `AppServiceRegistry`, `WeeklyWordStatsStore`).
+- `App/iCloud/`: Dedicated iCloud KVS sync helpers and payloads. `KeyVoxiCloudSyncCoordinator` remains focused on dictionary/settings sync, while `WeeklyWordStatsCloudSync` owns weekly usage convergence separately.
 - `Core/Transcription/`: Runtime state machine and the transcribe -> post-process -> paste orchestration boundary (`TranscriptionManager`, `DictationPipeline`, `TranscriptionPostProcessor`).
 - `Core/Audio/`: Recording, stream processing, silence classification, and threshold policy.
 - `Core/Language/Dictionary/` and `Core/Lists/`: Deterministic dictionary correction and list parsing/rendering, with matcher evaluation strategies organized under `Core/Language/Dictionary/Evaluation/` (`Helpers/`, `SplitJoin/`, and strategy files).

--- a/KeyVox.xcodeproj/project.pbxproj
+++ b/KeyVox.xcodeproj/project.pbxproj
@@ -69,6 +69,10 @@
 		9D4000162F4E000100AA0001 /* AudioRecorder+PostProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4000072F4E000100AA0001 /* AudioRecorder+PostProcessing.swift */; };
 		9D4000172F4E000100AA0001 /* AudioRecorder+Thresholds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4000082F4E000100AA0001 /* AudioRecorder+Thresholds.swift */; };
 		9E5000112F4F000100AA0001 /* AppSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5000012F4F000100AA0001 /* AppSettingsStore.swift */; };
+		A11000012FC1000100AA0001 /* WeeklyWordStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11000112FC1000100AA0001 /* WeeklyWordStatsStore.swift */; };
+		A11000022FC1000100AA0001 /* WeeklyWordStatsCloudSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11000122FC1000100AA0001 /* WeeklyWordStatsCloudSync.swift */; };
+		A11000032FC1000100AA0001 /* WeeklyWordStatsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11000132FC1000100AA0001 /* WeeklyWordStatsStoreTests.swift */; };
+		A11000042FC1000100AA0001 /* WeeklyWordStatsCloudSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11000142FC1000100AA0001 /* WeeklyWordStatsCloudSyncTests.swift */; };
 		AA1000112F50000100AA0001 /* OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = AA1000012F50000100AA0001 /* OFL.txt */; };
 		AA1000122F50000100AA0001 /* ../THIRD_PARTY_NOTICES.md in Resources */ = {isa = PBXBuildFile; fileRef = AA1000022F50000100AA0001 /* ../THIRD_PARTY_NOTICES.md */; };
 		AA1000132F50000100AA0001 /* ../LICENSE.md in Resources */ = {isa = PBXBuildFile; fileRef = AA1000032F50000100AA0001 /* ../LICENSE.md */; };
@@ -190,6 +194,10 @@
 		9D4000072F4E000100AA0001 /* AudioRecorder+PostProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioRecorder+PostProcessing.swift"; sourceTree = "<group>"; };
 		9D4000082F4E000100AA0001 /* AudioRecorder+Thresholds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioRecorder+Thresholds.swift"; sourceTree = "<group>"; };
 		9E5000012F4F000100AA0001 /* AppSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStore.swift; sourceTree = "<group>"; };
+		A11000112FC1000100AA0001 /* WeeklyWordStatsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyWordStatsStore.swift; sourceTree = "<group>"; };
+		A11000122FC1000100AA0001 /* WeeklyWordStatsCloudSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyWordStatsCloudSync.swift; sourceTree = "<group>"; };
+		A11000132FC1000100AA0001 /* WeeklyWordStatsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyWordStatsStoreTests.swift; sourceTree = "<group>"; };
+		A11000142FC1000100AA0001 /* WeeklyWordStatsCloudSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyWordStatsCloudSyncTests.swift; sourceTree = "<group>"; };
 		AA1000012F50000100AA0001 /* OFL.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = OFL.txt; sourceTree = "<group>"; };
 		AA1000022F50000100AA0001 /* ../THIRD_PARTY_NOTICES.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ../THIRD_PARTY_NOTICES.md; sourceTree = "<group>"; };
 		AA1000032F50000100AA0001 /* ../LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ../LICENSE.md; sourceTree = "<group>"; };
@@ -282,6 +290,7 @@
 				9E5000012F4F000100AA0001 /* AppSettingsStore.swift */,
 				D17000012FA3000100AA0001 /* AppServiceRegistry.swift */,
 				D15000012FA1000100AA0001 /* LoginItemController.swift */,
+				A11000112FC1000100AA0001 /* WeeklyWordStatsStore.swift */,
 				8E6D05C42F3C51C9003BD458 /* KeyVoxApp.swift */,
 				8E57FB892F3C9B6100935A26 /* UserDefaultsKeys.swift */,
 			);
@@ -515,6 +524,8 @@
 				AB2000342F60000100AA0001 /* AppSettingsStoreTests.swift */,
 				AB2000232F60000100AA0001 /* KeyVoxAppActivationPolicyTests.swift */,
 				E18000052FA4000100AA0001 /* KeyVoxiCloudSyncCoordinatorTests.swift */,
+				A11000132FC1000100AA0001 /* WeeklyWordStatsStoreTests.swift */,
+				A11000142FC1000100AA0001 /* WeeklyWordStatsCloudSyncTests.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -590,6 +601,7 @@
 				E18000012FA4000100AA0001 /* KeyVoxiCloudKeys.swift */,
 				E18000022FA4000100AA0001 /* KeyVoxiCloudPayloads.swift */,
 				E18000032FA4000100AA0001 /* KeyVoxiCloudSyncCoordinator.swift */,
+				A11000122FC1000100AA0001 /* WeeklyWordStatsCloudSync.swift */,
 			);
 			path = iCloud;
 			sourceTree = "<group>";
@@ -735,9 +747,11 @@
 				8EC700022F42000100C70001 /* WarningOverlayView.swift in Sources */,
 				8EC700032F42000100C70001 /* WarningManager.swift in Sources */,
 				9E5000112F4F000100AA0001 /* AppSettingsStore.swift in Sources */,
+				A11000012FC1000100AA0001 /* WeeklyWordStatsStore.swift in Sources */,
 				E18000112FA4000100AA0001 /* KeyVoxiCloudKeys.swift in Sources */,
 				E18000122FA4000100AA0001 /* KeyVoxiCloudPayloads.swift in Sources */,
 				E18000132FA4000100AA0001 /* KeyVoxiCloudSyncCoordinator.swift in Sources */,
+				A11000022FC1000100AA0001 /* WeeklyWordStatsCloudSync.swift in Sources */,
 				D17000112FA3000100AA0001 /* AppServiceRegistry.swift in Sources */,
 				D15000112FA1000100AA0001 /* LoginItemController.swift in Sources */,
 				8E57FB8A2F3C9B6100935A26 /* UserDefaultsKeys.swift in Sources */,
@@ -794,6 +808,8 @@
 				AB3000122F60000100AA0001 /* WarningKindTests.swift in Sources */,
 				AB3000342F60000100AA0001 /* AppSettingsStoreTests.swift in Sources */,
 				E18000142FA4000100AA0001 /* KeyVoxiCloudSyncCoordinatorTests.swift in Sources */,
+				A11000032FC1000100AA0001 /* WeeklyWordStatsStoreTests.swift in Sources */,
+				A11000042FC1000100AA0001 /* WeeklyWordStatsCloudSyncTests.swift in Sources */,
 				AB3000132F60000100AA0001 /* AppUpdateLogicTests.swift in Sources */,
 				AB3000142F60000100AA0001 /* PasteServiceListRenderModeTests.swift in Sources */,
 				AB3000152F60000100AA0001 /* PasteFailureRecoveryPolicyTests.swift in Sources */,

--- a/KeyVoxTests/App/AppSettingsStoreTests.swift
+++ b/KeyVoxTests/App/AppSettingsStoreTests.swift
@@ -7,10 +7,8 @@ final class AppSettingsStoreTests: XCTestCase {
     func testInitUsesExpectedDefaultsWhenNoValuesPersisted() {
         let (defaults, suiteName) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let calendar = makeCalendar()
-        let now = makeDate(calendar: calendar, year: 2026, month: 2, day: 17)
 
-        let store = AppSettingsStore(defaults: defaults, calendar: calendar, now: { now })
+        let store = AppSettingsStore(defaults: defaults)
 
         XCTAssertFalse(store.hasCompletedOnboarding)
         XCTAssertEqual(store.triggerBinding, .rightOption)
@@ -21,19 +19,13 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.selectedMicrophoneUID, "")
         XCTAssertNil(store.updateAlertLastShown)
         XCTAssertNil(store.updateAlertSnoozedUntil)
-        XCTAssertEqual(store.wordsThisWeek, 0)
-        XCTAssertNotNil(defaults.object(forKey: UserDefaultsKeys.App.wordsThisWeekWeekStart))
-        XCTAssertEqual(defaults.integer(forKey: UserDefaultsKeys.App.wordsThisWeekCount), 0)
     }
 
     func testInitHydratesPersistedValuesAndClampsStoredVolume() {
         let (defaults, suiteName) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let calendar = makeCalendar()
-        let now = makeDate(calendar: calendar, year: 2026, month: 2, day: 17)
-        let currentWeekStart = calendar.dateInterval(of: .weekOfYear, for: now)!.start
-        let lastShown = makeDate(calendar: calendar, year: 2026, month: 2, day: 10)
-        let snoozedUntil = makeDate(calendar: calendar, year: 2026, month: 2, day: 20)
+        let lastShown = makeDate(year: 2026, month: 2, day: 10)
+        let snoozedUntil = makeDate(year: 2026, month: 2, day: 20)
 
         defaults.set(true, forKey: UserDefaultsKeys.hasCompletedOnboarding)
         defaults.set(AppSettingsStore.TriggerBinding.leftCommand.rawValue, forKey: UserDefaultsKeys.triggerBinding)
@@ -44,10 +36,8 @@ final class AppSettingsStoreTests: XCTestCase {
         defaults.set("mic-123", forKey: UserDefaultsKeys.selectedMicrophoneUID)
         defaults.set(lastShown, forKey: UserDefaultsKeys.App.updateAlertLastShown)
         defaults.set(snoozedUntil, forKey: UserDefaultsKeys.App.updateAlertSnoozedUntil)
-        defaults.set(currentWeekStart, forKey: UserDefaultsKeys.App.wordsThisWeekWeekStart)
-        defaults.set(12, forKey: UserDefaultsKeys.App.wordsThisWeekCount)
 
-        let store = AppSettingsStore(defaults: defaults, calendar: calendar, now: { now })
+        let store = AppSettingsStore(defaults: defaults)
 
         XCTAssertTrue(store.hasCompletedOnboarding)
         XCTAssertEqual(store.triggerBinding, .leftCommand)
@@ -58,17 +48,14 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.selectedMicrophoneUID, "mic-123")
         XCTAssertEqual(store.updateAlertLastShown, lastShown)
         XCTAssertEqual(store.updateAlertSnoozedUntil, snoozedUntil)
-        XCTAssertEqual(store.wordsThisWeek, 12)
     }
 
     func testInitFallsBackToDefaultTriggerBindingForInvalidStoredValue() {
         let (defaults, suiteName) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let calendar = makeCalendar()
-        let now = makeDate(calendar: calendar, year: 2026, month: 2, day: 17)
 
         defaults.set("not-a-binding", forKey: UserDefaultsKeys.triggerBinding)
-        let store = AppSettingsStore(defaults: defaults, calendar: calendar, now: { now })
+        let store = AppSettingsStore(defaults: defaults)
 
         XCTAssertEqual(store.triggerBinding, .rightOption)
     }
@@ -76,9 +63,7 @@ final class AppSettingsStoreTests: XCTestCase {
     func testSoundVolumeClampsOnWriteAndPersistsClampedValue() {
         let (defaults, suiteName) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let calendar = makeCalendar()
-        let now = makeDate(calendar: calendar, year: 2026, month: 2, day: 17)
-        let store = AppSettingsStore(defaults: defaults, calendar: calendar, now: { now })
+        let store = AppSettingsStore(defaults: defaults)
 
         store.soundVolume = 2.5
         XCTAssertEqual(store.soundVolume, 1.0, accuracy: 0.0001)
@@ -89,33 +74,12 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertEqual(defaults.double(forKey: UserDefaultsKeys.soundVolume), 0.0, accuracy: 0.0001)
     }
 
-    func testRecordSpokenWordsAndWeeklyRollover() {
-        let (defaults, suiteName) = makeIsolatedDefaults()
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let calendar = makeCalendar()
-        let weekOneDate = makeDate(calendar: calendar, year: 2026, month: 2, day: 17)
-        let nextWeekDate = makeDate(calendar: calendar, year: 2026, month: 2, day: 24)
-        let store = AppSettingsStore(defaults: defaults, calendar: calendar, now: { weekOneDate })
-
-        store.recordSpokenWords(from: "hello   world", at: weekOneDate)
-        XCTAssertEqual(store.wordsThisWeek, 2)
-        XCTAssertEqual(defaults.integer(forKey: UserDefaultsKeys.App.wordsThisWeekCount), 2)
-
-        store.recordSpokenWords(from: "     ", at: weekOneDate)
-        XCTAssertEqual(store.wordsThisWeek, 2)
-
-        store.refreshWeeklyWordCounterIfNeeded(referenceDate: nextWeekDate)
-        XCTAssertEqual(store.wordsThisWeek, 0)
-    }
-
     func testPropertyWritesPersistExpectedValues() {
         let (defaults, suiteName) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let calendar = makeCalendar()
-        let now = makeDate(calendar: calendar, year: 2026, month: 2, day: 17)
-        let lastShown = makeDate(calendar: calendar, year: 2026, month: 2, day: 10)
-        let snoozedUntil = makeDate(calendar: calendar, year: 2026, month: 2, day: 20)
-        let store = AppSettingsStore(defaults: defaults, calendar: calendar, now: { now })
+        let lastShown = makeDate(year: 2026, month: 2, day: 10)
+        let snoozedUntil = makeDate(year: 2026, month: 2, day: 20)
+        let store = AppSettingsStore(defaults: defaults)
 
         store.hasCompletedOnboarding = true
         store.triggerBinding = .rightCommand
@@ -139,9 +103,7 @@ final class AppSettingsStoreTests: XCTestCase {
     func testRefreshSelectedMicrophoneFromDefaultsHydratesExternalDefaultWrite() {
         let (defaults, suiteName) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let calendar = makeCalendar()
-        let now = makeDate(calendar: calendar, year: 2026, month: 2, day: 17)
-        let store = AppSettingsStore(defaults: defaults, calendar: calendar, now: { now })
+        let store = AppSettingsStore(defaults: defaults)
 
         XCTAssertEqual(store.selectedMicrophoneUID, "")
         defaults.set("builtin-mic", forKey: UserDefaultsKeys.selectedMicrophoneUID)
@@ -154,9 +116,7 @@ final class AppSettingsStoreTests: XCTestCase {
     func testApplyCloudAutoParagraphsEnabledPersistsValue() {
         let (defaults, suiteName) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let calendar = makeCalendar()
-        let now = makeDate(calendar: calendar, year: 2026, month: 2, day: 17)
-        let store = AppSettingsStore(defaults: defaults, calendar: calendar, now: { now })
+        let store = AppSettingsStore(defaults: defaults)
 
         store.applyCloudAutoParagraphsEnabled(false)
 
@@ -164,12 +124,21 @@ final class AppSettingsStoreTests: XCTestCase {
         XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.autoParagraphsEnabled) as? Bool, false)
     }
 
+    func testApplyCloudTriggerBindingPersistsValue() {
+        let (defaults, suiteName) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = AppSettingsStore(defaults: defaults)
+
+        store.applyCloudTriggerBinding(.leftControl)
+
+        XCTAssertEqual(store.triggerBinding, .leftControl)
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.triggerBinding), AppSettingsStore.TriggerBinding.leftControl.rawValue)
+    }
+
     func testApplyCloudListFormattingEnabledPersistsValue() {
         let (defaults, suiteName) = makeIsolatedDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        let calendar = makeCalendar()
-        let now = makeDate(calendar: calendar, year: 2026, month: 2, day: 17)
-        let store = AppSettingsStore(defaults: defaults, calendar: calendar, now: { now })
+        let store = AppSettingsStore(defaults: defaults)
 
         store.applyCloudListFormattingEnabled(false)
 
@@ -184,26 +153,16 @@ final class AppSettingsStoreTests: XCTestCase {
         return (defaults, suiteName)
     }
 
-    private func makeCalendar() -> Calendar {
+    private func makeDate(year: Int, month: Int, day: Int) -> Date {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-        return calendar
-    }
-
-    private func makeDate(
-        calendar: Calendar,
-        year: Int,
-        month: Int,
-        day: Int
-    ) -> Date {
-        let components = DateComponents(
+        return DateComponents(
             calendar: calendar,
             timeZone: calendar.timeZone,
             year: year,
             month: month,
             day: day,
             hour: 12
-        )
-        return components.date!
+        ).date!
     }
 }

--- a/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
+++ b/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
@@ -223,7 +223,7 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
 
-        let appSettings = AppSettingsStore(defaults: defaults, now: { now })
+        let appSettings = AppSettingsStore(defaults: defaults)
         let dictionaryStore = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
 
         let harness = Harness(

--- a/KeyVoxTests/App/WeeklyWordStatsCloudSyncTests.swift
+++ b/KeyVoxTests/App/WeeklyWordStatsCloudSyncTests.swift
@@ -168,7 +168,7 @@ final class WeeklyWordStatsCloudSyncTests: XCTestCase {
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
 
-        var calendar = Calendar(identifier: .gregorian)
+        var calendar = Calendar(identifier: .iso8601)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
         let storeNow = initialNow ?? now
         let store = WeeklyWordStatsStore(

--- a/KeyVoxTests/App/WeeklyWordStatsCloudSyncTests.swift
+++ b/KeyVoxTests/App/WeeklyWordStatsCloudSyncTests.swift
@@ -1,0 +1,268 @@
+import Foundation
+import XCTest
+@testable import KeyVox
+
+@MainActor
+final class WeeklyWordStatsCloudSyncTests: XCTestCase {
+    func testLocalSnapshotSeedsEmptyCloud() throws {
+        let harness = makeHarness(now: makeDate(year: 2026, month: 3, day: 10, hour: 12))
+        harness.store.recordSpokenWords(from: "one two three", at: harness.now())
+
+        let sync = WeeklyWordStatsCloudSync(
+            ubiquitousStore: harness.cloudStore,
+            notificationCenter: harness.notificationCenter,
+            weeklyWordStatsStore: harness.store,
+            now: harness.now
+        )
+        _ = sync
+
+        XCTAssertEqual(try harness.cloudStore.weeklyPayload(), harness.store.snapshot)
+        XCTAssertEqual(harness.cloudStore.setCount(forKey: KeyVoxiCloudKeys.weeklyWordStatsPayload), 1)
+    }
+
+    func testRemoteSnapshotSeedsEmptyLocalStore() throws {
+        let harness = makeHarness(now: makeDate(year: 2026, month: 3, day: 10, hour: 12))
+        let remoteSnapshot = makeSnapshot(
+            weekStart: harness.weekStart,
+            modifiedAt: harness.now(),
+            deviceWordCounts: ["device-remote": 11]
+        )
+        try harness.cloudStore.seedWeeklyPayload(remoteSnapshot)
+
+        let sync = WeeklyWordStatsCloudSync(
+            ubiquitousStore: harness.cloudStore,
+            notificationCenter: harness.notificationCenter,
+            weeklyWordStatsStore: harness.store,
+            now: harness.now
+        )
+        _ = sync
+
+        XCTAssertEqual(harness.store.snapshot, remoteSnapshot)
+        XCTAssertEqual(harness.store.combinedWordCount, 11)
+    }
+
+    func testSameWeekMergeCombinesDeviceTotalsAndPushesMergedSnapshot() throws {
+        let harness = makeHarness(now: makeDate(year: 2026, month: 3, day: 10, hour: 12))
+        harness.store.applySynchronizedSnapshot(
+            makeSnapshot(
+                weekStart: harness.weekStart,
+                modifiedAt: harness.now(),
+                deviceWordCounts: ["device-local": 9]
+            )
+        )
+        try harness.cloudStore.seedWeeklyPayload(
+            makeSnapshot(
+                weekStart: harness.weekStart,
+                modifiedAt: makeDate(year: 2026, month: 3, day: 10, hour: 11),
+                deviceWordCounts: ["device-remote": 6]
+            )
+        )
+
+        let sync = WeeklyWordStatsCloudSync(
+            ubiquitousStore: harness.cloudStore,
+            notificationCenter: harness.notificationCenter,
+            weeklyWordStatsStore: harness.store,
+            now: harness.now
+        )
+        _ = sync
+
+        XCTAssertEqual(harness.store.snapshot.deviceWordCounts, ["device-local": 9, "device-remote": 6])
+        XCTAssertEqual(harness.store.combinedWordCount, 15)
+        XCTAssertEqual(try harness.cloudStore.weeklyPayload(), harness.store.snapshot)
+    }
+
+    func testSameWeekMergeKeepsLargestCountForSameDevice() throws {
+        let harness = makeHarness(now: makeDate(year: 2026, month: 3, day: 10, hour: 12))
+        harness.store.applySynchronizedSnapshot(
+            makeSnapshot(
+                weekStart: harness.weekStart,
+                modifiedAt: harness.now(),
+                deviceWordCounts: ["device-shared": 12]
+            )
+        )
+        try harness.cloudStore.seedWeeklyPayload(
+            makeSnapshot(
+                weekStart: harness.weekStart,
+                modifiedAt: makeDate(year: 2026, month: 3, day: 10, hour: 11),
+                deviceWordCounts: ["device-shared": 7, "device-other": 4]
+            )
+        )
+
+        let sync = WeeklyWordStatsCloudSync(
+            ubiquitousStore: harness.cloudStore,
+            notificationCenter: harness.notificationCenter,
+            weeklyWordStatsStore: harness.store,
+            now: harness.now
+        )
+        _ = sync
+
+        XCTAssertEqual(harness.store.snapshot.deviceWordCounts["device-shared"], 12)
+        XCTAssertEqual(harness.store.snapshot.deviceWordCounts["device-other"], 4)
+        XCTAssertEqual(harness.store.combinedWordCount, 16)
+    }
+
+    func testNewerRemoteWeekReplacesOlderLocalWeek() throws {
+        let localNow = makeDate(year: 2026, month: 3, day: 10, hour: 12)
+        let remoteNow = makeDate(year: 2026, month: 3, day: 17, hour: 12)
+        let harness = makeHarness(now: remoteNow, initialNow: localNow)
+        harness.store.applySynchronizedSnapshot(
+            makeSnapshot(
+                weekStart: harness.calendar.dateInterval(of: .weekOfYear, for: localNow)!.start,
+                modifiedAt: localNow,
+                deviceWordCounts: ["device-local": 5]
+            )
+        )
+        try harness.cloudStore.seedWeeklyPayload(
+            makeSnapshot(
+                weekStart: harness.calendar.dateInterval(of: .weekOfYear, for: remoteNow)!.start,
+                modifiedAt: remoteNow,
+                deviceWordCounts: ["device-remote": 8]
+            )
+        )
+
+        let sync = WeeklyWordStatsCloudSync(
+            ubiquitousStore: harness.cloudStore,
+            notificationCenter: harness.notificationCenter,
+            weeklyWordStatsStore: harness.store,
+            now: harness.now
+        )
+        _ = sync
+
+        XCTAssertEqual(harness.store.snapshot.deviceWordCounts, ["device-remote": 8])
+        XCTAssertEqual(harness.store.snapshot.weekStart, harness.calendar.dateInterval(of: .weekOfYear, for: remoteNow)!.start)
+    }
+
+    func testOlderRemoteWeekIsIgnoredAndLocalSnapshotWins() throws {
+        let localNow = makeDate(year: 2026, month: 3, day: 17, hour: 12)
+        let remoteNow = makeDate(year: 2026, month: 3, day: 10, hour: 12)
+        let harness = makeHarness(now: localNow)
+        harness.store.applySynchronizedSnapshot(
+            makeSnapshot(
+                weekStart: harness.calendar.dateInterval(of: .weekOfYear, for: localNow)!.start,
+                modifiedAt: localNow,
+                deviceWordCounts: ["device-local": 13]
+            )
+        )
+        try harness.cloudStore.seedWeeklyPayload(
+            makeSnapshot(
+                weekStart: harness.calendar.dateInterval(of: .weekOfYear, for: remoteNow)!.start,
+                modifiedAt: remoteNow,
+                deviceWordCounts: ["device-remote": 4]
+            )
+        )
+
+        let sync = WeeklyWordStatsCloudSync(
+            ubiquitousStore: harness.cloudStore,
+            notificationCenter: harness.notificationCenter,
+            weeklyWordStatsStore: harness.store,
+            now: harness.now
+        )
+        _ = sync
+
+        XCTAssertEqual(harness.store.snapshot.deviceWordCounts, ["device-local": 13])
+        XCTAssertEqual(try harness.cloudStore.weeklyPayload(), harness.store.snapshot)
+    }
+
+    private func makeHarness(now: Date, initialNow: Date? = nil) -> WeeklyHarness {
+        let suiteName = "WeeklyWordStatsCloudSyncTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let storeNow = initialNow ?? now
+        let store = WeeklyWordStatsStore(
+            defaults: defaults,
+            calendar: calendar,
+            now: { storeNow },
+            installationIDGenerator: { "device-local" }
+        )
+
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        return WeeklyHarness(
+            defaults: defaults,
+            store: store,
+            cloudStore: InMemoryWeeklyWordStatsCloudStore(),
+            notificationCenter: NotificationCenter(),
+            calendar: calendar,
+            now: { now },
+            weekStart: calendar.dateInterval(of: .weekOfYear, for: now)!.start
+        )
+    }
+
+    private func makeSnapshot(weekStart: Date, modifiedAt: Date, deviceWordCounts: [String: Int]) -> WeeklyWordStatsPayload {
+        WeeklyWordStatsPayload(
+            weekStart: weekStart,
+            modifiedAt: modifiedAt,
+            deviceWordCounts: deviceWordCounts
+        )
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int, hour: Int) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour
+        ).date!
+    }
+}
+
+private struct WeeklyHarness {
+    let defaults: UserDefaults
+    let store: WeeklyWordStatsStore
+    let cloudStore: InMemoryWeeklyWordStatsCloudStore
+    let notificationCenter: NotificationCenter
+    let calendar: Calendar
+    let now: () -> Date
+    let weekStart: Date
+}
+
+private final class InMemoryWeeklyWordStatsCloudStore: KeyVoxiCloudKeyValueStoring {
+    var notificationObject: AnyObject? { nil }
+
+    private var storage: [String: Any] = [:]
+    private var setCounts: [String: Int] = [:]
+
+    func object(forKey key: String) -> Any? {
+        storage[key]
+    }
+
+    func data(forKey key: String) -> Data? {
+        storage[key] as? Data
+    }
+
+    func bool(forKey key: String) -> Bool {
+        storage[key] as? Bool ?? false
+    }
+
+    func set(_ value: Any?, forKey key: String) {
+        storage[key] = value
+        setCounts[key, default: 0] += 1
+    }
+
+    func synchronize() -> Bool {
+        true
+    }
+
+    func seedWeeklyPayload(_ payload: WeeklyWordStatsPayload) throws {
+        storage[KeyVoxiCloudKeys.weeklyWordStatsPayload] = try JSONEncoder().encode(payload)
+        storage[KeyVoxiCloudKeys.weeklyWordStatsModifiedAt] = payload.modifiedAt
+    }
+
+    func weeklyPayload() throws -> WeeklyWordStatsPayload? {
+        guard let data = storage[KeyVoxiCloudKeys.weeklyWordStatsPayload] as? Data else { return nil }
+        return try JSONDecoder().decode(WeeklyWordStatsPayload.self, from: data)
+    }
+
+    func setCount(forKey key: String) -> Int {
+        setCounts[key, default: 0]
+    }
+}

--- a/KeyVoxTests/App/WeeklyWordStatsCloudSyncTests.swift
+++ b/KeyVoxTests/App/WeeklyWordStatsCloudSyncTests.swift
@@ -104,7 +104,7 @@ final class WeeklyWordStatsCloudSyncTests: XCTestCase {
     func testNewerRemoteWeekReplacesOlderLocalWeek() throws {
         let localNow = makeDate(year: 2026, month: 3, day: 10, hour: 12)
         let remoteNow = makeDate(year: 2026, month: 3, day: 17, hour: 12)
-        let harness = makeHarness(now: remoteNow, initialNow: localNow)
+        let harness = makeHarness(now: remoteNow)
         harness.store.applySynchronizedSnapshot(
             makeSnapshot(
                 weekStart: harness.calendar.dateInterval(of: .weekOfYear, for: localNow)!.start,

--- a/KeyVoxTests/App/WeeklyWordStatsStoreTests.swift
+++ b/KeyVoxTests/App/WeeklyWordStatsStoreTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import XCTest
+@testable import KeyVox
+
+@MainActor
+final class WeeklyWordStatsStoreTests: XCTestCase {
+    func testInitCreatesStableInstallationIDAndEmptyCurrentWeekSnapshot() throws {
+        let (defaults, suiteName) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let calendar = makeCalendar()
+        let now = makeDate(calendar: calendar, year: 2026, month: 3, day: 10)
+
+        let store = WeeklyWordStatsStore(
+            defaults: defaults,
+            calendar: calendar,
+            now: { now },
+            installationIDGenerator: { "device-a" }
+        )
+
+        XCTAssertEqual(store.installationID, "device-a")
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.App.weeklyWordStatsInstallationID), "device-a")
+        XCTAssertEqual(store.snapshot.weekStart, calendar.dateInterval(of: .weekOfYear, for: now)?.start)
+        XCTAssertEqual(store.snapshot.deviceWordCounts, [:])
+        XCTAssertEqual(store.combinedWordCount, 0)
+
+        let persisted = try XCTUnwrap(defaults.data(forKey: UserDefaultsKeys.App.weeklyWordStatsPayload))
+        let decoded = try JSONDecoder().decode(WeeklyWordStatsPayload.self, from: persisted)
+        XCTAssertEqual(decoded, store.snapshot)
+    }
+
+    func testInitHydratesPersistedSnapshotForCurrentWeek() {
+        let (defaults, suiteName) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let calendar = makeCalendar()
+        let now = makeDate(calendar: calendar, year: 2026, month: 3, day: 10)
+        let weekStart = calendar.dateInterval(of: .weekOfYear, for: now)!.start
+        let stored = WeeklyWordStatsPayload(
+            weekStart: weekStart,
+            modifiedAt: now,
+            deviceWordCounts: ["device-a": 14, "device-b": 9]
+        )
+
+        defaults.set("persisted-device", forKey: UserDefaultsKeys.App.weeklyWordStatsInstallationID)
+        defaults.set(try! JSONEncoder().encode(stored), forKey: UserDefaultsKeys.App.weeklyWordStatsPayload)
+
+        let store = WeeklyWordStatsStore(
+            defaults: defaults,
+            calendar: calendar,
+            now: { now },
+            installationIDGenerator: { "unused" }
+        )
+
+        XCTAssertEqual(store.installationID, "persisted-device")
+        XCTAssertEqual(store.snapshot, stored)
+        XCTAssertEqual(store.combinedWordCount, 23)
+    }
+
+    func testRecordSpokenWordsIncrementsOnlyLocalContributionAndIgnoresWhitespace() {
+        let (defaults, suiteName) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let calendar = makeCalendar()
+        let now = makeDate(calendar: calendar, year: 2026, month: 3, day: 10)
+        let store = WeeklyWordStatsStore(
+            defaults: defaults,
+            calendar: calendar,
+            now: { now },
+            installationIDGenerator: { "device-a" }
+        )
+
+        store.applySynchronizedSnapshot(
+            WeeklyWordStatsPayload(
+                weekStart: calendar.dateInterval(of: .weekOfYear, for: now)!.start,
+                modifiedAt: now,
+                deviceWordCounts: ["device-b": 5]
+            )
+        )
+
+        store.recordSpokenWords(from: "hello   weekly sync", at: now)
+        XCTAssertEqual(store.snapshot.deviceWordCounts["device-a"], 3)
+        XCTAssertEqual(store.snapshot.deviceWordCounts["device-b"], 5)
+        XCTAssertEqual(store.combinedWordCount, 8)
+
+        store.recordSpokenWords(from: "   \n\t  ", at: now)
+        XCTAssertEqual(store.snapshot.deviceWordCounts["device-a"], 3)
+        XCTAssertEqual(store.combinedWordCount, 8)
+    }
+
+    func testRefreshWeeklyWordStatsIfNeededRollsIntoNewWeek() {
+        let (defaults, suiteName) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let calendar = makeCalendar()
+        let weekOneDate = makeDate(calendar: calendar, year: 2026, month: 3, day: 10)
+        let nextWeekDate = makeDate(calendar: calendar, year: 2026, month: 3, day: 17)
+        let store = WeeklyWordStatsStore(
+            defaults: defaults,
+            calendar: calendar,
+            now: { weekOneDate },
+            installationIDGenerator: { "device-a" }
+        )
+
+        store.recordSpokenWords(from: "one two", at: weekOneDate)
+        XCTAssertEqual(store.combinedWordCount, 2)
+
+        store.refreshWeeklyWordStatsIfNeeded(referenceDate: nextWeekDate)
+
+        XCTAssertEqual(store.snapshot.weekStart, calendar.dateInterval(of: .weekOfYear, for: nextWeekDate)?.start)
+        XCTAssertEqual(store.snapshot.deviceWordCounts, [:])
+        XCTAssertEqual(store.combinedWordCount, 0)
+    }
+
+    private func makeIsolatedDefaults() -> (UserDefaults, String) {
+        let suiteName = "WeeklyWordStatsStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+
+    private func makeCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private func makeDate(
+        calendar: Calendar,
+        year: Int,
+        month: Int,
+        day: Int
+    ) -> Date {
+        DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: 12
+        ).date!
+    }
+}

--- a/KeyVoxTests/App/WeeklyWordStatsStoreTests.swift
+++ b/KeyVoxTests/App/WeeklyWordStatsStoreTests.swift
@@ -144,7 +144,7 @@ final class WeeklyWordStatsStoreTests: XCTestCase {
     }
 
     private func makeCalendar() -> Calendar {
-        var calendar = Calendar(identifier: .gregorian)
+        var calendar = Calendar(identifier: .iso8601)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
         return calendar
     }

--- a/KeyVoxTests/App/WeeklyWordStatsStoreTests.swift
+++ b/KeyVoxTests/App/WeeklyWordStatsStoreTests.swift
@@ -108,6 +108,34 @@ final class WeeklyWordStatsStoreTests: XCTestCase {
         XCTAssertEqual(store.combinedWordCount, 0)
     }
 
+    func testApplySynchronizedSnapshotIgnoresStaleWeekPayloads() {
+        let (defaults, suiteName) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let calendar = makeCalendar()
+        let currentDate = makeDate(calendar: calendar, year: 2026, month: 3, day: 17)
+        let staleDate = makeDate(calendar: calendar, year: 2026, month: 3, day: 10)
+        let store = WeeklyWordStatsStore(
+            defaults: defaults,
+            calendar: calendar,
+            now: { currentDate },
+            installationIDGenerator: { "device-a" }
+        )
+
+        store.recordSpokenWords(from: "one two", at: currentDate)
+        let currentSnapshot = store.snapshot
+
+        store.applySynchronizedSnapshot(
+            WeeklyWordStatsPayload(
+                weekStart: calendar.dateInterval(of: .weekOfYear, for: staleDate)!.start,
+                modifiedAt: staleDate,
+                deviceWordCounts: ["device-b": 20]
+            )
+        )
+
+        XCTAssertEqual(store.snapshot, currentSnapshot)
+        XCTAssertEqual(store.combinedWordCount, 2)
+    }
+
     private func makeIsolatedDefaults() -> (UserDefaults, String) {
         let suiteName = "WeeklyWordStatsStoreTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/Views/Settings/SettingsView+Sidebar.swift
+++ b/Views/Settings/SettingsView+Sidebar.swift
@@ -24,7 +24,7 @@ extension SettingsView {
                 Text("Words this week:")
                     .font(.custom("Kanit Medium", size: 14))
                     .foregroundColor(.white.opacity(0.95))
-                Text(appSettings.wordsThisWeek.formatted())
+                Text(weeklyWordStatsStore.combinedWordCount.formatted())
                     .font(.custom("Kanit Medium", size: 14))
                     .foregroundColor(.yellow)
             }

--- a/Views/Settings/SettingsView.swift
+++ b/Views/Settings/SettingsView.swift
@@ -8,6 +8,7 @@ struct SettingsView: View {
     @Environment(\.dismiss) var dismiss
 
     @StateObject internal var appSettings = AppSettingsStore.shared
+    @StateObject internal var weeklyWordStatsStore = AppServiceRegistry.shared.weeklyWordStatsStore
     @ObservedObject internal var downloader = ModelDownloader.shared
     @ObservedObject internal var audioDeviceManager = AudioDeviceManager.shared
     @ObservedObject internal var dictionaryStore = AppServiceRegistry.shared.dictionaryStore
@@ -79,7 +80,7 @@ struct SettingsView: View {
             )
         }
         .onAppear {
-            appSettings.refreshWeeklyWordCounterIfNeeded()
+            weeklyWordStatsStore.refreshWeeklyWordStatsIfNeeded()
             appSettings.refreshSelectedMicrophoneFromDefaults()
             if selectedTab == .dictionary {
                 hasVisitedDictionaryTab = true


### PR DESCRIPTION
- remove weekly word counting from AppSettingsStore and replace it with a dedicated WeeklyWordStatsStore that owns current-week snapshots, stable installation IDs, combined totals, and hidden per-device contributions
- add WeeklyWordStatsCloudSync plus new iCloud payload and key definitions so weekly usage converges separately from the existing dictionary and settings sync coordinator
- wire spoken-word recording through TranscriptionManager and AppServiceRegistry, and update the settings sidebar to display the new combined weekly total
- replace the old weekly-count settings tests with preference-only coverage, add dedicated weekly stats store and cloud sync tests, and include the new files in the Xcode project
- update CODEMAP.md and ENGINEERING.md to reflect the new weekly stats ownership boundary and sync architecture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly word statistics now sync reliably across devices with deterministic per-device merging so totals converge; Settings shows an accurate combined weekly count with automatic week rollover.

* **Chores**
  * Restructured the weekly stats subsystem, updated persistence keys, and added tests and documentation to improve reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->