### PR TITLE
fix(icloud): preserve persisted dictionary freshness on mac bootstrap

### DIFF
--- a/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
+++ b/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
@@ -166,11 +166,7 @@ final class KeyVoxiCloudSyncCoordinator {
         case (false, .some(let payload)):
             applyRemoteDictionary(payload)
         case (true, .some(let payload)):
-            guard let modifiedAt = localModifiedAt else {
-                applyRemoteDictionary(payload)
-                return
-            }
-
+            let modifiedAt = localModifiedAt!
             setLocalDictionaryModifiedAt(modifiedAt)
             if payload.modifiedAt > modifiedAt {
                 applyRemoteDictionary(payload)

--- a/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
+++ b/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
@@ -154,17 +154,18 @@ final class KeyVoxiCloudSyncCoordinator {
         let localEntries = dictionaryStore.entries
         let localModifiedAt = inferredLocalDictionaryModifiedAt()
         let remotePayload = loadRemoteDictionaryPayload()
+        let hasLocalSnapshot = localModifiedAt != nil
 
-        switch (localEntries.isEmpty, remotePayload) {
-        case (true, nil):
-            return
+        switch (hasLocalSnapshot, remotePayload) {
         case (false, nil):
+            return
+        case (true, nil):
             let modifiedAt = localModifiedAt ?? now()
             setLocalDictionaryModifiedAt(modifiedAt)
             pushDictionary(entries: localEntries, modifiedAt: modifiedAt)
-        case (true, .some(let payload)):
-            applyRemoteDictionary(payload)
         case (false, .some(let payload)):
+            applyRemoteDictionary(payload)
+        case (true, .some(let payload)):
             guard let modifiedAt = localModifiedAt else {
                 applyRemoteDictionary(payload)
                 return

--- a/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
+++ b/App/iCloud/KeyVoxiCloudSyncCoordinator.swift
@@ -165,7 +165,11 @@ final class KeyVoxiCloudSyncCoordinator {
         case (true, .some(let payload)):
             applyRemoteDictionary(payload)
         case (false, .some(let payload)):
-            let modifiedAt = localModifiedAt ?? now()
+            guard let modifiedAt = localModifiedAt else {
+                applyRemoteDictionary(payload)
+                return
+            }
+
             setLocalDictionaryModifiedAt(modifiedAt)
             if payload.modifiedAt > modifiedAt {
                 applyRemoteDictionary(payload)
@@ -495,7 +499,7 @@ final class KeyVoxiCloudSyncCoordinator {
     }
 
     private func inferredLocalDictionaryModifiedAt() -> Date? {
-        localDictionaryModifiedAt() ?? (dictionaryStore.entries.isEmpty ? nil : now())
+        localDictionaryModifiedAt() ?? dictionaryStore.persistedSnapshotModifiedAt
     }
 
     private func inferredLocalAutoParagraphsModifiedAt(defaultValue: Bool) -> Date? {

--- a/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
+++ b/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
@@ -221,6 +221,62 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.defaults.object(forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt) as? Date, localDate)
     }
 
+    func testPersistedEmptyDictionarySeedsEmptyCloudUsingFileTimestamp() throws {
+        let localDate = makeDate(year: 2026, month: 3, day: 7, hour: 8)
+        let harness = try makeHarness(
+            now: makeDate(year: 2026, month: 3, day: 10, hour: 8),
+            prepareBaseDirectory: { baseDirectoryURL in
+                try self.writePersistedDictionary(entries: [], modifiedAt: localDate, to: baseDirectoryURL)
+            }
+        )
+
+        let dictionaryPushed = expectation(description: "Persisted empty dictionary seeded to cloud")
+        harness.cloudStore.onSet = { key in
+            if key == KeyVoxiCloudKeys.dictionaryPayload {
+                dictionaryPushed.fulfill()
+            }
+        }
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+        wait(for: [dictionaryPushed], timeout: 1.0)
+
+        let payload = try XCTUnwrap(harness.cloudStore.dictionaryPayload())
+        XCTAssertTrue(harness.dictionaryStore.entries.isEmpty)
+        XCTAssertTrue(payload.entries.isEmpty)
+        XCTAssertEqual(payload.modifiedAt, localDate)
+        XCTAssertEqual(harness.defaults.object(forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt) as? Date, localDate)
+    }
+
+    func testPersistedEmptyDictionaryWinsOverOlderCloudDictionary() throws {
+        let localDate = makeDate(year: 2026, month: 3, day: 10, hour: 8)
+        let remoteDate = makeDate(year: 2026, month: 3, day: 9, hour: 8)
+        let harness = try makeHarness(
+            now: makeDate(year: 2026, month: 3, day: 12, hour: 8),
+            prepareBaseDirectory: { baseDirectoryURL in
+                try self.writePersistedDictionary(entries: [], modifiedAt: localDate, to: baseDirectoryURL)
+            }
+        )
+        try harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "Older Remote Phrase")], modifiedAt: remoteDate)
+
+        let dictionaryPushed = expectation(description: "Persisted empty dictionary pushed to cloud")
+        harness.cloudStore.onSet = { key in
+            if key == KeyVoxiCloudKeys.dictionaryPayload {
+                dictionaryPushed.fulfill()
+            }
+        }
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+        wait(for: [dictionaryPushed], timeout: 1.0)
+
+        let payload = try XCTUnwrap(harness.cloudStore.dictionaryPayload())
+        XCTAssertTrue(harness.dictionaryStore.entries.isEmpty)
+        XCTAssertTrue(payload.entries.isEmpty)
+        XCTAssertEqual(payload.modifiedAt, localDate)
+        XCTAssertEqual(harness.defaults.object(forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt) as? Date, localDate)
+    }
+
     func testNewerCloudAutoParagraphsAppliesLocally() throws {
         let remoteDate = makeDate(year: 2026, month: 3, day: 12, hour: 9)
         let harness = try makeHarness(now: remoteDate)

--- a/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
+++ b/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
@@ -6,8 +6,10 @@ import XCTest
 @MainActor
 final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
     func testLocalDictionarySeedsEmptyCloud() async throws {
-        let harness = try makeHarness(now: makeDate(year: 2026, month: 3, day: 7, hour: 12))
+        let localDate = makeDate(year: 2026, month: 3, day: 7, hour: 12)
+        let harness = try makeHarness(now: localDate)
         try harness.dictionaryStore.add(phrase: "Cueboard")
+        harness.defaults.set(localDate, forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt)
 
         let dictionaryPushed = expectation(description: "Dictionary pushed to cloud")
         harness.cloudStore.onSet = { key in
@@ -22,7 +24,7 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
 
         let payload = try XCTUnwrap(harness.cloudStore.dictionaryPayload())
         XCTAssertEqual(payload.entries.map(\.phrase), ["Cueboard"])
-        XCTAssertEqual(payload.modifiedAt, makeDate(year: 2026, month: 3, day: 7, hour: 12))
+        XCTAssertEqual(payload.modifiedAt, localDate)
     }
 
     func testCloudDictionarySeedsEmptyLocal() throws {
@@ -135,6 +137,90 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.cloudStore.setCount(forKey: KeyVoxiCloudKeys.dictionaryPayload), 0)
     }
 
+    func testNewerCloudDictionaryWinsWhenOnlyPersistedFileTimestampExists() throws {
+        let localDate = makeDate(year: 2026, month: 3, day: 7, hour: 8)
+        let remoteDate = makeDate(year: 2026, month: 3, day: 9, hour: 8)
+        let localEntries = [
+            DictionaryEntry(id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!, phrase: "Old Local Phrase"),
+        ]
+        let harness = try makeHarness(
+            now: makeDate(year: 2026, month: 3, day: 10, hour: 8),
+            prepareBaseDirectory: { baseDirectoryURL in
+                try self.writePersistedDictionary(entries: localEntries, modifiedAt: localDate, to: baseDirectoryURL)
+            }
+        )
+        try harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "New Remote Phrase")], modifiedAt: remoteDate)
+        harness.cloudStore.resetSetCounts()
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+
+        XCTAssertEqual(harness.dictionaryStore.entries.map(\.phrase), ["New Remote Phrase"])
+        XCTAssertEqual(harness.defaults.object(forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt) as? Date, remoteDate)
+        XCTAssertEqual(harness.cloudStore.setCount(forKey: KeyVoxiCloudKeys.dictionaryPayload), 0)
+    }
+
+    func testOlderCloudDictionaryIsIgnoredWhenOnlyPersistedFileTimestampExists() throws {
+        let localDate = makeDate(year: 2026, month: 3, day: 10, hour: 8)
+        let remoteDate = makeDate(year: 2026, month: 3, day: 9, hour: 8)
+        let localEntries = [
+            DictionaryEntry(id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!, phrase: "Latest Local Phrase"),
+        ]
+        let harness = try makeHarness(
+            now: makeDate(year: 2026, month: 3, day: 12, hour: 8),
+            prepareBaseDirectory: { baseDirectoryURL in
+                try self.writePersistedDictionary(entries: localEntries, modifiedAt: localDate, to: baseDirectoryURL)
+            }
+        )
+        try harness.cloudStore.seedDictionary(entries: [DictionaryEntry(phrase: "Older Remote Phrase")], modifiedAt: remoteDate)
+
+        let dictionaryPushed = expectation(description: "Persisted dictionary pushed to cloud")
+        harness.cloudStore.onSet = { key in
+            if key == KeyVoxiCloudKeys.dictionaryPayload {
+                dictionaryPushed.fulfill()
+            }
+        }
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+        wait(for: [dictionaryPushed], timeout: 1.0)
+
+        let payload = try XCTUnwrap(harness.cloudStore.dictionaryPayload())
+        XCTAssertEqual(harness.dictionaryStore.entries.map(\.phrase), ["Latest Local Phrase"])
+        XCTAssertEqual(payload.entries.map(\.phrase), ["Latest Local Phrase"])
+        XCTAssertEqual(payload.modifiedAt, localDate)
+        XCTAssertEqual(harness.defaults.object(forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt) as? Date, localDate)
+    }
+
+    func testPersistedDictionarySeedsEmptyCloudUsingFileTimestamp() throws {
+        let localDate = makeDate(year: 2026, month: 3, day: 7, hour: 8)
+        let localEntries = [
+            DictionaryEntry(id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!, phrase: "Cueboard"),
+        ]
+        let harness = try makeHarness(
+            now: makeDate(year: 2026, month: 3, day: 10, hour: 8),
+            prepareBaseDirectory: { baseDirectoryURL in
+                try self.writePersistedDictionary(entries: localEntries, modifiedAt: localDate, to: baseDirectoryURL)
+            }
+        )
+
+        let dictionaryPushed = expectation(description: "Persisted dictionary seeded to cloud")
+        harness.cloudStore.onSet = { key in
+            if key == KeyVoxiCloudKeys.dictionaryPayload {
+                dictionaryPushed.fulfill()
+            }
+        }
+
+        let coordinator = makeCoordinator(harness: harness)
+        _ = coordinator
+        wait(for: [dictionaryPushed], timeout: 1.0)
+
+        let payload = try XCTUnwrap(harness.cloudStore.dictionaryPayload())
+        XCTAssertEqual(payload.entries.map(\.phrase), ["Cueboard"])
+        XCTAssertEqual(payload.modifiedAt, localDate)
+        XCTAssertEqual(harness.defaults.object(forKey: UserDefaultsKeys.iCloud.dictionaryLastModifiedAt) as? Date, localDate)
+    }
+
     func testNewerCloudAutoParagraphsAppliesLocally() throws {
         let remoteDate = makeDate(year: 2026, month: 3, day: 12, hour: 9)
         let harness = try makeHarness(now: remoteDate)
@@ -213,7 +299,10 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
         )
     }
 
-    private func makeHarness(now: Date) throws -> Harness {
+    private func makeHarness(
+        now: Date,
+        prepareBaseDirectory: ((URL) throws -> Void)? = nil
+    ) throws -> Harness {
         let suiteName = "KeyVoxiCloudSyncCoordinatorTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
@@ -222,6 +311,7 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
             .appendingPathComponent("KeyVoxiCloudSyncCoordinatorTests", isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        try prepareBaseDirectory?(base)
 
         let appSettings = AppSettingsStore(defaults: defaults)
         let dictionaryStore = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
@@ -257,6 +347,29 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
             hour: hour
         ).date!
     }
+
+    private func writePersistedDictionary(
+        entries: [DictionaryEntry],
+        modifiedAt: Date,
+        to baseDirectoryURL: URL
+    ) throws {
+        let dictionaryDirectoryURL = baseDirectoryURL.appendingPathComponent("Dictionary", isDirectory: true)
+        let dictionaryFileURL = dictionaryDirectoryURL.appendingPathComponent("dictionary.json")
+
+        try FileManager.default.createDirectory(at: dictionaryDirectoryURL, withIntermediateDirectories: true)
+        let payload = PersistedDictionaryPayload(version: 1, entries: entries)
+        let data = try JSONEncoder().encode(payload)
+        try data.write(to: dictionaryFileURL, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.modificationDate: modifiedAt],
+            ofItemAtPath: dictionaryFileURL.path
+        )
+    }
+}
+
+private struct PersistedDictionaryPayload: Codable {
+    let version: Int
+    let entries: [DictionaryEntry]
 }
 
 private struct Harness {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryStore.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryStore.swift
@@ -27,6 +27,7 @@ public final class DictionaryStore: ObservableObject {
     @Published public private(set) var loadWarningMessage: String?
     @Published public private(set) var saveErrorMessage: String?
     @Published public private(set) var degradedDurability: Bool = false
+    public private(set) var persistedSnapshotModifiedAt: Date?
 
     private struct DictionaryPayload: Codable {
         let version: Int
@@ -145,6 +146,7 @@ public final class DictionaryStore: ObservableObject {
     private func loadFromDisk() {
         saveErrorMessage = nil
         degradedDurability = fileManager.fileExists(atPath: degradedDurabilityMarkerURL.path)
+        persistedSnapshotModifiedAt = nil
 
         let hasPrimary = fileManager.fileExists(atPath: dictionaryFileURL.path)
         let hasBackup = fileManager.fileExists(atPath: backupFileURL.path)
@@ -158,16 +160,18 @@ public final class DictionaryStore: ObservableObject {
 
         if hasPrimary, let payload = try? readPayload(from: dictionaryFileURL) {
             entries = payload.entries
+            persistedSnapshotModifiedAt = fileModificationDate(at: dictionaryFileURL)
             loadWarningMessage = nil
             return
         }
 
         if hasBackup, let backupPayload = try? readPayload(from: backupFileURL) {
             entries = backupPayload.entries
+            persistedSnapshotModifiedAt = fileModificationDate(at: backupFileURL)
             loadWarningMessage = "Dictionary was recovered from backup after a file issue."
 
             do {
-                try persist(entries: backupPayload.entries)
+                try persist(entries: backupPayload.entries, updatePersistedSnapshotModifiedAt: false)
                 // Keep this warning visible until the user performs the next save action.
                 loadWarningMessage = "Dictionary was recovered from backup after a file issue."
             } catch {
@@ -180,6 +184,7 @@ public final class DictionaryStore: ObservableObject {
         quarantineIfPresent(backupFileURL)
 
         entries = []
+        persistedSnapshotModifiedAt = nil
         loadWarningMessage = "Dictionary data was corrupted and reset."
     }
 
@@ -192,7 +197,10 @@ public final class DictionaryStore: ObservableObject {
         }
     }
 
-    private func persist(entries candidateEntries: [DictionaryEntry]) throws {
+    private func persist(
+        entries candidateEntries: [DictionaryEntry],
+        updatePersistedSnapshotModifiedAt: Bool = true
+    ) throws {
         try fileManager.createDirectory(at: dictionaryDirectoryURL, withIntermediateDirectories: true)
 
         let payload = DictionaryPayload(version: 1, entries: candidateEntries)
@@ -204,6 +212,10 @@ public final class DictionaryStore: ObservableObject {
             clearDegradedDurabilityMarker()
         } catch {
             markDegradedDurability()
+        }
+
+        if updatePersistedSnapshotModifiedAt {
+            persistedSnapshotModifiedAt = fileModificationDate(at: dictionaryFileURL)
         }
 
         saveErrorMessage = nil
@@ -238,6 +250,14 @@ public final class DictionaryStore: ObservableObject {
     private func readPayload(from fileURL: URL) throws -> DictionaryPayload {
         let data = try Data(contentsOf: fileURL)
         return try decoder.decode(DictionaryPayload.self, from: data)
+    }
+
+    private func fileModificationDate(at fileURL: URL) -> Date? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: fileURL.path) else {
+            return nil
+        }
+
+        return attributes[.modificationDate] as? Date
     }
 
     private func quarantineIfPresent(_ fileURL: URL) {

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryStoreTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryStoreTests.swift
@@ -26,6 +26,24 @@ final class DictionaryStoreTests: XCTestCase {
             try store.add(phrase: "Dom Esposito")
             let reloaded = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
             XCTAssertTrue(reloaded.entries.map(\.phrase) == ["Dom Esposito"])
+            XCTAssertNotNil(reloaded.persistedSnapshotModifiedAt)
+        }
+    }
+
+    func testLoadFromPrimaryCapturesPersistedSnapshotModifiedAt() throws {
+        try withTemporaryDirectory { root in
+            let base = root.appendingPathComponent("KeyVox", isDirectory: true)
+            let dictionaryDir = base.appendingPathComponent("Dictionary", isDirectory: true)
+            let expectedDate = makeDate(year: 2026, month: 3, day: 7, hour: 12)
+            try FileManager.default.createDirectory(at: dictionaryDir, withIntermediateDirectories: true)
+
+            let primary = dictionaryDir.appendingPathComponent("dictionary.json")
+            try makePayload(entries: [DictionaryEntry(phrase: "Cueboard")]).write(to: primary)
+            try FileManager.default.setAttributes([.modificationDate: expectedDate], ofItemAtPath: primary.path)
+
+            let store = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
+            XCTAssertEqual(store.entries.map(\.phrase), ["Cueboard"])
+            XCTAssertEqual(store.persistedSnapshotModifiedAt, expectedDate)
         }
     }
 
@@ -121,16 +139,29 @@ final class DictionaryStoreTests: XCTestCase {
         try withTemporaryDirectory { root in
             let base = root.appendingPathComponent("KeyVox", isDirectory: true)
             let dictionaryDir = base.appendingPathComponent("Dictionary", isDirectory: true)
+            let backupDate = makeDate(year: 2026, month: 3, day: 8, hour: 9)
             try FileManager.default.createDirectory(at: dictionaryDir, withIntermediateDirectories: true)
 
             let primary = dictionaryDir.appendingPathComponent("dictionary.json")
             let backup = dictionaryDir.appendingPathComponent("dictionary.backup.json")
             try "broken".data(using: .utf8)!.write(to: primary)
-            try makePayload(phrases: ["Dom Esposito"]).write(to: backup)
+            try makePayload(entries: [DictionaryEntry(phrase: "Dom Esposito")]).write(to: backup)
+            try FileManager.default.setAttributes([.modificationDate: backupDate], ofItemAtPath: backup.path)
 
             let store = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
             XCTAssertTrue(store.entries.map(\.phrase) == ["Dom Esposito"])
+            XCTAssertEqual(store.persistedSnapshotModifiedAt, backupDate)
             XCTAssertTrue(store.loadWarningMessage?.contains("recovered from backup") == true)
+        }
+    }
+
+    func testMissingPersistedDictionaryLeavesSnapshotModifiedAtNil() throws {
+        try withTemporaryDirectory { root in
+            let base = root.appendingPathComponent("KeyVox", isDirectory: true)
+            let store = DictionaryStore(fileManager: .default, baseDirectoryURL: base)
+
+            XCTAssertTrue(store.entries.isEmpty)
+            XCTAssertNil(store.persistedSnapshotModifiedAt)
         }
     }
 
@@ -259,14 +290,26 @@ final class DictionaryStoreTests: XCTestCase {
         }
     }
 
-    private func makePayload(phrases: [String]) throws -> Data {
-        let entries: [[String: String]] = phrases.map {
-            ["id": UUID().uuidString, "phrase": $0]
-        }
-        let payload: [String: Any] = [
-            "version": 1,
-            "entries": entries,
-        ]
-        return try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted])
+    private func makePayload(entries: [DictionaryEntry]) throws -> Data {
+        let payload = DictionaryPayloadFixture(version: 1, entries: entries)
+        return try JSONEncoder().encode(payload)
     }
+
+    private func makeDate(year: Int, month: Int, day: Int, hour: Int) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour
+        ).date!
+    }
+}
+
+private struct DictionaryPayloadFixture: Codable {
+    let version: Int
+    let entries: [DictionaryEntry]
 }


### PR DESCRIPTION
- track the persisted dictionary snapshot modification date in DictionaryStore
- use on-disk dictionary mtimes during mac iCloud bootstrap instead of fabricating now
- prefer the remote payload when local dictionary freshness is unknown
- add regression coverage for reinstall/bootstrap sync paths and dictionary timestamp loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud synchronization when local timestamps are missing, preventing incorrect overwrites and ensuring correct merge or push behavior.
  * Refined persisted-snapshot timestamp handling so on-disk modification dates are tracked more accurately, reducing sync conflicts and improving resolution of newer/older dictionary states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->