### PR TITLE
feat(updater): add in-place GitHub release updater flow

### DIFF
--- a/App/AppSettingsStore.swift
+++ b/App/AppSettingsStore.swift
@@ -88,6 +88,18 @@ final class AppSettingsStore: ObservableObject {
         }
     }
 
+    @Published var pendingUpdatedVersion: String? {
+        didSet {
+            defaults.set(pendingUpdatedVersion, forKey: UserDefaultsKeys.App.pendingUpdatedVersion)
+        }
+    }
+
+    @Published var lastAcknowledgedUpdatedVersion: String? {
+        didSet {
+            defaults.set(lastAcknowledgedUpdatedVersion, forKey: UserDefaultsKeys.App.lastAcknowledgedUpdatedVersion)
+        }
+    }
+
     private let defaults: UserDefaults
     private let defaultSoundVolume: Double = 0.1
 
@@ -121,6 +133,8 @@ final class AppSettingsStore: ObservableObject {
         selectedMicrophoneUID = defaults.string(forKey: UserDefaultsKeys.selectedMicrophoneUID) ?? ""
         updateAlertLastShown = defaults.object(forKey: UserDefaultsKeys.App.updateAlertLastShown) as? Date
         updateAlertSnoozedUntil = defaults.object(forKey: UserDefaultsKeys.App.updateAlertSnoozedUntil) as? Date
+        pendingUpdatedVersion = defaults.string(forKey: UserDefaultsKeys.App.pendingUpdatedVersion)
+        lastAcknowledgedUpdatedVersion = defaults.string(forKey: UserDefaultsKeys.App.lastAcknowledgedUpdatedVersion)
     }
 
     func refreshSelectedMicrophoneFromDefaults() {

--- a/App/KeyVoxApp.swift
+++ b/App/KeyVoxApp.swift
@@ -12,6 +12,10 @@ import Combine
 final class KeyVoxAppDelegate: NSObject, NSApplicationDelegate {
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         Task { @MainActor in
+            if WindowManager.shared.bringForwardNonSettingsWindowIfNeeded() {
+                return
+            }
+
             if AppSettingsStore.shared.hasCompletedOnboarding {
                 WindowManager.shared.openSettings(centered: true)
             } else {
@@ -45,6 +49,25 @@ class WindowManager: ObservableObject {
     @Published var postUpdateNoticeWindow: NSWindow?
     
     private init() {} // Private init for singleton
+
+    @MainActor
+    func bringForwardNonSettingsWindowIfNeeded() -> Bool {
+        let candidateWindows = [
+            postUpdateNoticeWindow,
+            updateWindow,
+            onboardingWindow
+        ]
+
+        guard let window = candidateWindows
+            .compactMap({ $0 })
+            .first(where: { $0.isVisible && !$0.isMiniaturized }) else {
+            return false
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        return true
+    }
     
     @MainActor
     func showOnboarding() {
@@ -238,7 +261,7 @@ struct KeyVoxApp: App {
             StatusMenuView(
                 manager: transcriptionManager,
                 openSettings: { tab in WindowManager.shared.openSettings(tab: tab) },
-                checkForUpdates: { AppUpdateCoordinator.shared.openWindowForManualCheck() },
+                checkForUpdates: { AppUpdateService.shared.checkForUpdatesManually() },
                 quitApp: { NSApplication.shared.terminate(nil) }
             )
         } label: {

--- a/App/KeyVoxApp.swift
+++ b/App/KeyVoxApp.swift
@@ -41,6 +41,8 @@ class WindowManager: ObservableObject {
     
     @Published var settingsWindow: NSWindow?
     @Published var onboardingWindow: NSWindow?
+    @Published var updateWindow: NSWindow?
+    @Published var postUpdateNoticeWindow: NSWindow?
     
     private init() {} // Private init for singleton
     
@@ -179,6 +181,7 @@ struct KeyVoxApp: App {
     @ObservedObject private var appSettings = AppSettingsStore.shared
     @ObservedObject private var windowManager = WindowManager.shared
     @ObservedObject private var downloader = ModelDownloader.shared
+    @ObservedObject private var updateCoordinator = AppUpdateCoordinator.shared
     private let appServiceRegistry = AppServiceRegistry.shared
     private let onboardingStartupDelay: TimeInterval = 0.1
 
@@ -210,7 +213,11 @@ struct KeyVoxApp: App {
         }
 
         Task { @MainActor in
+            AppUpdateCoordinator.shared.prepareForLaunch()
             AppUpdateService.shared.startUpdateTimer()
+            if AppUpdateCoordinator.shared.postUpdateNoticeVersion != nil {
+                WindowManager.shared.showPostUpdateNoticeWindow()
+            }
         }
 
         _ = appServiceRegistry.iCloudSyncCoordinator
@@ -231,7 +238,7 @@ struct KeyVoxApp: App {
             StatusMenuView(
                 manager: transcriptionManager,
                 openSettings: { tab in WindowManager.shared.openSettings(tab: tab) },
-                checkForUpdates: { AppUpdateService.shared.checkForUpdatesManually() },
+                checkForUpdates: { AppUpdateCoordinator.shared.openWindowForManualCheck() },
                 quitApp: { NSApplication.shared.terminate(nil) }
             )
         } label: {

--- a/App/UserDefaultsKeys.swift
+++ b/App/UserDefaultsKeys.swift
@@ -18,6 +18,9 @@ enum UserDefaultsKeys {
     enum App {
         static let updateAlertLastShown = "KeyVox.App.UpdateAlertLastShown"
         static let updateAlertSnoozedUntil = "KeyVox.App.UpdateAlertSnoozedUntil"
+        static let pendingUpdatedVersion = "KeyVox.App.PendingUpdatedVersion"
+        static let lastAcknowledgedUpdatedVersion = "KeyVox.App.LastAcknowledgedUpdatedVersion"
+        static let resumeUpdaterAfterApplicationsMove = "KeyVox.App.ResumeUpdaterAfterApplicationsMove"
         static let weeklyWordStatsPayload = "KeyVox.App.WeeklyWordStatsPayload"
         static let weeklyWordStatsInstallationID = "KeyVox.App.WeeklyWordStatsInstallationID"
     }

--- a/App/WindowManager+Updates.swift
+++ b/App/WindowManager+Updates.swift
@@ -1,0 +1,93 @@
+import AppKit
+import SwiftUI
+
+extension WindowManager {
+    @MainActor
+    func openUpdateWindow(centered: Bool = true) {
+        let window: NSWindow
+        if let existing = updateWindow {
+            window = existing
+        } else {
+            window = NSWindow(
+                contentRect: NSRect(
+                    x: 0,
+                    y: 0,
+                    width: UpdateWindowView.preferredWindowSize.width,
+                    height: UpdateWindowView.preferredWindowSize.height
+                ),
+                styleMask: [.titled, .fullSizeContentView, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            window.isReleasedWhenClosed = false
+            window.titlebarAppearsTransparent = true
+            window.titleVisibility = .hidden
+            window.backgroundColor = .clear
+            window.isOpaque = false
+            window.hasShadow = true
+            window.isMovableByWindowBackground = true
+            updateWindow = window
+        }
+
+        window.contentView = NSHostingView(rootView: UpdateWindowView(coordinator: AppUpdateCoordinator.shared))
+        window.setContentSize(UpdateWindowView.preferredWindowSize)
+        if centered {
+            window.center()
+        }
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @MainActor
+    func hideUpdateWindow() {
+        updateWindow?.orderOut(nil)
+    }
+
+    @MainActor
+    func showPostUpdateNoticeWindow() {
+        guard let version = AppUpdateCoordinator.shared.postUpdateNoticeVersion else { return }
+
+        let window: NSWindow
+        if let existing = postUpdateNoticeWindow {
+            window = existing
+        } else {
+            window = NSWindow(
+                contentRect: NSRect(
+                    x: 0,
+                    y: 0,
+                    width: PostUpdateNoticeView.preferredWindowSize.width,
+                    height: PostUpdateNoticeView.preferredWindowSize.height
+                ),
+                styleMask: [.titled, .fullSizeContentView, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            window.isReleasedWhenClosed = false
+            window.titlebarAppearsTransparent = true
+            window.titleVisibility = .hidden
+            window.backgroundColor = .clear
+            window.isOpaque = false
+            window.hasShadow = true
+            window.isMovableByWindowBackground = true
+            postUpdateNoticeWindow = window
+        }
+
+        window.contentView = NSHostingView(
+            rootView: PostUpdateNoticeView(
+                version: version,
+                onDismiss: {
+                    AppUpdateCoordinator.shared.dismissPostUpdateNotice()
+                }
+            )
+        )
+        window.setContentSize(PostUpdateNoticeView.preferredWindowSize)
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @MainActor
+    func hidePostUpdateNoticeWindow() {
+        postUpdateNoticeWindow?.orderOut(nil)
+    }
+}

--- a/App/WindowManager+Updates.swift
+++ b/App/WindowManager+Updates.swift
@@ -5,8 +5,10 @@ extension WindowManager {
     @MainActor
     func openUpdateWindow(centered: Bool = true) {
         let window: NSWindow
+        let isNewWindow: Bool
         if let existing = updateWindow {
             window = existing
+            isNewWindow = false
         } else {
             window = NSWindow(
                 contentRect: NSRect(
@@ -15,24 +17,45 @@ extension WindowManager {
                     width: UpdateWindowView.preferredWindowSize.width,
                     height: UpdateWindowView.preferredWindowSize.height
                 ),
-                styleMask: [.titled, .fullSizeContentView, .closable],
+                styleMask: [.titled, .fullSizeContentView],
                 backing: .buffered,
                 defer: false
             )
             window.isReleasedWhenClosed = false
             window.titlebarAppearsTransparent = true
             window.titleVisibility = .hidden
+            window.standardWindowButton(.closeButton)?.isHidden = true
+            window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+            window.standardWindowButton(.zoomButton)?.isHidden = true
             window.backgroundColor = .clear
             window.isOpaque = false
             window.hasShadow = true
-            window.isMovableByWindowBackground = true
+            window.isMovableByWindowBackground = false
             updateWindow = window
+            isNewWindow = true
         }
 
-        window.contentView = NSHostingView(rootView: UpdateWindowView(coordinator: AppUpdateCoordinator.shared))
-        window.setContentSize(UpdateWindowView.preferredWindowSize)
+        window.contentView = NSHostingView(
+            rootView: UpdateWindowView(
+                coordinator: AppUpdateCoordinator.shared,
+                onPreferredHeightChange: { [weak window] height in
+                    guard let window else { return }
+                    let targetSize = CGSize(
+                        width: UpdateWindowView.preferredWindowSize.width,
+                        height: height
+                    )
+                    if window.contentLayoutRect.size != targetSize {
+                        window.setContentSize(targetSize)
+                        self.centerUpdateWindow(window)
+                    }
+                }
+            )
+        )
+        if isNewWindow {
+            window.setContentSize(UpdateWindowView.preferredWindowSize)
+        }
         if centered {
-            window.center()
+            centerUpdateWindow(window)
         }
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
@@ -58,17 +81,20 @@ extension WindowManager {
                     width: PostUpdateNoticeView.preferredWindowSize.width,
                     height: PostUpdateNoticeView.preferredWindowSize.height
                 ),
-                styleMask: [.titled, .fullSizeContentView, .closable],
+                styleMask: [.titled, .fullSizeContentView],
                 backing: .buffered,
                 defer: false
             )
             window.isReleasedWhenClosed = false
             window.titlebarAppearsTransparent = true
             window.titleVisibility = .hidden
+            window.standardWindowButton(.closeButton)?.isHidden = true
+            window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+            window.standardWindowButton(.zoomButton)?.isHidden = true
             window.backgroundColor = .clear
             window.isOpaque = false
             window.hasShadow = true
-            window.isMovableByWindowBackground = true
+            window.isMovableByWindowBackground = false
             postUpdateNoticeWindow = window
         }
 
@@ -81,7 +107,7 @@ extension WindowManager {
             )
         )
         window.setContentSize(PostUpdateNoticeView.preferredWindowSize)
-        window.center()
+        centerFloatingWindow(window)
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }
@@ -89,5 +115,24 @@ extension WindowManager {
     @MainActor
     func hidePostUpdateNoticeWindow() {
         postUpdateNoticeWindow?.orderOut(nil)
+    }
+
+    @MainActor
+    private func centerUpdateWindow(_ window: NSWindow) {
+        centerFloatingWindow(window)
+    }
+
+    @MainActor
+    private func centerFloatingWindow(_ window: NSWindow) {
+        let screen = window.screen ?? NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens.first
+        guard let screen else { return }
+
+        let visibleFrame = screen.visibleFrame
+        let windowSize = window.frame.size
+        let origin = NSPoint(
+            x: visibleFrame.midX - (windowSize.width / 2),
+            y: visibleFrame.midY - (windowSize.height / 2)
+        )
+        window.setFrameOrigin(origin)
     }
 }

--- a/Core/Services/AppUpdate/AppReleaseInfo.swift
+++ b/Core/Services/AppUpdate/AppReleaseInfo.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum AppInstallAssetKind: Equatable {
+    case zip
+    case manualOnly
+}
+
+struct AppUpdateManifest: Decodable, Equatable {
+    let version: String
+    let assetName: String
+    let sha256: String
+    let byteSize: Int64
+    let bundleIdentifier: String
+    let minimumSupportedMacOS: String?
+}
+
+struct AppReleaseInfo: Equatable {
+    let version: String
+    let message: String?
+    let releasePageURL: URL
+    let installAssetURL: URL?
+    let installAssetName: String?
+    let manifestAssetURL: URL?
+    let installAssetKind: AppInstallAssetKind
+
+    var isInstallableInApp: Bool {
+        installAssetKind == .zip && installAssetURL != nil && manifestAssetURL != nil
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdateApplicationsPrereflight.swift
+++ b/Core/Services/AppUpdate/AppUpdateApplicationsPrereflight.swift
@@ -52,7 +52,15 @@ struct AppUpdateApplicationsPrereflight {
         try fileManager.copyItem(at: sourceURL, to: stagingURL)
 
         if fileManager.fileExists(atPath: destinationURL.path) {
-            try fileManager.removeItem(at: destinationURL)
+            var resultingURL: NSURL?
+            try fileManager.replaceItem(
+                at: destinationURL,
+                withItemAt: stagingURL,
+                backupItemName: nil,
+                options: [],
+                resultingItemURL: &resultingURL
+            )
+            return (resultingURL as URL?) ?? destinationURL
         }
 
         try fileManager.moveItem(at: stagingURL, to: destinationURL)

--- a/Core/Services/AppUpdate/AppUpdateApplicationsPrereflight.swift
+++ b/Core/Services/AppUpdate/AppUpdateApplicationsPrereflight.swift
@@ -1,0 +1,61 @@
+import Foundation
+import AppKit
+
+struct AppUpdateApplicationsPrereflight {
+    private let fileManager: FileManager
+    private let defaults: UserDefaults
+
+    init(
+        fileManager: FileManager = .default,
+        defaults: UserDefaults = .standard
+    ) {
+        self.fileManager = fileManager
+        self.defaults = defaults
+    }
+
+    func requiresApplicationsInstall(bundleURL: URL = Bundle.main.bundleURL) -> Bool {
+        let standardizedPath = bundleURL.standardizedFileURL.path
+        return !standardizedPath.hasPrefix("/Applications/")
+    }
+
+    func destinationURL(for bundleURL: URL = Bundle.main.bundleURL) -> URL {
+        URL(fileURLWithPath: "/Applications", isDirectory: true)
+            .appendingPathComponent(bundleURL.lastPathComponent, isDirectory: true)
+    }
+
+    func stageResumeAfterApplicationsMove() {
+        defaults.set(true, forKey: UserDefaultsKeys.App.resumeUpdaterAfterApplicationsMove)
+    }
+
+    func consumeResumeAfterApplicationsMove() -> Bool {
+        let shouldResume = defaults.bool(forKey: UserDefaultsKeys.App.resumeUpdaterAfterApplicationsMove)
+        if shouldResume {
+            defaults.removeObject(forKey: UserDefaultsKeys.App.resumeUpdaterAfterApplicationsMove)
+        }
+        return shouldResume
+    }
+
+    func moveCurrentAppToApplications(bundleURL: URL = Bundle.main.bundleURL) throws -> URL {
+        let sourceURL = bundleURL.standardizedFileURL
+        let destinationURL = destinationURL(for: sourceURL)
+        let stagingURL = destinationURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(destinationURL.deletingPathExtension().lastPathComponent)-staged-\(UUID().uuidString).app")
+
+        if sourceURL == destinationURL {
+            return destinationURL
+        }
+
+        if fileManager.fileExists(atPath: stagingURL.path) {
+            try fileManager.removeItem(at: stagingURL)
+        }
+        try fileManager.copyItem(at: sourceURL, to: stagingURL)
+
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+
+        try fileManager.moveItem(at: stagingURL, to: destinationURL)
+        return destinationURL
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdateArchiveExtractor.swift
+++ b/Core/Services/AppUpdate/AppUpdateArchiveExtractor.swift
@@ -13,13 +13,34 @@ struct AppUpdateArchiveExtractor {
         }
         try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
 
+        let stderrPipe = Pipe()
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
         process.arguments = ["-x", "-k", zipURL.path, destinationURL.path]
+        process.standardError = stderrPipe
         try process.run()
-        process.waitUntilExit()
 
-        guard process.terminationStatus == 0 else {
+        let deadline = Date().addingTimeInterval(30)
+        var didTimeOut = false
+        while process.isRunning && Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+
+        if process.isRunning {
+            didTimeOut = true
+            process.terminate()
+        }
+
+        process.waitUntilExit()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrOutput = String(data: stderrData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !didTimeOut, process.terminationStatus == 0 else {
+            #if DEBUG
+            let diagnostic = didTimeOut ? "ditto timed out after 30s" : (stderrOutput?.isEmpty == false ? stderrOutput! : "ditto exited with status \(process.terminationStatus)")
+            print("[AppUpdateArchiveExtractor] \(diagnostic)")
+            #endif
             throw AppUpdateError.extractionFailed
         }
     }

--- a/Core/Services/AppUpdate/AppUpdateArchiveExtractor.swift
+++ b/Core/Services/AppUpdate/AppUpdateArchiveExtractor.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct AppUpdateArchiveExtractor {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func extract(zipURL: URL, to destinationURL: URL) throws {
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+        try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/ditto")
+        process.arguments = ["-x", "-k", zipURL.path, destinationURL.path]
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw AppUpdateError.extractionFailed
+        }
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdateBundleVerifier.swift
+++ b/Core/Services/AppUpdate/AppUpdateBundleVerifier.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+struct AppUpdateBundleVerifier {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func verifyExtractedApp(
+        in directoryURL: URL,
+        expectedBundleIdentifier: String,
+        expectedVersion: String
+    ) throws -> URL {
+        let appURL = try locateAppBundle(in: directoryURL)
+        guard let bundle = Bundle(url: appURL) else {
+            throw AppUpdateError.invalidBundle
+        }
+
+        let bundleIdentifier = bundle.bundleIdentifier ?? ""
+        guard bundleIdentifier == expectedBundleIdentifier else {
+            throw AppUpdateError.bundleIdentifierMismatch
+        }
+
+        let version = (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) ?? ""
+        let normalizedVersion = AppUpdateLogic.normalizeVersionTag(version)
+        guard normalizedVersion == expectedVersion else {
+            throw AppUpdateError.versionMismatch
+        }
+
+        try verifyCodesign(at: appURL)
+        try verifyGatekeeper(at: appURL)
+        return appURL
+    }
+
+    private func locateAppBundle(in directoryURL: URL) throws -> URL {
+        guard let enumerator = fileManager.enumerator(
+            at: directoryURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            throw AppUpdateError.invalidBundle
+        }
+
+        for case let candidate as URL in enumerator {
+            if candidate.pathExtension == "app" {
+                return candidate
+            }
+        }
+
+        throw AppUpdateError.invalidBundle
+    }
+
+    private func verifyCodesign(at appURL: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+        process.arguments = ["--verify", "--deep", "--strict", appURL.path]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw AppUpdateError.signatureVerificationFailed
+        }
+    }
+
+    private func verifyGatekeeper(at appURL: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/spctl")
+        process.arguments = ["-a", "-t", "exec", appURL.path]
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw AppUpdateError.signatureVerificationFailed
+        }
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdateBundleVerifier.swift
+++ b/Core/Services/AppUpdate/AppUpdateBundleVerifier.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Security
 
 struct AppUpdateBundleVerifier {
     private let fileManager: FileManager
@@ -60,6 +61,8 @@ struct AppUpdateBundleVerifier {
         guard process.terminationStatus == 0 else {
             throw AppUpdateError.signatureVerificationFailed
         }
+
+        try verifySigningIdentity(at: appURL)
     }
 
     private func verifyGatekeeper(at appURL: URL) throws {
@@ -71,5 +74,48 @@ struct AppUpdateBundleVerifier {
         guard process.terminationStatus == 0 else {
             throw AppUpdateError.signatureVerificationFailed
         }
+    }
+
+    private func verifySigningIdentity(at appURL: URL) throws {
+        var currentCode: SecStaticCode?
+        var candidateCode: SecStaticCode?
+
+        let currentStatus = SecStaticCodeCreateWithPath(Bundle.main.bundleURL as CFURL, [], &currentCode)
+        let candidateStatus = SecStaticCodeCreateWithPath(appURL as CFURL, [], &candidateCode)
+
+        guard currentStatus == errSecSuccess,
+              candidateStatus == errSecSuccess,
+              let currentCode,
+              let candidateCode else {
+            throw AppUpdateError.signatureVerificationFailed
+        }
+
+        // Team ID matching is intentional here: it keeps updates pinned to the
+        // same Apple developer team without rejecting valid builds that differ
+        // in profile-specific designated requirement details.
+        let currentTeamIdentifier = try teamIdentifier(for: currentCode)
+        let candidateTeamIdentifier = try teamIdentifier(for: candidateCode)
+
+        guard currentTeamIdentifier == candidateTeamIdentifier else {
+            throw AppUpdateError.signatureVerificationFailed
+        }
+    }
+
+    private func teamIdentifier(for code: SecStaticCode) throws -> String {
+        var signingInformation: CFDictionary?
+        let status = SecCodeCopySigningInformation(
+            code,
+            SecCSFlags(rawValue: kSecCSSigningInformation),
+            &signingInformation
+        )
+
+        guard status == errSecSuccess,
+              let info = signingInformation as? [String: Any],
+              let teamIdentifier = info[kSecCodeInfoTeamIdentifier as String] as? String,
+              !teamIdentifier.isEmpty else {
+            throw AppUpdateError.signatureVerificationFailed
+        }
+
+        return teamIdentifier
     }
 }

--- a/Core/Services/AppUpdate/AppUpdateChecksumVerifier.swift
+++ b/Core/Services/AppUpdate/AppUpdateChecksumVerifier.swift
@@ -1,0 +1,13 @@
+import Foundation
+import CryptoKit
+
+struct AppUpdateChecksumVerifier {
+    func verify(fileURL: URL, expectedSHA256: String) throws {
+        let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+        let digest = SHA256.hash(data: data)
+        let hash = digest.map { String(format: "%02x", $0) }.joined()
+        guard hash == expectedSHA256.lowercased() else {
+            throw AppUpdateError.checksumMismatch
+        }
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdateCleanupService.swift
+++ b/Core/Services/AppUpdate/AppUpdateCleanupService.swift
@@ -14,7 +14,26 @@ struct AppUpdateCleanupService {
 
     func cleanupStaleArtifacts() {
         let updatesURL = paths.updatesDirectoryURL
-        guard fileManager.fileExists(atPath: updatesURL.path) else { return }
-        try? fileManager.removeItem(at: updatesURL)
+        if fileManager.fileExists(atPath: updatesURL.path) {
+            try? fileManager.removeItem(at: updatesURL)
+        }
+        cleanupBackupBundles()
+    }
+
+    private func cleanupBackupBundles(bundleURL: URL = Bundle.main.bundleURL) {
+        let parentURL = bundleURL.deletingLastPathComponent()
+        let backupPrefix = "\(bundleURL.lastPathComponent).backup."
+
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: parentURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+
+        for candidate in contents where candidate.lastPathComponent.hasPrefix(backupPrefix) {
+            try? fileManager.removeItem(at: candidate)
+        }
     }
 }

--- a/Core/Services/AppUpdate/AppUpdateCleanupService.swift
+++ b/Core/Services/AppUpdate/AppUpdateCleanupService.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct AppUpdateCleanupService {
+    private let fileManager: FileManager
+    private let paths: AppUpdatePaths
+
+    init(
+        fileManager: FileManager = .default,
+        paths: AppUpdatePaths = AppUpdatePaths()
+    ) {
+        self.fileManager = fileManager
+        self.paths = paths
+    }
+
+    func cleanupStaleArtifacts() {
+        let updatesURL = paths.updatesDirectoryURL
+        guard fileManager.fileExists(atPath: updatesURL.path) else { return }
+        try? fileManager.removeItem(at: updatesURL)
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdateCoordinator.swift
+++ b/Core/Services/AppUpdate/AppUpdateCoordinator.swift
@@ -1,0 +1,363 @@
+import AppKit
+import Combine
+import Foundation
+
+enum AppUpdateError: LocalizedError {
+    case networkUnavailable
+    case applicationsMoveFailed
+    case checksumMismatch
+    case extractionFailed
+    case invalidBundle
+    case bundleIdentifierMismatch
+    case versionMismatch
+    case signatureVerificationFailed
+    case releaseUnavailable
+    case missingInstallAsset
+    case missingInstallerScript
+
+    var errorDescription: String? {
+        switch self {
+        case .networkUnavailable:
+            return "Updates are temporarily unavailable."
+        case .applicationsMoveFailed:
+            return "KeyVox could not move itself into Applications."
+        case .checksumMismatch:
+            return "The downloaded update did not match the expected checksum."
+        case .extractionFailed:
+            return "KeyVox could not unpack the update archive."
+        case .invalidBundle:
+            return "The downloaded update bundle was not valid."
+        case .bundleIdentifierMismatch:
+            return "The downloaded update did not match this app."
+        case .versionMismatch:
+            return "The downloaded update version did not match the release metadata."
+        case .signatureVerificationFailed:
+            return "The downloaded update could not be verified by macOS."
+        case .releaseUnavailable:
+            return "No update release is available right now."
+        case .missingInstallAsset:
+            return "This release is only available as a manual download."
+        case .missingInstallerScript:
+            return "The updater script could not be found in the app bundle."
+        }
+    }
+}
+
+@MainActor
+final class AppUpdateCoordinator: ObservableObject {
+    static let shared = AppUpdateCoordinator()
+
+    @Published private(set) var state: AppUpdateState = .idle
+    @Published private(set) var releaseInfo: AppReleaseInfo?
+    @Published private(set) var progress: Double = 0
+    @Published private(set) var downloadedBytes: Int64 = 0
+    @Published private(set) var totalBytes: Int64 = 0
+    @Published private(set) var statusMessage: String = "Check for updates to begin."
+    @Published private(set) var failureMessage: String?
+    @Published private(set) var currentVersion: String
+    @Published private(set) var targetVersion: String?
+    @Published private(set) var releaseNotesPreview: String = ""
+    @Published private(set) var postUpdateNoticeVersion: String?
+
+    private let service: AppUpdateService
+    private let manifestLoader: AppUpdateManifestLoader
+    private let downloadService: AppUpdateDownloadService
+    private let checksumVerifier: AppUpdateChecksumVerifier
+    private let archiveExtractor: AppUpdateArchiveExtractor
+    private let bundleVerifier: AppUpdateBundleVerifier
+    private let installLauncher: AppUpdateInstallLauncher
+    private let applicationsPrereflight: AppUpdateApplicationsPrereflight
+    private let cleanupService: AppUpdateCleanupService
+    private let noticeService: AppUpdateLaunchNoticeService
+    private let paths: AppUpdatePaths
+    private let fileManager: FileManager
+    private var isResumingInstallAfterApplicationsMove = false
+
+    init(bundle: Bundle = .main) {
+        self.service = AppUpdateService.shared
+        self.manifestLoader = AppUpdateManifestLoader(session: .shared)
+        self.downloadService = AppUpdateDownloadService(fileManager: .default)
+        self.checksumVerifier = AppUpdateChecksumVerifier()
+        self.archiveExtractor = AppUpdateArchiveExtractor(fileManager: .default)
+        self.bundleVerifier = AppUpdateBundleVerifier(fileManager: .default)
+        self.installLauncher = AppUpdateInstallLauncher(noticeService: AppUpdateLaunchNoticeService(bundle: bundle))
+        self.applicationsPrereflight = AppUpdateApplicationsPrereflight()
+        self.cleanupService = AppUpdateCleanupService(fileManager: .default, paths: AppUpdatePaths())
+        self.noticeService = AppUpdateLaunchNoticeService(bundle: bundle)
+        self.paths = AppUpdatePaths()
+        self.fileManager = .default
+        self.currentVersion = AppUpdateLogic.normalizeVersionTag(
+            (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "Unknown"
+        )
+    }
+
+    func prepareForLaunch() {
+        cleanupService.cleanupStaleArtifacts()
+        postUpdateNoticeVersion = noticeService.consumePendingNoticeVersionIfNeeded()
+        if applicationsPrereflight.consumeResumeAfterApplicationsMove() {
+            service.suppressNextAutomaticUpdatePrompt()
+            WindowManager.shared.openUpdateWindow()
+            Task {
+                await resumeInstallAfterApplicationsMove()
+            }
+        }
+    }
+
+    func openWindowForManualCheck() {
+        WindowManager.shared.openUpdateWindow()
+        Task {
+            await refreshRelease(userInitiated: true)
+        }
+    }
+
+    func openWindow(for releaseInfo: AppReleaseInfo?) {
+        WindowManager.shared.openUpdateWindow()
+        if let releaseInfo {
+            applyReleaseInfo(releaseInfo, userInitiated: false)
+        } else {
+            Task {
+                await refreshRelease(userInitiated: true)
+            }
+        }
+    }
+
+    func dismissPostUpdateNotice() {
+        guard let version = postUpdateNoticeVersion else { return }
+        noticeService.acknowledge(version: version)
+        postUpdateNoticeVersion = nil
+        WindowManager.shared.hidePostUpdateNoticeWindow()
+    }
+
+    func primaryAction() {
+        switch state {
+        case .available:
+            Task {
+                await installAvailableRelease()
+            }
+        case .manualOnly:
+            openReleasePage()
+        case .requiresApplicationsInstall:
+            moveToApplicationsAndResumeUpdater()
+        case .failed, .completed, .idle:
+            Task {
+                await refreshRelease(userInitiated: true)
+            }
+        default:
+            break
+        }
+    }
+
+    func secondaryAction() {
+        switch state {
+        case .available, .manualOnly, .failed, .completed, .requiresApplicationsInstall:
+            WindowManager.shared.hideUpdateWindow()
+        default:
+            break
+        }
+    }
+
+    var primaryButtonTitle: String {
+        switch state {
+        case .available:
+            return "Install Update"
+        case .manualOnly:
+            return "Open Release Page"
+        case .requiresApplicationsInstall:
+            return "Move To Applications"
+        case .failed, .completed, .idle:
+            return "Check Again"
+        case .downloading:
+            return "Downloading..."
+        case .verifyingChecksum:
+            return "Verifying..."
+        case .extracting:
+            return "Extracting..."
+        case .verifyingSignature:
+            return "Validating..."
+        case .readyToInstall:
+            return "Installing..."
+        case .installing:
+            return "Installing..."
+        case .checking:
+            return "Checking..."
+        }
+    }
+
+    var secondaryButtonTitle: String {
+        switch state {
+        case .downloading, .verifyingChecksum, .extracting, .verifyingSignature, .readyToInstall, .installing, .checking:
+            return "Close"
+        default:
+            return "Later"
+        }
+    }
+
+    var canTriggerPrimaryAction: Bool {
+        switch state {
+        case .available, .manualOnly, .requiresApplicationsInstall, .failed, .completed, .idle:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func refreshUpToDateState() {
+        state = .completed
+        targetVersion = nil
+        failureMessage = nil
+        progress = 0
+        downloadedBytes = 0
+        totalBytes = 0
+        releaseNotesPreview = "KeyVox \(currentVersion) is currently the latest version."
+        statusMessage = "You're up to date."
+    }
+
+    private func applyReleaseInfo(_ releaseInfo: AppReleaseInfo, userInitiated: Bool) {
+        self.releaseInfo = releaseInfo
+        targetVersion = releaseInfo.version
+        releaseNotesPreview = service.summarizedReleaseBodyForDisplay(releaseInfo.message)
+        failureMessage = nil
+        progress = 0
+        downloadedBytes = 0
+        totalBytes = 0
+
+        if !service.shouldOfferUpdateToCurrentVersion(releaseInfo) {
+            refreshUpToDateState()
+            return
+        }
+
+        if releaseInfo.isInstallableInApp {
+            if applicationsPrereflight.requiresApplicationsInstall() {
+                state = .requiresApplicationsInstall
+                statusMessage = "Move KeyVox to Applications to use in-app updates."
+            } else if isResumingInstallAfterApplicationsMove {
+                state = .checking
+                statusMessage = "Resuming update..."
+            } else {
+                state = .available
+                statusMessage = userInitiated ? "Update ready to install." : "A new version of KeyVox is available."
+            }
+        } else {
+            state = .manualOnly
+            statusMessage = "This release needs to be installed manually."
+        }
+    }
+
+    private func openReleasePage() {
+        guard let releasePageURL = releaseInfo?.releasePageURL else { return }
+        NSWorkspace.shared.open(releasePageURL)
+    }
+
+    private func moveToApplicationsAndResumeUpdater() {
+        do {
+            statusMessage = "Moving KeyVox to Applications..."
+            let destinationURL = try applicationsPrereflight.moveCurrentAppToApplications()
+            applicationsPrereflight.stageResumeAfterApplicationsMove()
+            NSWorkspace.shared.open(destinationURL)
+            NSApplication.shared.terminate(nil)
+        } catch {
+            state = .failed
+            statusMessage = "KeyVox could not move into Applications."
+            failureMessage = AppUpdateError.applicationsMoveFailed.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    private func refreshRelease(userInitiated: Bool) async {
+        state = .checking
+        statusMessage = "Checking for updates..."
+        failureMessage = nil
+
+        guard let releaseInfo = await service.fetchLatestReleaseInfo() else {
+            state = .failed
+            statusMessage = "Updates are temporarily unavailable."
+            failureMessage = AppUpdateError.releaseUnavailable.errorDescription
+            if !userInitiated {
+                WindowManager.shared.hideUpdateWindow()
+            }
+            return
+        }
+
+        applyReleaseInfo(releaseInfo, userInitiated: userInitiated)
+    }
+
+    private func resumeInstallAfterApplicationsMove() async {
+        isResumingInstallAfterApplicationsMove = true
+        defer { isResumingInstallAfterApplicationsMove = false }
+
+        await refreshRelease(userInitiated: true)
+
+        guard releaseInfo?.isInstallableInApp == true,
+              !applicationsPrereflight.requiresApplicationsInstall() else {
+            return
+        }
+
+        await installAvailableRelease()
+    }
+
+    private func installAvailableRelease() async {
+        guard let releaseInfo, let installAssetURL = releaseInfo.installAssetURL else {
+            state = .manualOnly
+            failureMessage = AppUpdateError.missingInstallAsset.errorDescription
+            return
+        }
+        guard let manifestAssetURL = releaseInfo.manifestAssetURL,
+              let installAssetName = releaseInfo.installAssetName else {
+            state = .manualOnly
+            failureMessage = AppUpdateError.missingInstallAsset.errorDescription
+            return
+        }
+
+        do {
+            if applicationsPrereflight.requiresApplicationsInstall() {
+                state = .requiresApplicationsInstall
+                statusMessage = "Move KeyVox to Applications to use in-app updates."
+                return
+            }
+
+            try paths.createReleaseDirectoryIfNeeded(for: releaseInfo.version)
+            let manifest = try await manifestLoader.loadManifest(from: manifestAssetURL)
+            guard manifest.assetName == installAssetName else {
+                throw AppUpdateError.missingInstallAsset
+            }
+
+            let zipURL = paths.zipURL(for: releaseInfo.version, assetName: installAssetName)
+            state = .downloading
+            statusMessage = "Downloading update..."
+            try await downloadService.download(from: installAssetURL, to: zipURL) { [weak self] written, expected in
+                DispatchQueue.main.async {
+                    guard let self else { return }
+                    self.downloadedBytes = written
+                    self.totalBytes = expected
+                    if expected > 0 {
+                        self.progress = Double(written) / Double(expected)
+                    }
+                }
+            }
+
+            state = .verifyingChecksum
+            statusMessage = "Verifying download..."
+            try checksumVerifier.verify(fileURL: zipURL, expectedSHA256: manifest.sha256)
+
+            state = .extracting
+            statusMessage = "Preparing update..."
+            let extractedURL = paths.extractedDirectoryURL(for: releaseInfo.version)
+            try archiveExtractor.extract(zipURL: zipURL, to: extractedURL)
+
+            state = .verifyingSignature
+            statusMessage = "Validating signed app..."
+            _ = try bundleVerifier.verifyExtractedApp(
+                in: extractedURL,
+                expectedBundleIdentifier: manifest.bundleIdentifier,
+                expectedVersion: releaseInfo.version
+            )
+
+            state = .readyToInstall
+            statusMessage = "Installing KeyVox..."
+            try installLauncher.launchInstall(version: releaseInfo.version, stagedZipURL: zipURL)
+        } catch {
+            state = .failed
+            statusMessage = "The update could not be installed."
+            failureMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdateCoordinator.swift
+++ b/Core/Services/AppUpdate/AppUpdateCoordinator.swift
@@ -14,6 +14,7 @@ enum AppUpdateError: LocalizedError {
     case releaseUnavailable
     case missingInstallAsset
     case missingInstallerScript
+    case installerLaunchFailed
 
     var errorDescription: String? {
         switch self {
@@ -39,6 +40,8 @@ enum AppUpdateError: LocalizedError {
             return "This release is only available as a manual download."
         case .missingInstallerScript:
             return "The updater script could not be found in the app bundle."
+        case .installerLaunchFailed:
+            return "KeyVox could not start the installer."
         }
     }
 }
@@ -74,17 +77,19 @@ final class AppUpdateCoordinator: ObservableObject {
     private var isResumingInstallAfterApplicationsMove = false
 
     init(bundle: Bundle = .main) {
+        let paths = AppUpdatePaths()
+        let noticeService = AppUpdateLaunchNoticeService(bundle: bundle)
         self.service = AppUpdateService.shared
         self.manifestLoader = AppUpdateManifestLoader(session: .shared)
         self.downloadService = AppUpdateDownloadService(fileManager: .default)
         self.checksumVerifier = AppUpdateChecksumVerifier()
         self.archiveExtractor = AppUpdateArchiveExtractor(fileManager: .default)
         self.bundleVerifier = AppUpdateBundleVerifier(fileManager: .default)
-        self.installLauncher = AppUpdateInstallLauncher(noticeService: AppUpdateLaunchNoticeService(bundle: bundle))
+        self.installLauncher = AppUpdateInstallLauncher(noticeService: noticeService)
         self.applicationsPrereflight = AppUpdateApplicationsPrereflight()
-        self.cleanupService = AppUpdateCleanupService(fileManager: .default, paths: AppUpdatePaths())
-        self.noticeService = AppUpdateLaunchNoticeService(bundle: bundle)
-        self.paths = AppUpdatePaths()
+        self.cleanupService = AppUpdateCleanupService(fileManager: .default, paths: paths)
+        self.noticeService = noticeService
+        self.paths = paths
         self.fileManager = .default
         self.currentVersion = AppUpdateLogic.normalizeVersionTag(
             (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "Unknown"

--- a/Core/Services/AppUpdate/AppUpdateCoordinator.swift
+++ b/Core/Services/AppUpdate/AppUpdateCoordinator.swift
@@ -48,6 +48,8 @@ enum AppUpdateError: LocalizedError {
 
 @MainActor
 final class AppUpdateCoordinator: ObservableObject {
+    private typealias CoordinatorOperation = @MainActor () async -> Void
+
     static let shared = AppUpdateCoordinator()
 
     @Published private(set) var state: AppUpdateState = .idle
@@ -75,6 +77,7 @@ final class AppUpdateCoordinator: ObservableObject {
     private let paths: AppUpdatePaths
     private let fileManager: FileManager
     private var isResumingInstallAfterApplicationsMove = false
+    private var isOperationInFlight = false
 
     init(bundle: Bundle = .main) {
         let paths = AppUpdatePaths()
@@ -102,26 +105,27 @@ final class AppUpdateCoordinator: ObservableObject {
         if applicationsPrereflight.consumeResumeAfterApplicationsMove() {
             service.suppressNextAutomaticUpdatePrompt()
             WindowManager.shared.openUpdateWindow()
-            Task {
-                await resumeInstallAfterApplicationsMove()
+            startTrackedOperation {
+                await self.resumeInstallAfterApplicationsMove()
             }
         }
     }
 
     func openWindowForManualCheck() {
         WindowManager.shared.openUpdateWindow()
-        Task {
-            await refreshRelease(userInitiated: true)
+        startTrackedOperation {
+            await self.refreshRelease(userInitiated: true)
         }
     }
 
     func openWindow(for releaseInfo: AppReleaseInfo?) {
         WindowManager.shared.openUpdateWindow()
+        guard !isOperationInFlight else { return }
         if let releaseInfo {
             applyReleaseInfo(releaseInfo, userInitiated: false)
         } else {
-            Task {
-                await refreshRelease(userInitiated: true)
+            startTrackedOperation {
+                await self.refreshRelease(userInitiated: true)
             }
         }
     }
@@ -136,16 +140,16 @@ final class AppUpdateCoordinator: ObservableObject {
     func primaryAction() {
         switch state {
         case .available:
-            Task {
-                await installAvailableRelease()
+            startTrackedOperation {
+                await self.installAvailableRelease()
             }
         case .manualOnly:
             openReleasePage()
         case .requiresApplicationsInstall:
             moveToApplicationsAndResumeUpdater()
         case .failed, .completed, .idle:
-            Task {
-                await refreshRelease(userInitiated: true)
+            startTrackedOperation {
+                await self.refreshRelease(userInitiated: true)
             }
         default:
             break
@@ -154,7 +158,9 @@ final class AppUpdateCoordinator: ObservableObject {
 
     func secondaryAction() {
         switch state {
-        case .available, .manualOnly, .failed, .completed, .requiresApplicationsInstall:
+        case .available, .manualOnly, .failed, .completed, .requiresApplicationsInstall,
+                .checking, .downloading, .verifyingChecksum, .extracting,
+                .verifyingSignature, .readyToInstall, .installing:
             WindowManager.shared.hideUpdateWindow()
         default:
             break
@@ -319,13 +325,18 @@ final class AppUpdateCoordinator: ObservableObject {
                 return
             }
 
-            try paths.createReleaseDirectoryIfNeeded(for: releaseInfo.version)
             let manifest = try await manifestLoader.loadManifest(from: manifestAssetURL)
             guard manifest.assetName == installAssetName else {
                 throw AppUpdateError.missingInstallAsset
             }
 
             let zipURL = paths.zipURL(for: releaseInfo.version, assetName: installAssetName)
+            let extractedURL = paths.extractedDirectoryURL(for: releaseInfo.version)
+            let paths = self.paths
+            try await runBlockingWork {
+                try paths.createReleaseDirectoryIfNeeded(for: releaseInfo.version)
+            }
+
             state = .downloading
             statusMessage = "Downloading update..."
             try await downloadService.download(from: installAssetURL, to: zipURL) { [weak self] written, expected in
@@ -341,28 +352,59 @@ final class AppUpdateCoordinator: ObservableObject {
 
             state = .verifyingChecksum
             statusMessage = "Verifying download..."
-            try checksumVerifier.verify(fileURL: zipURL, expectedSHA256: manifest.sha256)
+            let checksumVerifier = self.checksumVerifier
+            try await runBlockingWork {
+                try checksumVerifier.verify(fileURL: zipURL, expectedSHA256: manifest.sha256)
+            }
 
             state = .extracting
             statusMessage = "Preparing update..."
-            let extractedURL = paths.extractedDirectoryURL(for: releaseInfo.version)
-            try archiveExtractor.extract(zipURL: zipURL, to: extractedURL)
+            let archiveExtractor = self.archiveExtractor
+            try await runBlockingWork {
+                try archiveExtractor.extract(zipURL: zipURL, to: extractedURL)
+            }
 
             state = .verifyingSignature
             statusMessage = "Validating signed app..."
-            _ = try bundleVerifier.verifyExtractedApp(
-                in: extractedURL,
-                expectedBundleIdentifier: manifest.bundleIdentifier,
-                expectedVersion: releaseInfo.version
-            )
+            let bundleVerifier = self.bundleVerifier
+            try await runBlockingWork {
+                _ = try bundleVerifier.verifyExtractedApp(
+                    in: extractedURL,
+                    expectedBundleIdentifier: manifest.bundleIdentifier,
+                    expectedVersion: releaseInfo.version
+                )
+            }
 
             state = .readyToInstall
             statusMessage = "Installing KeyVox..."
-            try installLauncher.launchInstall(version: releaseInfo.version, stagedZipURL: zipURL)
+            try await installLauncher.launchInstall(version: releaseInfo.version, stagedZipURL: zipURL)
         } catch {
             state = .failed
             statusMessage = "The update could not be installed."
             failureMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+    }
+
+    private func startTrackedOperation(_ operation: @escaping CoordinatorOperation) {
+        guard !isOperationInFlight else { return }
+        // The coordinator intentionally serializes update work so release checks,
+        // staging, and install handoff cannot overlap and race shared state.
+        isOperationInFlight = true
+        Task { @MainActor [weak self] in
+            defer { self?.isOperationInFlight = false }
+            await operation()
+        }
+    }
+
+    private func runBlockingWork<T>(_ work: @escaping () throws -> T) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    continuation.resume(returning: try work())
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
         }
     }
 }

--- a/Core/Services/AppUpdate/AppUpdateDownloadDelegate.swift
+++ b/Core/Services/AppUpdate/AppUpdateDownloadDelegate.swift
@@ -21,7 +21,11 @@ final class AppUpdateDownloadDelegate: NSObject, URLSessionDownloadDelegate {
         didFinishDownloadingTo location: URL
     ) {
         _ = session
-        _ = downloadTask
+        if let httpResponse = downloadTask.response as? HTTPURLResponse,
+           !(200...299).contains(httpResponse.statusCode) {
+            onFinish?(.failure(AppUpdateError.networkUnavailable))
+            return
+        }
         onFinish?(.success(location))
     }
 

--- a/Core/Services/AppUpdate/AppUpdateDownloadDelegate.swift
+++ b/Core/Services/AppUpdate/AppUpdateDownloadDelegate.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+final class AppUpdateDownloadDelegate: NSObject, URLSessionDownloadDelegate {
+    var onProgress: ((Int64, Int64) -> Void)?
+    var onFinish: ((Result<URL, Error>) -> Void)?
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        _ = session
+        onProgress?(totalBytesWritten, totalBytesExpectedToWrite)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        _ = session
+        _ = downloadTask
+        onFinish?(.success(location))
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        _ = session
+        _ = task
+        guard let error else { return }
+        onFinish?(.failure(error))
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdateDownloadService.swift
+++ b/Core/Services/AppUpdate/AppUpdateDownloadService.swift
@@ -22,6 +22,8 @@ struct AppUpdateDownloadService {
 
         let configuration = URLSessionConfiguration.default
         configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.timeoutIntervalForRequest = 60
+        configuration.timeoutIntervalForResource = 60 * 30
         let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
 
         defer {

--- a/Core/Services/AppUpdate/AppUpdateDownloadService.swift
+++ b/Core/Services/AppUpdate/AppUpdateDownloadService.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+struct AppUpdateDownloadService {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    func download(
+        from url: URL,
+        to destinationURL: URL,
+        progress: @escaping @Sendable (Int64, Int64) -> Void
+    ) async throws {
+        try fileManager.createDirectory(at: destinationURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+
+        let delegate = AppUpdateDownloadDelegate()
+        delegate.onProgress = progress
+
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+
+        defer {
+            session.finishTasksAndInvalidate()
+        }
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            var hasResumed = false
+            delegate.onFinish = { result in
+                guard !hasResumed else { return }
+                hasResumed = true
+
+                switch result {
+                case .success(let location):
+                    do {
+                        try fileManager.moveItem(at: location, to: destinationURL)
+                        continuation.resume()
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+
+            let task = session.downloadTask(with: url)
+            task.resume()
+        }
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
+++ b/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
@@ -8,12 +8,13 @@ struct AppUpdateInstallLauncher {
         self.noticeService = noticeService
     }
 
+    @MainActor
     func launchInstall(
         version: String,
         stagedZipURL: URL,
         installPath: String = Bundle.main.bundleURL.path,
         bundle: Bundle = .main
-    ) throws {
+    ) async throws {
         guard let scriptPath = bundle.path(forResource: "updater", ofType: "sh") else {
             throw AppUpdateError.missingInstallerScript
         }
@@ -32,7 +33,7 @@ struct AppUpdateInstallLauncher {
 
         let deadline = Date().addingTimeInterval(1)
         while !process.isRunning && Date() < deadline {
-            Thread.sleep(forTimeInterval: 0.05)
+            try await Task.sleep(nanoseconds: 50_000_000)
         }
 
         guard process.isRunning else {

--- a/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
+++ b/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
@@ -1,0 +1,34 @@
+import AppKit
+import Foundation
+
+struct AppUpdateInstallLauncher {
+    private let noticeService: AppUpdateLaunchNoticeService
+
+    init(noticeService: AppUpdateLaunchNoticeService = AppUpdateLaunchNoticeService()) {
+        self.noticeService = noticeService
+    }
+
+    func launchInstall(
+        version: String,
+        stagedZipURL: URL,
+        installPath: String = Bundle.main.bundleURL.path,
+        bundle: Bundle = .main
+    ) throws {
+        guard let scriptPath = bundle.path(forResource: "updater", ofType: "sh") else {
+            throw AppUpdateError.missingInstallerScript
+        }
+
+        noticeService.stagePendingUpdatedVersion(version)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [
+            scriptPath,
+            String(ProcessInfo.processInfo.processIdentifier),
+            stagedZipURL.path,
+            installPath,
+        ]
+        try process.run()
+        NSApplication.shared.terminate(nil)
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
+++ b/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
@@ -43,6 +43,9 @@ struct AppUpdateInstallLauncher {
             throw AppUpdateError.installerLaunchFailed
         }
 
+        // Confirm the updater survives a brief startup window before we
+        // terminate KeyVox, so a process that launches and exits immediately
+        // does not strand the app without an installer actually running.
         let confirmationDeadline = Date().addingTimeInterval(0.2)
         while Date() < confirmationDeadline {
             if !process.isRunning {

--- a/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
+++ b/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
@@ -29,6 +29,19 @@ struct AppUpdateInstallLauncher {
             installPath,
         ]
         try process.run()
+
+        let deadline = Date().addingTimeInterval(1)
+        while !process.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+
+        guard process.isRunning else {
+            #if DEBUG
+            print("[AppUpdateInstallLauncher] updater.sh exited before install handoff completed.")
+            #endif
+            throw AppUpdateError.installerLaunchFailed
+        }
+
         NSApplication.shared.terminate(nil)
     }
 }

--- a/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
+++ b/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
@@ -31,8 +31,8 @@ struct AppUpdateInstallLauncher {
         ]
         try process.run()
 
-        let deadline = Date().addingTimeInterval(1)
-        while !process.isRunning && Date() < deadline {
+        let launchDeadline = Date().addingTimeInterval(1)
+        while !process.isRunning && Date() < launchDeadline {
             try await Task.sleep(nanoseconds: 50_000_000)
         }
 
@@ -41,6 +41,17 @@ struct AppUpdateInstallLauncher {
             print("[AppUpdateInstallLauncher] updater.sh exited before install handoff completed.")
             #endif
             throw AppUpdateError.installerLaunchFailed
+        }
+
+        let confirmationDeadline = Date().addingTimeInterval(0.2)
+        while Date() < confirmationDeadline {
+            if !process.isRunning {
+                #if DEBUG
+                print("[AppUpdateInstallLauncher] updater.sh exited during launch confirmation.")
+                #endif
+                throw AppUpdateError.installerLaunchFailed
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
         }
 
         NSApplication.shared.terminate(nil)

--- a/Core/Services/AppUpdate/AppUpdateLaunchNoticeService.swift
+++ b/Core/Services/AppUpdate/AppUpdateLaunchNoticeService.swift
@@ -24,10 +24,11 @@ struct AppUpdateLaunchNoticeService {
         guard let pendingVersion = defaults.string(forKey: UserDefaultsKeys.App.pendingUpdatedVersion) else {
             return nil
         }
+        let normalizedPendingVersion = AppUpdateLogic.normalizeVersionTag(pendingVersion)
 
-        if pendingVersion == currentVersion,
+        if normalizedPendingVersion == currentVersion,
            defaults.string(forKey: UserDefaultsKeys.App.lastAcknowledgedUpdatedVersion) != currentVersion {
-            return currentVersion
+            return normalizedPendingVersion
         }
 
         defaults.removeObject(forKey: UserDefaultsKeys.App.pendingUpdatedVersion)

--- a/Core/Services/AppUpdate/AppUpdateLaunchNoticeService.swift
+++ b/Core/Services/AppUpdate/AppUpdateLaunchNoticeService.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct AppUpdateLaunchNoticeService {
+    private let bundle: Bundle
+    private let defaults: UserDefaults
+
+    init(
+        bundle: Bundle = .main,
+        defaults: UserDefaults = .standard
+    ) {
+        self.bundle = bundle
+        self.defaults = defaults
+    }
+
+    func stagePendingUpdatedVersion(_ version: String) {
+        defaults.set(version, forKey: UserDefaultsKeys.App.pendingUpdatedVersion)
+        defaults.removeObject(forKey: UserDefaultsKeys.App.lastAcknowledgedUpdatedVersion)
+    }
+
+    func consumePendingNoticeVersionIfNeeded() -> String? {
+        let currentVersion = AppUpdateLogic.normalizeVersionTag(
+            (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) ?? ""
+        )
+        guard let pendingVersion = defaults.string(forKey: UserDefaultsKeys.App.pendingUpdatedVersion) else {
+            return nil
+        }
+
+        if pendingVersion == currentVersion,
+           defaults.string(forKey: UserDefaultsKeys.App.lastAcknowledgedUpdatedVersion) != currentVersion {
+            return currentVersion
+        }
+
+        defaults.removeObject(forKey: UserDefaultsKeys.App.pendingUpdatedVersion)
+        return nil
+    }
+
+    func acknowledge(version: String) {
+        defaults.set(version, forKey: UserDefaultsKeys.App.lastAcknowledgedUpdatedVersion)
+        defaults.removeObject(forKey: UserDefaultsKeys.App.pendingUpdatedVersion)
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdateManifestLoader.swift
+++ b/Core/Services/AppUpdate/AppUpdateManifestLoader.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct AppUpdateManifestLoader {
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func loadManifest(from url: URL) async throws -> AppUpdateManifest {
+        let (data, response) = try await session.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw AppUpdateError.networkUnavailable
+        }
+
+        let manifest = try JSONDecoder().decode(AppUpdateManifest.self, from: data)
+        let normalizedVersion = AppUpdateLogic.normalizeVersionTag(manifest.version)
+        return AppUpdateManifest(
+            version: normalizedVersion,
+            assetName: manifest.assetName,
+            sha256: manifest.sha256.lowercased(),
+            byteSize: manifest.byteSize,
+            bundleIdentifier: manifest.bundleIdentifier,
+            minimumSupportedMacOS: manifest.minimumSupportedMacOS
+        )
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdatePaths.swift
+++ b/Core/Services/AppUpdate/AppUpdatePaths.swift
@@ -25,7 +25,7 @@ struct AppUpdatePaths {
     }
 
     func releaseDirectoryURL(for version: String) -> URL {
-        updatesDirectoryURL.appendingPathComponent(version, isDirectory: true)
+        updatesDirectoryURL.appendingPathComponent(sanitizedVersion(version), isDirectory: true)
     }
 
     func zipURL(for version: String, assetName: String) -> URL {
@@ -38,5 +38,16 @@ struct AppUpdatePaths {
 
     func createReleaseDirectoryIfNeeded(for version: String) throws {
         try fileManager.createDirectory(at: releaseDirectoryURL(for: version), withIntermediateDirectories: true)
+    }
+
+    private func sanitizedVersion(_ version: String) -> String {
+        let disallowedCharacters = CharacterSet(charactersIn: "/\\:")
+        let sanitized = version
+            .components(separatedBy: disallowedCharacters)
+            .joined(separator: "")
+            .replacingOccurrences(of: "..", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return sanitized.isEmpty ? "unknown-version" : sanitized
     }
 }

--- a/Core/Services/AppUpdate/AppUpdatePaths.swift
+++ b/Core/Services/AppUpdate/AppUpdatePaths.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct AppUpdatePaths {
+    private let fileManager: FileManager
+    private let rootDirectory: URL
+
+    init(
+        fileManager: FileManager = .default,
+        rootDirectory: URL? = nil
+    ) {
+        self.fileManager = fileManager
+        if let rootDirectory {
+            self.rootDirectory = rootDirectory
+        } else {
+            let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+                ?? fileManager.temporaryDirectory
+            self.rootDirectory = appSupport
+                .appendingPathComponent("KeyVox", isDirectory: true)
+                .appendingPathComponent("Updates", isDirectory: true)
+        }
+    }
+
+    var updatesDirectoryURL: URL {
+        rootDirectory
+    }
+
+    func releaseDirectoryURL(for version: String) -> URL {
+        updatesDirectoryURL.appendingPathComponent(version, isDirectory: true)
+    }
+
+    func zipURL(for version: String, assetName: String) -> URL {
+        releaseDirectoryURL(for: version).appendingPathComponent(assetName)
+    }
+
+    func extractedDirectoryURL(for version: String) -> URL {
+        releaseDirectoryURL(for: version).appendingPathComponent("extracted", isDirectory: true)
+    }
+
+    func createReleaseDirectoryIfNeeded(for version: String) throws {
+        try fileManager.createDirectory(at: releaseDirectoryURL(for: version), withIntermediateDirectories: true)
+    }
+}

--- a/Core/Services/AppUpdate/AppUpdatePaths.swift
+++ b/Core/Services/AppUpdate/AppUpdatePaths.swift
@@ -48,6 +48,10 @@ struct AppUpdatePaths {
             .replacingOccurrences(of: "..", with: "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
-        return sanitized.isEmpty ? "unknown-version" : sanitized
+        if sanitized.isEmpty || sanitized.trimmingCharacters(in: CharacterSet(charactersIn: ".")).isEmpty {
+            return "unknown-version"
+        }
+
+        return sanitized
     }
 }

--- a/Core/Services/AppUpdate/AppUpdateState.swift
+++ b/Core/Services/AppUpdate/AppUpdateState.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum AppUpdateState: Equatable {
+    case idle
+    case checking
+    case available
+    case requiresApplicationsInstall
+    case downloading
+    case verifyingChecksum
+    case extracting
+    case verifyingSignature
+    case readyToInstall
+    case installing
+    case failed
+    case completed
+    case manualOnly
+}

--- a/Core/Services/AppUpdateLogic.swift
+++ b/Core/Services/AppUpdateLogic.swift
@@ -1,26 +1,43 @@
 import Foundation
 
 enum AppUpdateLogic {
+    static let manifestAssetName = "keyvox-update-manifest.json"
+
     static func mapReleaseInfo(
         from release: GitHubLatestReleaseResponse,
         allowedHosts: [String]
-    ) -> LatestReleaseInfo? {
+    ) -> AppReleaseInfo? {
         let normalizedVersion = normalizeVersionTag(release.tagName)
         guard !normalizedVersion.isEmpty else { return nil }
 
-        let selectedDownloadURL: URL? = release.assets.first(where: { asset in
-            asset.name.lowercased().hasSuffix(".dmg")
-        }).flatMap { URL(string: $0.browserDownloadURL) } ?? URL(string: release.htmlURL)
-
-        guard let selectedDownloadURL,
-              hasAllowedHost(selectedDownloadURL, allowedHosts: allowedHosts) else {
+        guard let releasePageURL = URL(string: release.htmlURL),
+              hasAllowedHost(releasePageURL, allowedHosts: allowedHosts) else {
             return nil
         }
 
-        return LatestReleaseInfo(
+        let zipAsset = release.assets.first(where: { asset in
+            asset.name.lowercased().hasSuffix(".zip")
+        })
+        let manifestAsset = release.assets.first(where: { asset in
+            asset.name == manifestAssetName
+        })
+
+        let installAssetURL = zipAsset.flatMap { URL(string: $0.browserDownloadURL) }
+        let manifestAssetURL = manifestAsset.flatMap { URL(string: $0.browserDownloadURL) }
+        let hasValidInstallAssets =
+            installAssetURL != nil &&
+            manifestAssetURL != nil &&
+            installAssetURL.map { hasAllowedHost($0, allowedHosts: allowedHosts) } == true &&
+            manifestAssetURL.map { hasAllowedHost($0, allowedHosts: allowedHosts) } == true
+
+        return AppReleaseInfo(
             version: normalizedVersion,
             message: release.body,
-            updateURL: selectedDownloadURL
+            releasePageURL: releasePageURL,
+            installAssetURL: hasValidInstallAssets ? installAssetURL : nil,
+            installAssetName: hasValidInstallAssets ? zipAsset?.name : nil,
+            manifestAssetURL: hasValidInstallAssets ? manifestAssetURL : nil,
+            installAssetKind: hasValidInstallAssets ? .zip : .manualOnly
         )
     }
 

--- a/Core/Services/AppUpdateLogic.swift
+++ b/Core/Services/AppUpdateLogic.swift
@@ -15,11 +15,15 @@ enum AppUpdateLogic {
             return nil
         }
 
-        let zipAsset = release.assets.first(where: { asset in
+        let zipAssets = release.assets.filter { asset in
             asset.name.lowercased().hasSuffix(".zip")
-        })
+        }
+        // Fail closed when multiple ZIP assets are present. The manifest is
+        // loaded later in the pipeline, so release parsing only auto-installs
+        // when there is a single unambiguous ZIP candidate here.
+        let zipAsset = zipAssets.count == 1 ? zipAssets.first : nil
         let manifestAsset = release.assets.first(where: { asset in
-            asset.name == manifestAssetName
+            asset.name.caseInsensitiveCompare(manifestAssetName) == .orderedSame
         })
 
         let installAssetURL = zipAsset.flatMap { URL(string: $0.browserDownloadURL) }

--- a/Core/Services/AppUpdateService.swift
+++ b/Core/Services/AppUpdateService.swift
@@ -26,12 +26,6 @@ struct GitHubLatestReleaseResponse: Decodable {
     }
 }
 
-struct LatestReleaseInfo {
-    let version: String
-    let message: String?
-    let updateURL: URL
-}
-
 struct UpdatePrompt {
     let title: String
     let message: String
@@ -47,7 +41,7 @@ struct UpdatePrompt {
 final class AppUpdateService: ObservableObject {
     static let shared = AppUpdateService()
 
-    @Published private(set) var latestRemoteInfo: LatestReleaseInfo?
+    @Published private(set) var latestRemoteInfo: AppReleaseInfo?
 
     private enum ReleaseNotesPreview {
         static let maxLines = 4
@@ -63,6 +57,7 @@ final class AppUpdateService: ObservableObject {
     private var updateTimer: Timer?
     private var suppressedUpdateIDThisSession: String?
     private var autoPromptSnoozedUntilInSession: Date?
+    private var suppressNextAutomaticPrompt = false
 
     init(
         feedConfig: UpdateFeedConfig? = nil,
@@ -110,6 +105,18 @@ final class AppUpdateService: ObservableObject {
         }
     }
 
+    func fetchLatestReleaseInfo() async -> AppReleaseInfo? {
+        await fetchLatestVersionInfo()
+    }
+
+    func shouldOfferUpdateToCurrentVersion(_ remoteInfo: AppReleaseInfo) -> Bool {
+        shouldOfferUpdate(remoteInfo: remoteInfo)
+    }
+
+    func suppressNextAutomaticUpdatePrompt() {
+        suppressNextAutomaticPrompt = true
+    }
+
     private func restartUpdateTimerIfNeeded() {
         updateTimer?.invalidate()
         updateTimer = Timer.scheduledTimer(withTimeInterval: defaultCheckInterval, repeats: true) { [weak self] _ in
@@ -120,6 +127,11 @@ final class AppUpdateService: ObservableObject {
     }
 
     private func performUpdateCheck(isManualCheck: Bool) async {
+        if !isManualCheck, suppressNextAutomaticPrompt {
+            suppressNextAutomaticPrompt = false
+            return
+        }
+
         guard let remoteInfo = await fetchLatestVersionInfo() else {
             if isManualCheck {
                 showUnavailableUpdatePrompt()
@@ -132,7 +144,7 @@ final class AppUpdateService: ObservableObject {
             }
             return
         }
-        let updateID = "\(remoteInfo.version)+\(remoteInfo.updateURL.absoluteString)"
+        let updateID = "\(remoteInfo.version)+\(remoteInfo.releasePageURL.absoluteString)"
         let cooldown = max(defaultCheckInterval, 1)
 
         // If user pressed "Later", suppress repeats for this app session.
@@ -152,10 +164,10 @@ final class AppUpdateService: ObservableObject {
         promptPresenter.show(prompt: prompt)
     }
 
-    private func buildPrompt(from remoteInfo: LatestReleaseInfo, updateID: String, cooldown: TimeInterval) -> UpdatePrompt? {
-        guard AppUpdateLogic.hasAllowedHost(remoteInfo.updateURL, allowedHosts: feedConfig.allowedHosts) else {
+    private func buildPrompt(from remoteInfo: AppReleaseInfo, updateID: String, cooldown: TimeInterval) -> UpdatePrompt? {
+        guard AppUpdateLogic.hasAllowedHost(remoteInfo.releasePageURL, allowedHosts: feedConfig.allowedHosts) else {
             #if DEBUG
-            print("[AppUpdateService] Ignoring update URL outside allowlist: \(remoteInfo.updateURL.absoluteString)")
+            print("[AppUpdateService] Ignoring update URL outside allowlist: \(remoteInfo.releasePageURL.absoluteString)")
             #endif
             return nil
         }
@@ -174,9 +186,9 @@ final class AppUpdateService: ObservableObject {
             version: remoteInfo.version,
             build: nil,
             dismissButtonTitle: "Later",
-            primaryButtonTitle: "Download Update",
+            primaryButtonTitle: "Open Updater",
             onPrimaryAction: { [weak self] in
-                NSWorkspace.shared.open(remoteInfo.updateURL)
+                AppUpdateCoordinator.shared.openWindow(for: remoteInfo)
                 self?.snoozeAutoPrompt(for: cooldown, updateID: updateID)
             },
             onDismiss: { [weak self] in
@@ -225,7 +237,7 @@ final class AppUpdateService: ObservableObject {
         suppressedUpdateIDThisSession = updateID
     }
 
-    private func fetchLatestVersionInfo() async -> LatestReleaseInfo? {
+    private func fetchLatestVersionInfo() async -> AppReleaseInfo? {
         do {
             var request = URLRequest(url: feedConfig.latestReleaseURL)
             request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
@@ -259,13 +271,20 @@ final class AppUpdateService: ObservableObject {
         }
     }
 
-    private func shouldOfferUpdate(remoteInfo: LatestReleaseInfo) -> Bool {
+    private func shouldOfferUpdate(remoteInfo: AppReleaseInfo) -> Bool {
         guard let localVersion = bundle.infoDictionary?["CFBundleShortVersionString"] as? String else {
             return false
         }
 
         let normalizedLocalVersion = AppUpdateLogic.normalizeVersionTag(localVersion)
         return AppUpdateLogic.compareVersionStrings(remoteInfo.version, normalizedLocalVersion) > 0
+    }
+
+    func summarizedReleaseBodyForDisplay(_ body: String?) -> String {
+        guard let body else {
+            return "A new version of KeyVox is available."
+        }
+        return summarizedReleaseBody(body) ?? "A new version of KeyVox is available."
     }
 
     private func summarizedReleaseBody(_ body: String) -> String? {

--- a/KeyVox.xcodeproj/project.pbxproj
+++ b/KeyVox.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		8E6D05E12F3C5246003BD458 /* KeyboardMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6D05CC2F3C51D6003BD458 /* KeyboardMonitor.swift */; };
 		8E6D05E22F3C5246003BD458 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6D05CB2F3C51D6003BD458 /* AudioRecorder.swift */; };
 		8E6D05E42F3C524B003BD458 /* UIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6D05D52F3C51D6003BD458 /* UIComponents.swift */; };
+		8E70C6ED2F623AFA00E9E555 /* updater.sh in Resources */ = {isa = PBXBuildFile; fileRef = 8E70C6EC2F623AFA00E9E555 /* updater.sh */; };
 		8E927F652F3C532800C071B3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8E6D05D02F3C51D6003BD458 /* Assets.xcassets */; };
 		8E927F662F3C532D00C071B3 /* Kanit-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8E6D05D12F3C51D6003BD458 /* Kanit-Medium.ttf */; };
 		8E927F672F3C533300C071B3 /* keyvox.icon in Resources */ = {isa = PBXBuildFile; fileRef = 8E6D05D22F3C51D6003BD458 /* keyvox.icon */; };
@@ -118,6 +119,32 @@
 		F20000022FB0000100AA0001 /* AudioIndicatorDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20000012FB0000100AA0001 /* AudioIndicatorDriver.swift */; };
 		F20000042FB0000100AA0001 /* LogoBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20000032FB0000100AA0001 /* LogoBarView.swift */; };
 		F20000062FB0000100AA0001 /* AudioIndicatorDriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20000052FB0000100AA0001 /* AudioIndicatorDriverTests.swift */; };
+		F30000022FC2000100AA0001 /* WindowManager+Updates.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000012FC2000100AA0001 /* WindowManager+Updates.swift */; };
+		F30000042FC2000100AA0001 /* AppUpdateProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000032FC2000100AA0001 /* AppUpdateProgressBar.swift */; };
+		F30000072FC2000100AA0001 /* AppReleaseInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000062FC2000100AA0001 /* AppReleaseInfo.swift */; };
+		F30000092FC2000100AA0001 /* AppUpdateManifestLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000082FC2000100AA0001 /* AppUpdateManifestLoader.swift */; };
+		F300000B2FC2000100AA0001 /* AppUpdateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F300000A2FC2000100AA0001 /* AppUpdateCoordinator.swift */; };
+		F300000D2FC2000100AA0001 /* AppUpdateState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F300000C2FC2000100AA0001 /* AppUpdateState.swift */; };
+		F300000F2FC2000100AA0001 /* AppUpdatePaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = F300000E2FC2000100AA0001 /* AppUpdatePaths.swift */; };
+		F30000112FC2000100AA0001 /* AppUpdateDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000102FC2000100AA0001 /* AppUpdateDownloadService.swift */; };
+		F30000132FC2000100AA0001 /* AppUpdateDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000122FC2000100AA0001 /* AppUpdateDownloadDelegate.swift */; };
+		F30000152FC2000100AA0001 /* AppUpdateChecksumVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000142FC2000100AA0001 /* AppUpdateChecksumVerifier.swift */; };
+		F30000172FC2000100AA0001 /* AppUpdateArchiveExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000162FC2000100AA0001 /* AppUpdateArchiveExtractor.swift */; };
+		F30000192FC2000100AA0001 /* AppUpdateBundleVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000182FC2000100AA0001 /* AppUpdateBundleVerifier.swift */; };
+		F300001B2FC2000100AA0001 /* AppUpdateInstallLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F300001A2FC2000100AA0001 /* AppUpdateInstallLauncher.swift */; };
+		F300001D2FC2000100AA0001 /* AppUpdateApplicationsPrereflight.swift in Sources */ = {isa = PBXBuildFile; fileRef = F300001C2FC2000100AA0001 /* AppUpdateApplicationsPrereflight.swift */; };
+		F300001F2FC2000100AA0001 /* AppUpdateLaunchNoticeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F300001E2FC2000100AA0001 /* AppUpdateLaunchNoticeService.swift */; };
+		F30000212FC2000100AA0001 /* AppUpdateCleanupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000202FC2000100AA0001 /* AppUpdateCleanupService.swift */; };
+		F30000242FC2000100AA0001 /* UpdateWindowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000232FC2000100AA0001 /* UpdateWindowView.swift */; };
+		F30000262FC2000100AA0001 /* UpdateHeaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000252FC2000100AA0001 /* UpdateHeaderCard.swift */; };
+		F30000282FC2000100AA0001 /* UpdateReleaseNotesCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000272FC2000100AA0001 /* UpdateReleaseNotesCard.swift */; };
+		F300002A2FC2000100AA0001 /* UpdateProgressCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000292FC2000100AA0001 /* UpdateProgressCard.swift */; };
+		F300002C2FC2000100AA0001 /* UpdateApplicationsRequirementCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F300002B2FC2000100AA0001 /* UpdateApplicationsRequirementCard.swift */; };
+		F300002E2FC2000100AA0001 /* UpdateFailureCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F300002D2FC2000100AA0001 /* UpdateFailureCard.swift */; };
+		F30000302FC2000100AA0001 /* PostUpdateNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F300002F2FC2000100AA0001 /* PostUpdateNoticeView.swift */; };
+		F30000322FC2000100AA0001 /* AppUpdateChecksumVerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000312FC2000100AA0001 /* AppUpdateChecksumVerifierTests.swift */; };
+		F30000342FC2000100AA0001 /* AppUpdateLaunchNoticeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000332FC2000100AA0001 /* AppUpdateLaunchNoticeServiceTests.swift */; };
+		F30000362FC2000100AA0001 /* AppUpdateApplicationsPrereflightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000352FC2000100AA0001 /* AppUpdateApplicationsPrereflightTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -154,6 +181,7 @@
 		8E6D05D72F3C51D6003BD458 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		8E6D05D82F3C51D6003BD458 /* RecordingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingOverlay.swift; sourceTree = "<group>"; };
 		8E6D05DA2F3C51D6003BD458 /* StatusMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusMenuView.swift; sourceTree = "<group>"; };
+		8E70C6EC2F623AFA00E9E555 /* updater.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = updater.sh; sourceTree = "<group>"; };
 		8E927F6A2F3C7AA000C071B3 /* Credits.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
 		8E927F6C2F3C7EA600C071B3 /* KeyVox.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KeyVox.entitlements; sourceTree = "<group>"; };
 		8E9E38252F5BBA5400EAFA72 /* AudioRecorderStopRecordingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderStopRecordingTests.swift; sourceTree = "<group>"; };
@@ -242,6 +270,32 @@
 		F20000012FB0000100AA0001 /* AudioIndicatorDriver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioIndicatorDriver.swift; sourceTree = "<group>"; };
 		F20000032FB0000100AA0001 /* LogoBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoBarView.swift; sourceTree = "<group>"; };
 		F20000052FB0000100AA0001 /* AudioIndicatorDriverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioIndicatorDriverTests.swift; sourceTree = "<group>"; };
+		F30000012FC2000100AA0001 /* WindowManager+Updates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WindowManager+Updates.swift"; sourceTree = "<group>"; };
+		F30000032FC2000100AA0001 /* AppUpdateProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateProgressBar.swift; sourceTree = "<group>"; };
+		F30000062FC2000100AA0001 /* AppReleaseInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppReleaseInfo.swift; sourceTree = "<group>"; };
+		F30000082FC2000100AA0001 /* AppUpdateManifestLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateManifestLoader.swift; sourceTree = "<group>"; };
+		F300000A2FC2000100AA0001 /* AppUpdateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateCoordinator.swift; sourceTree = "<group>"; };
+		F300000C2FC2000100AA0001 /* AppUpdateState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateState.swift; sourceTree = "<group>"; };
+		F300000E2FC2000100AA0001 /* AppUpdatePaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdatePaths.swift; sourceTree = "<group>"; };
+		F30000102FC2000100AA0001 /* AppUpdateDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateDownloadService.swift; sourceTree = "<group>"; };
+		F30000122FC2000100AA0001 /* AppUpdateDownloadDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateDownloadDelegate.swift; sourceTree = "<group>"; };
+		F30000142FC2000100AA0001 /* AppUpdateChecksumVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateChecksumVerifier.swift; sourceTree = "<group>"; };
+		F30000162FC2000100AA0001 /* AppUpdateArchiveExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateArchiveExtractor.swift; sourceTree = "<group>"; };
+		F30000182FC2000100AA0001 /* AppUpdateBundleVerifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateBundleVerifier.swift; sourceTree = "<group>"; };
+		F300001A2FC2000100AA0001 /* AppUpdateInstallLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateInstallLauncher.swift; sourceTree = "<group>"; };
+		F300001C2FC2000100AA0001 /* AppUpdateApplicationsPrereflight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateApplicationsPrereflight.swift; sourceTree = "<group>"; };
+		F300001E2FC2000100AA0001 /* AppUpdateLaunchNoticeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateLaunchNoticeService.swift; sourceTree = "<group>"; };
+		F30000202FC2000100AA0001 /* AppUpdateCleanupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateCleanupService.swift; sourceTree = "<group>"; };
+		F30000232FC2000100AA0001 /* UpdateWindowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateWindowView.swift; sourceTree = "<group>"; };
+		F30000252FC2000100AA0001 /* UpdateHeaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateHeaderCard.swift; sourceTree = "<group>"; };
+		F30000272FC2000100AA0001 /* UpdateReleaseNotesCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateReleaseNotesCard.swift; sourceTree = "<group>"; };
+		F30000292FC2000100AA0001 /* UpdateProgressCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProgressCard.swift; sourceTree = "<group>"; };
+		F300002B2FC2000100AA0001 /* UpdateApplicationsRequirementCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateApplicationsRequirementCard.swift; sourceTree = "<group>"; };
+		F300002D2FC2000100AA0001 /* UpdateFailureCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateFailureCard.swift; sourceTree = "<group>"; };
+		F300002F2FC2000100AA0001 /* PostUpdateNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUpdateNoticeView.swift; sourceTree = "<group>"; };
+		F30000312FC2000100AA0001 /* AppUpdateChecksumVerifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateChecksumVerifierTests.swift; sourceTree = "<group>"; };
+		F30000332FC2000100AA0001 /* AppUpdateLaunchNoticeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateLaunchNoticeServiceTests.swift; sourceTree = "<group>"; };
+		F30000352FC2000100AA0001 /* AppUpdateApplicationsPrereflightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateApplicationsPrereflightTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -292,6 +346,7 @@
 				D15000012FA1000100AA0001 /* LoginItemController.swift */,
 				A11000112FC1000100AA0001 /* WeeklyWordStatsStore.swift */,
 				8E6D05C42F3C51C9003BD458 /* KeyVoxApp.swift */,
+				F30000012FC2000100AA0001 /* WindowManager+Updates.swift */,
 				8E57FB892F3C9B6100935A26 /* UserDefaultsKeys.swift */,
 			);
 			path = App;
@@ -300,6 +355,7 @@
 		8E6D05CA2F3C51D6003BD458 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				F30000052FC2000100AA0001 /* AppUpdate */,
 				8F5501022F47010000EE5501 /* AppUpdateLogic.swift */,
 				8EE6025E2F3FC5C80094EC16 /* AppUpdateService.swift */,
 				9A1000012F4B000100AA0001 /* Paste */,
@@ -326,6 +382,7 @@
 		8E6D05D32F3C51D6003BD458 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				8E70C6EC2F623AFA00E9E555 /* updater.sh */,
 				8E927F6C2F3C7EA600C071B3 /* KeyVox.entitlements */,
 				8E927F6A2F3C7AA000C071B3 /* Credits.rtf */,
 				AA1000012F50000100AA0001 /* OFL.txt */,
@@ -341,6 +398,7 @@
 		8E6D05D62F3C51D6003BD458 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				F30000032FC2000100AA0001 /* AppUpdateProgressBar.swift */,
 				8F2201072F44010000BB2201 /* ConfirmDeletePromptView.swift */,
 				F20000032FB0000100AA0001 /* LogoBarView.swift */,
 				BF2000022F70000100AA0001 /* OnboardingMicrophonePickerView.swift */,
@@ -354,6 +412,7 @@
 			children = (
 				8E57FB9B2F3E444B00935A26 /* Settings */,
 				8E6D05D62F3C51D6003BD458 /* Components */,
+				F30000222FC2000100AA0001 /* Updates */,
 				8EC700212F42000100C70001 /* Warnings */,
 				8E6D05D72F3C51D6003BD458 /* OnboardingView.swift */,
 				BF2000012F70000100AA0001 /* OnboardingMicrophoneStepController.swift */,
@@ -483,6 +542,9 @@
 		AB1000062F60000100AA0001 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				F30000352FC2000100AA0001 /* AppUpdateApplicationsPrereflightTests.swift */,
+				F30000312FC2000100AA0001 /* AppUpdateChecksumVerifierTests.swift */,
+				F30000332FC2000100AA0001 /* AppUpdateLaunchNoticeServiceTests.swift */,
 				8E03671B2F49848500017017 /* PasteServiceExecutionMocks.swift */,
 				AB2000152F60000100AA0001 /* AppUpdateLogicTests.swift */,
 				AB2000182F60000100AA0001 /* AppUpdateServiceTests.swift */,
@@ -606,6 +668,41 @@
 			path = iCloud;
 			sourceTree = "<group>";
 		};
+		F30000052FC2000100AA0001 /* AppUpdate */ = {
+			isa = PBXGroup;
+			children = (
+				F30000062FC2000100AA0001 /* AppReleaseInfo.swift */,
+				F300000A2FC2000100AA0001 /* AppUpdateCoordinator.swift */,
+				F30000202FC2000100AA0001 /* AppUpdateCleanupService.swift */,
+				F30000142FC2000100AA0001 /* AppUpdateChecksumVerifier.swift */,
+				F300001C2FC2000100AA0001 /* AppUpdateApplicationsPrereflight.swift */,
+				F30000162FC2000100AA0001 /* AppUpdateArchiveExtractor.swift */,
+				F30000182FC2000100AA0001 /* AppUpdateBundleVerifier.swift */,
+				F30000122FC2000100AA0001 /* AppUpdateDownloadDelegate.swift */,
+				F30000102FC2000100AA0001 /* AppUpdateDownloadService.swift */,
+				F300001A2FC2000100AA0001 /* AppUpdateInstallLauncher.swift */,
+				F300001E2FC2000100AA0001 /* AppUpdateLaunchNoticeService.swift */,
+				F30000082FC2000100AA0001 /* AppUpdateManifestLoader.swift */,
+				F300000E2FC2000100AA0001 /* AppUpdatePaths.swift */,
+				F300000C2FC2000100AA0001 /* AppUpdateState.swift */,
+			);
+			path = AppUpdate;
+			sourceTree = "<group>";
+		};
+		F30000222FC2000100AA0001 /* Updates */ = {
+			isa = PBXGroup;
+			children = (
+				F300002F2FC2000100AA0001 /* PostUpdateNoticeView.swift */,
+				F300002B2FC2000100AA0001 /* UpdateApplicationsRequirementCard.swift */,
+				F300002D2FC2000100AA0001 /* UpdateFailureCard.swift */,
+				F30000252FC2000100AA0001 /* UpdateHeaderCard.swift */,
+				F30000292FC2000100AA0001 /* UpdateProgressCard.swift */,
+				F30000272FC2000100AA0001 /* UpdateReleaseNotesCard.swift */,
+				F30000232FC2000100AA0001 /* UpdateWindowView.swift */,
+			);
+			path = Updates;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -698,6 +795,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8E70C6ED2F623AFA00E9E555 /* updater.sh in Resources */,
 				8E927F652F3C532800C071B3 /* Assets.xcassets in Resources */,
 				8E927F662F3C532D00C071B3 /* Kanit-Medium.ttf in Resources */,
 				8E927F672F3C533300C071B3 /* keyvox.icon in Resources */,
@@ -724,6 +822,29 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F30000042FC2000100AA0001 /* AppUpdateProgressBar.swift in Sources */,
+				F30000072FC2000100AA0001 /* AppReleaseInfo.swift in Sources */,
+				F30000092FC2000100AA0001 /* AppUpdateManifestLoader.swift in Sources */,
+				F300000B2FC2000100AA0001 /* AppUpdateCoordinator.swift in Sources */,
+				F300000D2FC2000100AA0001 /* AppUpdateState.swift in Sources */,
+				F300000F2FC2000100AA0001 /* AppUpdatePaths.swift in Sources */,
+				F30000112FC2000100AA0001 /* AppUpdateDownloadService.swift in Sources */,
+				F30000132FC2000100AA0001 /* AppUpdateDownloadDelegate.swift in Sources */,
+				F30000152FC2000100AA0001 /* AppUpdateChecksumVerifier.swift in Sources */,
+				F30000172FC2000100AA0001 /* AppUpdateArchiveExtractor.swift in Sources */,
+				F30000192FC2000100AA0001 /* AppUpdateBundleVerifier.swift in Sources */,
+				F300001B2FC2000100AA0001 /* AppUpdateInstallLauncher.swift in Sources */,
+				F300001D2FC2000100AA0001 /* AppUpdateApplicationsPrereflight.swift in Sources */,
+				F300001F2FC2000100AA0001 /* AppUpdateLaunchNoticeService.swift in Sources */,
+				F30000212FC2000100AA0001 /* AppUpdateCleanupService.swift in Sources */,
+				F30000242FC2000100AA0001 /* UpdateWindowView.swift in Sources */,
+				F30000262FC2000100AA0001 /* UpdateHeaderCard.swift in Sources */,
+				F30000282FC2000100AA0001 /* UpdateReleaseNotesCard.swift in Sources */,
+				F300002A2FC2000100AA0001 /* UpdateProgressCard.swift in Sources */,
+				F300002C2FC2000100AA0001 /* UpdateApplicationsRequirementCard.swift in Sources */,
+				F300002E2FC2000100AA0001 /* UpdateFailureCard.swift in Sources */,
+				F30000302FC2000100AA0001 /* PostUpdateNoticeView.swift in Sources */,
+				F30000022FC2000100AA0001 /* WindowManager+Updates.swift in Sources */,
 				8F2202072F44010000BB2201 /* ConfirmDeletePromptView.swift in Sources */,
 				8E6D05DC2F3C523D003BD458 /* StatusMenuView.swift in Sources */,
 				8E6D05E42F3C524B003BD458 /* UIComponents.swift in Sources */,
@@ -800,6 +921,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F30000362FC2000100AA0001 /* AppUpdateApplicationsPrereflightTests.swift in Sources */,
+				F30000322FC2000100AA0001 /* AppUpdateChecksumVerifierTests.swift in Sources */,
+				F30000342FC2000100AA0001 /* AppUpdateLaunchNoticeServiceTests.swift in Sources */,
 				AB3000232F60000100AA0001 /* KeyVoxAppActivationPolicyTests.swift in Sources */,
 				AB3000012F60000100AA0001 /* TestHelpers.swift in Sources */,
 				AB3000242F60000100AA0001 /* AudioDeviceManagerCompatibilityTests.swift in Sources */,

--- a/KeyVox.xcodeproj/project.pbxproj
+++ b/KeyVox.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		F30000322FC2000100AA0001 /* AppUpdateChecksumVerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000312FC2000100AA0001 /* AppUpdateChecksumVerifierTests.swift */; };
 		F30000342FC2000100AA0001 /* AppUpdateLaunchNoticeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000332FC2000100AA0001 /* AppUpdateLaunchNoticeServiceTests.swift */; };
 		F30000362FC2000100AA0001 /* AppUpdateApplicationsPrereflightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000352FC2000100AA0001 /* AppUpdateApplicationsPrereflightTests.swift */; };
+		F30000382FC2000100AA0001 /* AppActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30000372FC2000100AA0001 /* AppActionButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -296,6 +297,7 @@
 		F30000312FC2000100AA0001 /* AppUpdateChecksumVerifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateChecksumVerifierTests.swift; sourceTree = "<group>"; };
 		F30000332FC2000100AA0001 /* AppUpdateLaunchNoticeServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateLaunchNoticeServiceTests.swift; sourceTree = "<group>"; };
 		F30000352FC2000100AA0001 /* AppUpdateApplicationsPrereflightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdateApplicationsPrereflightTests.swift; sourceTree = "<group>"; };
+		F30000372FC2000100AA0001 /* AppActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppActionButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -398,6 +400,7 @@
 		8E6D05D62F3C51D6003BD458 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				F30000372FC2000100AA0001 /* AppActionButton.swift */,
 				F30000032FC2000100AA0001 /* AppUpdateProgressBar.swift */,
 				8F2201072F44010000BB2201 /* ConfirmDeletePromptView.swift */,
 				F20000032FB0000100AA0001 /* LogoBarView.swift */,
@@ -822,6 +825,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F30000382FC2000100AA0001 /* AppActionButton.swift in Sources */,
 				F30000042FC2000100AA0001 /* AppUpdateProgressBar.swift in Sources */,
 				F30000072FC2000100AA0001 /* AppReleaseInfo.swift in Sources */,
 				F30000092FC2000100AA0001 /* AppUpdateManifestLoader.swift in Sources */,

--- a/KeyVoxTests/Services/AppUpdateApplicationsPrereflightTests.swift
+++ b/KeyVoxTests/Services/AppUpdateApplicationsPrereflightTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import XCTest
+@testable import KeyVox
+
+final class AppUpdateApplicationsPrereflightTests: XCTestCase {
+    func testRequiresApplicationsInstallForNonApplicationsPath() {
+        let service = AppUpdateApplicationsPrereflight()
+        let bundleURL = URL(fileURLWithPath: "/Users/test/Downloads/KeyVox.app", isDirectory: true)
+        XCTAssertTrue(service.requiresApplicationsInstall(bundleURL: bundleURL))
+    }
+
+    func testDestinationURLUsesApplicationsFolder() {
+        let service = AppUpdateApplicationsPrereflight()
+        let bundleURL = URL(fileURLWithPath: "/Users/test/Desktop/KeyVox.app", isDirectory: true)
+        XCTAssertEqual(service.destinationURL(for: bundleURL).path, "/Applications/KeyVox.app")
+    }
+
+    func testConsumeResumeAfterApplicationsMoveClearsFlag() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defer {
+            defaults.removePersistentDomain(forName: #function)
+        }
+
+        let service = AppUpdateApplicationsPrereflight(defaults: defaults)
+        service.stageResumeAfterApplicationsMove()
+
+        XCTAssertTrue(service.consumeResumeAfterApplicationsMove())
+        XCTAssertFalse(service.consumeResumeAfterApplicationsMove())
+    }
+}

--- a/KeyVoxTests/Services/AppUpdateChecksumVerifierTests.swift
+++ b/KeyVoxTests/Services/AppUpdateChecksumVerifierTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import XCTest
+@testable import KeyVox
+
+final class AppUpdateChecksumVerifierTests: XCTestCase {
+    func testVerifyAcceptsMatchingChecksum() throws {
+        try withTemporaryDirectory { root in
+            let fileURL = root.appendingPathComponent("payload.zip")
+            let data = Data("hello".utf8)
+            try data.write(to: fileURL)
+
+            let verifier = AppUpdateChecksumVerifier()
+            try verifier.verify(
+                fileURL: fileURL,
+                expectedSHA256: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            )
+        }
+    }
+
+    func testVerifyRejectsMismatchedChecksum() throws {
+        try withTemporaryDirectory { root in
+            let fileURL = root.appendingPathComponent("payload.zip")
+            try Data("hello".utf8).write(to: fileURL)
+
+            let verifier = AppUpdateChecksumVerifier()
+            XCTAssertThrowsError(
+                try verifier.verify(
+                    fileURL: fileURL,
+                    expectedSHA256: "deadbeef"
+                )
+            )
+        }
+    }
+}

--- a/KeyVoxTests/Services/AppUpdateLaunchNoticeServiceTests.swift
+++ b/KeyVoxTests/Services/AppUpdateLaunchNoticeServiceTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import XCTest
+@testable import KeyVox
+
+final class AppUpdateLaunchNoticeServiceTests: XCTestCase {
+    func testConsumePendingNoticeReturnsVersionWhenCurrentVersionMatches() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defer {
+            defaults.removePersistentDomain(forName: #function)
+        }
+
+        let bundle = Bundle.main
+        let currentVersion = AppUpdateLogic.normalizeVersionTag(
+            (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) ?? ""
+        )
+        let service = AppUpdateLaunchNoticeService(bundle: bundle, defaults: defaults)
+        service.stagePendingUpdatedVersion(currentVersion)
+
+        XCTAssertEqual(service.consumePendingNoticeVersionIfNeeded(), currentVersion)
+    }
+
+    func testConsumePendingNoticeClearsMismatchedVersion() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defer {
+            defaults.removePersistentDomain(forName: #function)
+        }
+
+        let service = AppUpdateLaunchNoticeService(bundle: .main, defaults: defaults)
+        service.stagePendingUpdatedVersion("999.0.0")
+
+        XCTAssertNil(service.consumePendingNoticeVersionIfNeeded())
+        XCTAssertNil(defaults.string(forKey: UserDefaultsKeys.App.pendingUpdatedVersion))
+    }
+
+    func testStagePendingUpdatedVersionClearsAcknowledgedVersionForRepeatUpdate() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defer {
+            defaults.removePersistentDomain(forName: #function)
+        }
+
+        let bundle = Bundle.main
+        let currentVersion = AppUpdateLogic.normalizeVersionTag(
+            (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) ?? ""
+        )
+        let service = AppUpdateLaunchNoticeService(bundle: bundle, defaults: defaults)
+
+        service.acknowledge(version: currentVersion)
+        service.stagePendingUpdatedVersion(currentVersion)
+
+        XCTAssertEqual(service.consumePendingNoticeVersionIfNeeded(), currentVersion)
+    }
+}

--- a/KeyVoxTests/Services/AppUpdateLaunchNoticeServiceTests.swift
+++ b/KeyVoxTests/Services/AppUpdateLaunchNoticeServiceTests.swift
@@ -52,4 +52,21 @@ final class AppUpdateLaunchNoticeServiceTests: XCTestCase {
 
         XCTAssertEqual(service.consumePendingNoticeVersionIfNeeded(), currentVersion)
     }
+
+    func testConsumePendingNoticeNormalizesPendingVersionBeforeComparing() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defer {
+            defaults.removePersistentDomain(forName: #function)
+        }
+
+        let bundle = Bundle.main
+        let currentVersion = AppUpdateLogic.normalizeVersionTag(
+            (bundle.infoDictionary?["CFBundleShortVersionString"] as? String) ?? ""
+        )
+        let service = AppUpdateLaunchNoticeService(bundle: bundle, defaults: defaults)
+        defaults.set("v\(currentVersion)", forKey: UserDefaultsKeys.App.pendingUpdatedVersion)
+
+        XCTAssertEqual(service.consumePendingNoticeVersionIfNeeded(), currentVersion)
+    }
 }

--- a/KeyVoxTests/Services/AppUpdateLogicTests.swift
+++ b/KeyVoxTests/Services/AppUpdateLogicTests.swift
@@ -44,10 +44,10 @@ final class AppUpdateLogicTests: XCTestCase {
         )
 
         let mapped = AppUpdateLogic.mapReleaseInfo(from: release, allowedHosts: ["github.com", "api.github.com"])
-        XCTAssertTrue(mapped != nil)
-        XCTAssertTrue(mapped?.version == "1.2.0")
-        XCTAssertTrue(mapped?.installAssetURL?.absoluteString.contains(".zip") == true)
-        XCTAssertTrue(mapped?.installAssetKind == .zip)
+        XCTAssertNotNil(mapped)
+        XCTAssertEqual(mapped?.version, "1.2.0")
+        XCTAssertTrue(mapped?.installAssetURL?.absoluteString.contains(".zip") ?? false)
+        XCTAssertEqual(mapped?.installAssetKind, .zip)
     }
 
     func testMapReleaseInfoFallsBackToManualOnlyWhenManifestMissing() throws {

--- a/KeyVoxTests/Services/AppUpdateLogicTests.swift
+++ b/KeyVoxTests/Services/AppUpdateLogicTests.swift
@@ -117,4 +117,14 @@ final class AppUpdateLogicTests: XCTestCase {
         XCTAssertTrue(releaseURL.path.hasPrefix(rootURL.path))
         XCTAssertTrue(releaseURL.lastPathComponent == "1.2.3evil")
     }
+
+    func testAppUpdatePathsFallsBackForDotOnlyVersion() {
+        let rootURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let paths = AppUpdatePaths(fileManager: .default, rootDirectory: rootURL)
+
+        let releaseURL = paths.releaseDirectoryURL(for: ".....")
+
+        XCTAssertTrue(releaseURL.path.hasPrefix(rootURL.path))
+        XCTAssertTrue(releaseURL.lastPathComponent == "unknown-version")
+    }
 }

--- a/KeyVoxTests/Services/AppUpdateLogicTests.swift
+++ b/KeyVoxTests/Services/AppUpdateLogicTests.swift
@@ -22,12 +22,20 @@ final class AppUpdateLogicTests: XCTestCase {
         XCTAssertTrue(!AppUpdateLogic.hasAllowedHost(URL(string: "https://example.com/release")!, allowedHosts: allowed))
     }
 
-    func testMapReleaseInfoPrefersDmgAsset() throws {
+    func testMapReleaseInfoPrefersZipWhenManifestIsPresent() throws {
         let release = GitHubLatestReleaseResponse(
             tagName: "v1.2.0",
             body: "Release notes",
             htmlURL: "https://github.com/macmixing/keyvox/releases/tag/v1.2.0",
             assets: [
+                GitHubReleaseAsset(
+                    name: "KeyVox-1.2.0.zip",
+                    browserDownloadURL: "https://github.com/macmixing/keyvox/releases/download/v1.2.0/KeyVox-1.2.0.zip"
+                ),
+                GitHubReleaseAsset(
+                    name: AppUpdateLogic.manifestAssetName,
+                    browserDownloadURL: "https://github.com/macmixing/keyvox/releases/download/v1.2.0/keyvox-update-manifest.json"
+                ),
                 GitHubReleaseAsset(
                     name: "KeyVox-1.2.0.dmg",
                     browserDownloadURL: "https://github.com/macmixing/keyvox/releases/download/v1.2.0/KeyVox-1.2.0.dmg"
@@ -38,20 +46,28 @@ final class AppUpdateLogicTests: XCTestCase {
         let mapped = AppUpdateLogic.mapReleaseInfo(from: release, allowedHosts: ["github.com", "api.github.com"])
         XCTAssertTrue(mapped != nil)
         XCTAssertTrue(mapped?.version == "1.2.0")
-        XCTAssertTrue(mapped?.updateURL.absoluteString.contains(".dmg") == true)
+        XCTAssertTrue(mapped?.installAssetURL?.absoluteString.contains(".zip") == true)
+        XCTAssertTrue(mapped?.installAssetKind == .zip)
     }
 
-    func testMapReleaseInfoFallsBackToHtmlWhenNoDmg() throws {
+    func testMapReleaseInfoFallsBackToManualOnlyWhenManifestMissing() throws {
         let release = GitHubLatestReleaseResponse(
             tagName: "v1.2.0",
             body: "Release notes",
             htmlURL: "https://github.com/macmixing/keyvox/releases/tag/v1.2.0",
-            assets: []
+            assets: [
+                GitHubReleaseAsset(
+                    name: "KeyVox-1.2.0.zip",
+                    browserDownloadURL: "https://github.com/macmixing/keyvox/releases/download/v1.2.0/KeyVox-1.2.0.zip"
+                )
+            ]
         )
 
         let mapped = AppUpdateLogic.mapReleaseInfo(from: release, allowedHosts: ["github.com", "api.github.com"])
         XCTAssertTrue(mapped != nil)
-        XCTAssertTrue(mapped?.updateURL.absoluteString == release.htmlURL)
+        XCTAssertTrue(mapped?.releasePageURL.absoluteString == release.htmlURL)
+        XCTAssertTrue(mapped?.installAssetURL == nil)
+        XCTAssertTrue(mapped?.installAssetKind == .manualOnly)
     }
 
     func testMapReleaseInfoRejectsNonAllowlistedHost() {

--- a/KeyVoxTests/Services/AppUpdateLogicTests.swift
+++ b/KeyVoxTests/Services/AppUpdateLogicTests.swift
@@ -70,6 +70,32 @@ final class AppUpdateLogicTests: XCTestCase {
         XCTAssertTrue(mapped?.installAssetKind == .manualOnly)
     }
 
+    func testMapReleaseInfoFallsBackToManualOnlyWhenMultipleZipAssetsExist() {
+        let release = GitHubLatestReleaseResponse(
+            tagName: "v1.2.0",
+            body: "Release notes",
+            htmlURL: "https://github.com/macmixing/keyvox/releases/tag/v1.2.0",
+            assets: [
+                GitHubReleaseAsset(
+                    name: "KeyVox-1.2.0-arm64.zip",
+                    browserDownloadURL: "https://github.com/macmixing/keyvox/releases/download/v1.2.0/KeyVox-1.2.0-arm64.zip"
+                ),
+                GitHubReleaseAsset(
+                    name: "KeyVox-1.2.0-universal.zip",
+                    browserDownloadURL: "https://github.com/macmixing/keyvox/releases/download/v1.2.0/KeyVox-1.2.0-universal.zip"
+                ),
+                GitHubReleaseAsset(
+                    name: AppUpdateLogic.manifestAssetName,
+                    browserDownloadURL: "https://github.com/macmixing/keyvox/releases/download/v1.2.0/keyvox-update-manifest.json"
+                )
+            ]
+        )
+
+        let mapped = AppUpdateLogic.mapReleaseInfo(from: release, allowedHosts: ["github.com", "api.github.com"])
+        XCTAssertTrue(mapped?.installAssetURL == nil)
+        XCTAssertTrue(mapped?.installAssetKind == .manualOnly)
+    }
+
     func testMapReleaseInfoRejectsNonAllowlistedHost() {
         let release = GitHubLatestReleaseResponse(
             tagName: "1.2.0",
@@ -80,5 +106,15 @@ final class AppUpdateLogicTests: XCTestCase {
 
         let mapped = AppUpdateLogic.mapReleaseInfo(from: release, allowedHosts: ["github.com", "api.github.com"])
         XCTAssertTrue(mapped == nil)
+    }
+
+    func testAppUpdatePathsSanitizesVersionForReleaseDirectory() {
+        let rootURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let paths = AppUpdatePaths(fileManager: .default, rootDirectory: rootURL)
+
+        let releaseURL = paths.releaseDirectoryURL(for: "../1.2.3/../../evil")
+
+        XCTAssertTrue(releaseURL.path.hasPrefix(rootURL.path))
+        XCTAssertTrue(releaseURL.lastPathComponent == "1.2.3evil")
     }
 }

--- a/KeyVoxTests/Services/AppUpdateServiceTests.swift
+++ b/KeyVoxTests/Services/AppUpdateServiceTests.swift
@@ -43,6 +43,7 @@ final class AppUpdateServiceTests: XCTestCase {
 
         XCTAssertTrue(promptPresenter.prompts[0].title == "KeyVox Update Available")
         XCTAssertTrue(service.latestRemoteInfo?.version == "999.0.0")
+        XCTAssertTrue(promptPresenter.prompts[0].primaryButtonTitle == "Open Updater")
     }
 
     func testUpdatePromptUsesSummarySectionWhenPresent() async throws {

--- a/Resources/updater.sh
+++ b/Resources/updater.sh
@@ -91,7 +91,7 @@ echo "Unzipping update payload..."
 /usr/bin/ditto -x -k "$ZIP_PATH" "$STAGING_DIR"
 
 # Locate the newly extracted .app bundle
-NEW_APP_PATH=$(find "$STAGING_DIR" -name "*.app" -maxdepth 2 | head -n 1)
+NEW_APP_PATH=$(find "$STAGING_DIR" -maxdepth 2 -name "*.app" | head -n 1)
 
 if [ -z "$NEW_APP_PATH" ]; then
     echo "Error: No .app bundle found in the downloaded zip." >&2

--- a/Resources/updater.sh
+++ b/Resources/updater.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -euo pipefail
+
+# KeyVox In-Place Auto-Updater
+# Arguments:
+# $1 = Target PID (The running KeyVox app to wait for)
+# $2 = Zip Path (The downloaded update payload)
+# $3 = Install Path (The current location of KeyVox.app to be replaced)
+
+TARGET_PID=$1
+ZIP_PATH=$2
+INSTALL_PATH=$3
+BACKUP_PATH=""
+STAGING_DIR=""
+
+cleanup() {
+    if [ -n "$STAGING_DIR" ] && [ -d "$STAGING_DIR" ]; then
+        rm -rf "$STAGING_DIR"
+    fi
+}
+
+restore_backup() {
+    if [ -n "$BACKUP_PATH" ] && [ -d "$BACKUP_PATH" ] && [ ! -e "$INSTALL_PATH" ]; then
+        mv "$BACKUP_PATH" "$INSTALL_PATH"
+        open "$INSTALL_PATH"
+    fi
+}
+
+trap cleanup EXIT
+
+# 1. Wait for KeyVox to exit completely
+# kill -0 checks if the process is running without actually sending a kill signal
+echo "Waiting for KeyVox (PID: $TARGET_PID) to terminate..."
+while kill -0 "$TARGET_PID" 2>/dev/null; do
+    sleep 0.2
+done
+
+# 2. Create a temporary staging directory
+STAGING_DIR=$(mktemp -d)
+
+if [ ! -e "$INSTALL_PATH" ]; then
+    echo "Error: Install path does not exist: $INSTALL_PATH"
+    exit 1
+fi
+
+# 3. Unzip the downloaded payload silently
+echo "Unzipping update payload..."
+/usr/bin/ditto -x -k "$ZIP_PATH" "$STAGING_DIR"
+
+# Locate the newly extracted .app bundle
+NEW_APP_PATH=$(find "$STAGING_DIR" -name "*.app" -maxdepth 2 | head -n 1)
+
+if [ -z "$NEW_APP_PATH" ]; then
+    echo "Error: No .app bundle found in the downloaded zip."
+    exit 1
+fi
+
+# 4. Swap the binaries
+echo "Replacing old application bundle..."
+BACKUP_PATH="${INSTALL_PATH}.backup.$(date +%s)"
+mv "$INSTALL_PATH" "$BACKUP_PATH"
+
+if ! mv "$NEW_APP_PATH" "$INSTALL_PATH"; then
+    echo "Error: Failed to move new application bundle into place."
+    restore_backup
+    exit 1
+fi
+
+# 5. Clean up the downloaded zip and staging folder
+rm -rf "$BACKUP_PATH"
+rm -f "$ZIP_PATH"
+
+# 6. Relaunch KeyVox
+echo "Relaunching updated KeyVox..."
+open "$INSTALL_PATH"
+
+exit 0

--- a/Resources/updater.sh
+++ b/Resources/updater.sh
@@ -104,7 +104,7 @@ BACKUP_PATH="${INSTALL_PATH}.backup.$(date +%s)"
 mv "$INSTALL_PATH" "$BACKUP_PATH"
 
 if ! mv "$NEW_APP_PATH" "$INSTALL_PATH"; then
-    echo "Error: Failed to move new application bundle into place."
+    echo "Error: Failed to move new application bundle into place." >&2
     restore_backup
     exit 1
 fi

--- a/Resources/updater.sh
+++ b/Resources/updater.sh
@@ -58,7 +58,15 @@ on_exit() {
     cleanup
 }
 
-trap on_exit EXIT INT TERM
+on_signal() {
+    # INT/TERM should restore and stop immediately; reusing on_exit alone would
+    # recover but still allow the script body to continue after the signal.
+    on_exit
+    exit 1
+}
+
+trap on_exit EXIT
+trap on_signal INT TERM
 
 # 1. Wait for KeyVox to exit completely
 # kill -0 checks if the process is running without actually sending a kill signal

--- a/Resources/updater.sh
+++ b/Resources/updater.sh
@@ -63,15 +63,26 @@ trap on_exit EXIT INT TERM
 # 1. Wait for KeyVox to exit completely
 # kill -0 checks if the process is running without actually sending a kill signal
 echo "Waiting for KeyVox (PID: $TARGET_PID) to terminate..."
+WAIT_TICKS=0
+MAX_WAIT_SECONDS=30
+TICK_DURATION_SECONDS=0.2
+MAX_WAIT_TICKS=150
 while kill -0 "$TARGET_PID" 2>/dev/null; do
-    sleep 0.2
+    if [ "$WAIT_TICKS" -ge "$MAX_WAIT_TICKS" ]; then
+        # Fail closed instead of force-killing the app so the updater does not
+        # discard unsaved state in the event the original process is hung.
+        echo "Warning: Timed out waiting for PID $TARGET_PID after ${MAX_WAIT_SECONDS}s." >&2
+        exit 1
+    fi
+    sleep "$TICK_DURATION_SECONDS"
+    WAIT_TICKS=$((WAIT_TICKS + 1))
 done
 
 # 2. Create a temporary staging directory
 STAGING_DIR=$(mktemp -d)
 
 if [ ! -e "$INSTALL_PATH" ]; then
-    echo "Error: Install path does not exist: $INSTALL_PATH"
+    echo "Error: Install path does not exist: $INSTALL_PATH" >&2
     exit 1
 fi
 
@@ -83,7 +94,7 @@ echo "Unzipping update payload..."
 NEW_APP_PATH=$(find "$STAGING_DIR" -name "*.app" -maxdepth 2 | head -n 1)
 
 if [ -z "$NEW_APP_PATH" ]; then
-    echo "Error: No .app bundle found in the downloaded zip."
+    echo "Error: No .app bundle found in the downloaded zip." >&2
     exit 1
 fi
 

--- a/Resources/updater.sh
+++ b/Resources/updater.sh
@@ -7,11 +7,33 @@ set -euo pipefail
 # $2 = Zip Path (The downloaded update payload)
 # $3 = Install Path (The current location of KeyVox.app to be replaced)
 
-TARGET_PID=$1
-ZIP_PATH=$2
-INSTALL_PATH=$3
+TARGET_PID="${1:-}"
+ZIP_PATH="${2:-}"
+INSTALL_PATH="${3:-}"
 BACKUP_PATH=""
 STAGING_DIR=""
+UPDATE_COMPLETED=0
+
+if [ -z "$TARGET_PID" ] || [ -z "$ZIP_PATH" ] || [ -z "$INSTALL_PATH" ]; then
+    echo "Error: updater.sh requires target pid, zip path, and install path." >&2
+    exit 1
+fi
+
+if ! [[ "$TARGET_PID" =~ ^[0-9]+$ ]]; then
+    echo "Error: Invalid target pid: $TARGET_PID" >&2
+    exit 1
+fi
+
+if [ ! -r "$ZIP_PATH" ]; then
+    echo "Error: Update zip is not readable: $ZIP_PATH" >&2
+    exit 1
+fi
+
+INSTALL_PARENT="$(dirname "$INSTALL_PATH")"
+if [ ! -d "$INSTALL_PARENT" ] || [ ! -w "$INSTALL_PARENT" ]; then
+    echo "Error: Install directory is not writable: $INSTALL_PARENT" >&2
+    exit 1
+fi
 
 cleanup() {
     if [ -n "$STAGING_DIR" ] && [ -d "$STAGING_DIR" ]; then
@@ -20,13 +42,23 @@ cleanup() {
 }
 
 restore_backup() {
-    if [ -n "$BACKUP_PATH" ] && [ -d "$BACKUP_PATH" ] && [ ! -e "$INSTALL_PATH" ]; then
+    if [ -n "$BACKUP_PATH" ] && [ -d "$BACKUP_PATH" ]; then
+        if [ -e "$INSTALL_PATH" ]; then
+            rm -rf "$INSTALL_PATH"
+        fi
         mv "$BACKUP_PATH" "$INSTALL_PATH"
         open "$INSTALL_PATH"
     fi
 }
 
-trap cleanup EXIT
+on_exit() {
+    if [ "$UPDATE_COMPLETED" -ne 1 ]; then
+        restore_backup
+    fi
+    cleanup
+}
+
+trap on_exit EXIT INT TERM
 
 # 1. Wait for KeyVox to exit completely
 # kill -0 checks if the process is running without actually sending a kill signal
@@ -67,11 +99,13 @@ if ! mv "$NEW_APP_PATH" "$INSTALL_PATH"; then
 fi
 
 # 5. Clean up the downloaded zip and staging folder
-rm -rf "$BACKUP_PATH"
+# Preserve BACKUP_PATH for the relaunched app to clean up after a successful
+# launch so we still have a rollback target if relaunch fails unexpectedly.
 rm -f "$ZIP_PATH"
 
 # 6. Relaunch KeyVox
 echo "Relaunching updated KeyVox..."
 open "$INSTALL_PATH"
+UPDATE_COMPLETED=1
 
 exit 0

--- a/Views/Components/AppActionButton.swift
+++ b/Views/Components/AppActionButton.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct AppActionButton: View {
+    enum Style {
+        case primary
+        case secondary
+    }
+
+    let title: String
+    let style: Style
+    let minWidth: CGFloat
+    var isEnabled: Bool = true
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.custom("Kanit Medium", size: 14))
+                .foregroundColor(foregroundColor)
+                .padding(.horizontal, 28)
+                .padding(.vertical, 11)
+                .frame(minWidth: minWidth)
+                .background(backgroundColor)
+                .overlay {
+                    if style == .secondary {
+                        Capsule()
+                            .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                    }
+                }
+                .clipShape(Capsule())
+                .shadow(color: shadowColor, radius: 10)
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+    }
+
+    private var foregroundColor: Color {
+        switch style {
+        case .primary:
+            return isEnabled ? .black : .white.opacity(0.3)
+        case .secondary:
+            return isEnabled ? .white.opacity(0.9) : .white.opacity(0.3)
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch style {
+        case .primary:
+            return isEnabled ? .yellow : Color.white.opacity(0.05)
+        case .secondary:
+            return Color.white.opacity(isEnabled ? 0.08 : 0.05)
+        }
+    }
+
+    private var shadowColor: Color {
+        guard style == .primary, isEnabled else { return .clear }
+        return .yellow.opacity(0.3)
+    }
+}

--- a/Views/Components/AppUpdateProgressBar.swift
+++ b/Views/Components/AppUpdateProgressBar.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct AppUpdateProgressBar: View {
+    let progress: Double
+    let label: String
+    let detail: String?
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ProgressView(value: progress)
+                .progressViewStyle(KeyVoxProgressStyle())
+                .frame(height: 8)
+
+            HStack(alignment: .firstTextBaseline) {
+                Text(label)
+                    .font(.custom("Kanit Medium", size: 11))
+                    .foregroundColor(.secondary)
+
+                Spacer()
+
+                Text("\(Int(progress * 100))%")
+                    .font(.custom("Kanit Medium", size: 11))
+                    .foregroundColor(.indigo)
+            }
+
+            if let detail, !detail.isEmpty {
+                Text(detail)
+                    .font(.custom("Kanit Medium", size: 10))
+                    .foregroundColor(.secondary.opacity(0.8))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+}

--- a/Views/Components/AppUpdateProgressBar.swift
+++ b/Views/Components/AppUpdateProgressBar.swift
@@ -4,6 +4,9 @@ struct AppUpdateProgressBar: View {
     let progress: Double
     let label: String
     let detail: String?
+    private var clampedProgress: Double {
+        min(max(progress, 0), 1)
+    }
 
     var body: some View {
         VStack(spacing: 8) {
@@ -18,7 +21,7 @@ struct AppUpdateProgressBar: View {
 
                 Spacer()
 
-                Text("\(Int(progress * 100))%")
+                Text("\(Int(clampedProgress * 100))%")
                     .font(.custom("Kanit Medium", size: 11))
                     .foregroundColor(.indigo)
             }

--- a/Views/Components/AppUpdateProgressBar.swift
+++ b/Views/Components/AppUpdateProgressBar.swift
@@ -10,7 +10,7 @@ struct AppUpdateProgressBar: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            ProgressView(value: progress)
+            ProgressView(value: clampedProgress)
                 .progressViewStyle(KeyVoxProgressStyle())
                 .frame(height: 8)
 

--- a/Views/UpdatePromptOverlay.swift
+++ b/Views/UpdatePromptOverlay.swift
@@ -3,9 +3,8 @@ import AppKit
 
 private enum UpdatePromptLayout {
     static let width: CGFloat = 430
-    static let height: CGFloat = 250
-    static let messageMinHeight: CGFloat = 42
-    static let messageMaxHeight: CGFloat = 84
+    static let height: CGFloat = 280
+    static let shellPadding = EdgeInsets(top: 20, leading: 24, bottom: 30, trailing: 24)
 }
 
 struct UpdatePromptOverlay: View {
@@ -22,13 +21,12 @@ struct UpdatePromptOverlay: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 16) {
             AnimatedWaveHeader {
                 if let versionBadgeTitle {
                     StatusBadge(title: versionBadgeTitle, color: .indigo)
                 }
             }
-            .padding(.horizontal, 8)
 
             VStack(alignment: .center, spacing: 8) {
                 Text(prompt.title)
@@ -45,38 +43,31 @@ struct UpdatePromptOverlay: View {
                     .lineLimit(4)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .center)
-                .frame(maxWidth: .infinity)
-                .frame(
-                    minHeight: UpdatePromptLayout.messageMinHeight,
-                    maxHeight: UpdatePromptLayout.messageMaxHeight,
-                    alignment: .center
-                )
             }
-            .padding(.horizontal, 8)
 
             Spacer(minLength: 0)
 
             HStack(spacing: 10) {
-                Button(prompt.dismissButtonTitle, action: onDismiss)
-                    .buttonStyle(.bordered)
-                    .controlSize(.regular)
+                AppActionButton(
+                    title: prompt.dismissButtonTitle,
+                    style: .secondary,
+                    minWidth: 150,
+                    action: onDismiss
+                )
 
                 if let primaryButtonTitle = prompt.primaryButtonTitle {
-                    Button(action: onPrimaryAction) {
-                        Text(primaryButtonTitle)
-                            .fontWeight(.bold)
-                            .foregroundColor(.black)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(.indigo)
-                    .controlSize(.regular)
+                    AppActionButton(
+                        title: primaryButtonTitle,
+                        style: .primary,
+                        minWidth: 150,
+                        action: onPrimaryAction
+                    )
                 }
             }
-            .environment(\.controlActiveState, .active)
-            .padding(.horizontal, 8)
             .frame(maxWidth: .infinity, alignment: .center)
         }
-        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(UpdatePromptLayout.shellPadding)
         .frame(width: UpdatePromptLayout.width, height: UpdatePromptLayout.height)
         .background(
             ZStack {
@@ -131,23 +122,27 @@ final class UpdatePromptManager {
         hostingView.frame = NSRect(x: 0, y: 0, width: UpdatePromptLayout.width, height: UpdatePromptLayout.height)
         window?.contentView = hostingView
         window?.setContentSize(NSSize(width: UpdatePromptLayout.width, height: UpdatePromptLayout.height))
-
-        if let screen = NSScreen.main {
-            let visibleFrame = screen.visibleFrame
-            let targetFrame = NSRect(
-                x: visibleFrame.midX - (UpdatePromptLayout.width / 2),
-                y: visibleFrame.midY - (UpdatePromptLayout.height / 2),
-                width: UpdatePromptLayout.width,
-                height: UpdatePromptLayout.height
-            )
-            window?.setFrame(targetFrame, display: false)
-        }
+        centerPromptWindow()
 
         window?.orderFrontRegardless()
     }
 
     func hide() {
         window?.orderOut(nil)
+    }
+
+    private func centerPromptWindow() {
+        guard let window else { return }
+        let screen = window.screen ?? NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens.first
+        guard let screen else { return }
+
+        let visibleFrame = screen.visibleFrame
+        let windowSize = window.frame.size
+        let origin = NSPoint(
+            x: visibleFrame.midX - (windowSize.width / 2),
+            y: visibleFrame.midY - (windowSize.height / 2)
+        )
+        window.setFrameOrigin(origin)
     }
 }
 

--- a/Views/Updates/PostUpdateNoticeView.swift
+++ b/Views/Updates/PostUpdateNoticeView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct PostUpdateNoticeView: View {
+    let version: String
+    let onDismiss: () -> Void
+
+    static let preferredWindowSize = CGSize(width: 360, height: 190)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            AnimatedWaveHeader()
+
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("You've been updated to v\(version)")
+                        .font(.custom("Kanit Medium", size: 18))
+                        .foregroundColor(.white)
+
+                    Text("KeyVox is ready to go with the latest improvements.")
+                        .font(.custom("Kanit Medium", size: 12))
+                        .foregroundColor(.secondary)
+                        .lineSpacing(2)
+                }
+            }
+
+            HStack {
+                Spacer()
+
+                Button("Okay", action: onDismiss)
+                    .buttonStyle(.borderedProminent)
+                    .tint(.indigo)
+            }
+        }
+        .padding(20)
+        .frame(width: Self.preferredWindowSize.width, height: Self.preferredWindowSize.height)
+        .background(
+            ZStack {
+                VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
+                Color.black.opacity(0.9)
+            }
+        )
+        .preferredColorScheme(.dark)
+    }
+}

--- a/Views/Updates/PostUpdateNoticeView.swift
+++ b/Views/Updates/PostUpdateNoticeView.swift
@@ -4,40 +4,57 @@ struct PostUpdateNoticeView: View {
     let version: String
     let onDismiss: () -> Void
 
-    static let preferredWindowSize = CGSize(width: 360, height: 190)
+    static let preferredWindowSize = CGSize(width: 420, height: 280)
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            AnimatedWaveHeader()
+            AnimatedWaveHeader {
+                StatusBadge(title: "Updated", color: .indigo)
+            }
+            .padding(.top, 10)
 
             SettingsCard {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("You've been updated to v\(version)")
-                        .font(.custom("Kanit Medium", size: 18))
+                        .font(.custom("Kanit Medium", size: 20))
                         .foregroundColor(.white)
+                        .frame(maxWidth: .infinity, alignment: .center)
 
                     Text("KeyVox is ready to go with the latest improvements.")
                         .font(.custom("Kanit Medium", size: 12))
                         .foregroundColor(.secondary)
                         .lineSpacing(2)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity, alignment: .center)
                 }
+                .frame(maxWidth: .infinity, alignment: .center)
             }
 
             HStack {
-                Spacer()
-
-                Button("Okay", action: onDismiss)
-                    .buttonStyle(.borderedProminent)
-                    .tint(.indigo)
+                AppActionButton(
+                    title: "Okay",
+                    style: .primary,
+                    minWidth: 160,
+                    action: onDismiss
+                )
             }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.top, 6)
+            .padding(.bottom, 10)
         }
-        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 24)
+        .padding(.top, 28)
+        .padding(.bottom, 28)
         .frame(width: Self.preferredWindowSize.width, height: Self.preferredWindowSize.height)
         .background(
-            ZStack {
-                VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
-                Color.black.opacity(0.9)
-            }
+            Color.indigo.opacity(0.15)
+                .background(Color(white: 0.01))
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .stroke(Color.white.opacity(0.12), lineWidth: 0.7)
         )
         .preferredColorScheme(.dark)
     }

--- a/Views/Updates/UpdateApplicationsRequirementCard.swift
+++ b/Views/Updates/UpdateApplicationsRequirementCard.swift
@@ -13,6 +13,7 @@ struct UpdateApplicationsRequirementCard: View {
                     .foregroundColor(.secondary)
                     .lineSpacing(2)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }

--- a/Views/Updates/UpdateApplicationsRequirementCard.swift
+++ b/Views/Updates/UpdateApplicationsRequirementCard.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct UpdateApplicationsRequirementCard: View {
+    var body: some View {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Move KeyVox To Applications")
+                    .font(.custom("Kanit Medium", size: 15))
+                    .foregroundColor(.white)
+
+                Text("KeyVox will copy itself into Applications, relaunch there, and resume the updater automatically.")
+                    .font(.custom("Kanit Medium", size: 12))
+                    .foregroundColor(.secondary)
+                    .lineSpacing(2)
+            }
+        }
+    }
+}

--- a/Views/Updates/UpdateFailureCard.swift
+++ b/Views/Updates/UpdateFailureCard.swift
@@ -15,6 +15,7 @@ struct UpdateFailureCard: View {
                     .foregroundColor(.orange)
                     .lineSpacing(2)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }

--- a/Views/Updates/UpdateFailureCard.swift
+++ b/Views/Updates/UpdateFailureCard.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct UpdateFailureCard: View {
+    let message: String
+
+    var body: some View {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Update Failed")
+                    .font(.custom("Kanit Medium", size: 15))
+                    .foregroundColor(.white)
+
+                Text(message)
+                    .font(.custom("Kanit Medium", size: 12))
+                    .foregroundColor(.orange)
+                    .lineSpacing(2)
+            }
+        }
+    }
+}

--- a/Views/Updates/UpdateHeaderCard.swift
+++ b/Views/Updates/UpdateHeaderCard.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct UpdateHeaderCard: View {
+    let currentVersion: String
+    let targetVersion: String?
+    let statusMessage: String
+    let state: AppUpdateState
+
+    private var badgeTitle: String {
+        if let targetVersion, !targetVersion.isEmpty {
+            return "v\(targetVersion)"
+        }
+        return "v\(currentVersion)"
+    }
+
+    var body: some View {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Updater")
+                            .font(.custom("Kanit Medium", size: 18))
+                            .foregroundColor(.white)
+                        Text(statusMessage)
+                            .font(.custom("Kanit Medium", size: 12))
+                            .foregroundColor(.secondary)
+                    }
+
+                    Spacer()
+
+                    StatusBadge(title: badgeTitle, color: .indigo)
+                }
+
+                HStack {
+                    Text("Current: v\(currentVersion)")
+                        .font(.custom("Kanit Medium", size: 11))
+                        .foregroundColor(.secondary)
+                    Spacer()
+                    if let targetVersion, state != .completed {
+                        Text("Update: v\(targetVersion)")
+                            .font(.custom("Kanit Medium", size: 11))
+                            .foregroundColor(.indigo)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Views/Updates/UpdateProgressCard.swift
+++ b/Views/Updates/UpdateProgressCard.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct UpdateProgressCard: View {
+    let progress: Double
+    let statusMessage: String
+    let downloadedBytes: Int64
+    let totalBytes: Int64
+
+    private var detailText: String? {
+        guard totalBytes > 0 else { return nil }
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return "\(formatter.string(fromByteCount: downloadedBytes)) of \(formatter.string(fromByteCount: totalBytes))"
+    }
+
+    var body: some View {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Download Progress")
+                    .font(.custom("Kanit Medium", size: 15))
+                    .foregroundColor(.white)
+
+                AppUpdateProgressBar(
+                    progress: progress,
+                    label: statusMessage,
+                    detail: detailText
+                )
+            }
+        }
+    }
+}

--- a/Views/Updates/UpdateProgressCard.swift
+++ b/Views/Updates/UpdateProgressCard.swift
@@ -30,6 +30,7 @@ struct UpdateProgressCard: View {
                     detail: detailText
                 )
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }

--- a/Views/Updates/UpdateProgressCard.swift
+++ b/Views/Updates/UpdateProgressCard.swift
@@ -6,11 +6,15 @@ struct UpdateProgressCard: View {
     let downloadedBytes: Int64
     let totalBytes: Int64
 
-    private var detailText: String? {
-        guard totalBytes > 0 else { return nil }
+    private static let byteFormatter: ByteCountFormatter = {
         let formatter = ByteCountFormatter()
         formatter.countStyle = .file
-        return "\(formatter.string(fromByteCount: downloadedBytes)) of \(formatter.string(fromByteCount: totalBytes))"
+        return formatter
+    }()
+
+    private var detailText: String? {
+        guard totalBytes > 0 else { return nil }
+        return "\(Self.byteFormatter.string(fromByteCount: downloadedBytes)) of \(Self.byteFormatter.string(fromByteCount: totalBytes))"
     }
 
     var body: some View {

--- a/Views/Updates/UpdateReleaseNotesCard.swift
+++ b/Views/Updates/UpdateReleaseNotesCard.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct UpdateReleaseNotesCard: View {
+    let releaseNotes: String
+
+    var body: some View {
+        SettingsCard {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Release Notes")
+                    .font(.custom("Kanit Medium", size: 15))
+                    .foregroundColor(.white)
+
+                Text(releaseNotes)
+                    .font(.custom("Kanit Medium", size: 12))
+                    .foregroundColor(.secondary)
+                    .lineSpacing(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+}

--- a/Views/Updates/UpdateWindowView.swift
+++ b/Views/Updates/UpdateWindowView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct UpdateWindowView: View {
+    @ObservedObject var coordinator: AppUpdateCoordinator
+
+    static let preferredWindowSize = CGSize(width: 520, height: 500)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            AnimatedWaveHeader {
+                StatusBadge(title: "Updater", color: .indigo)
+            }
+
+            UpdateHeaderCard(
+                currentVersion: coordinator.currentVersion,
+                targetVersion: coordinator.targetVersion,
+                statusMessage: coordinator.statusMessage,
+                state: coordinator.state
+            )
+
+            if !coordinator.releaseNotesPreview.isEmpty {
+                UpdateReleaseNotesCard(releaseNotes: coordinator.releaseNotesPreview)
+            }
+
+            if coordinator.state == .requiresApplicationsInstall {
+                UpdateApplicationsRequirementCard()
+            }
+
+            if coordinator.state == .downloading ||
+                coordinator.state == .verifyingChecksum ||
+                coordinator.state == .extracting ||
+                coordinator.state == .verifyingSignature ||
+                coordinator.state == .readyToInstall ||
+                coordinator.state == .installing {
+                UpdateProgressCard(
+                    progress: coordinator.progress,
+                    statusMessage: coordinator.statusMessage,
+                    downloadedBytes: coordinator.downloadedBytes,
+                    totalBytes: coordinator.totalBytes
+                )
+            }
+
+            if let failureMessage = coordinator.failureMessage,
+               coordinator.state == .failed {
+                UpdateFailureCard(message: failureMessage)
+            }
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 10) {
+                Button(coordinator.secondaryButtonTitle) {
+                    coordinator.secondaryAction()
+                }
+                .buttonStyle(.bordered)
+
+                Spacer()
+
+                Button(coordinator.primaryButtonTitle) {
+                    coordinator.primaryAction()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.indigo)
+                .disabled(!coordinator.canTriggerPrimaryAction)
+            }
+        }
+        .padding(20)
+        .frame(width: Self.preferredWindowSize.width, height: Self.preferredWindowSize.height)
+        .background(
+            ZStack {
+                VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
+                Color.black.opacity(0.94)
+            }
+        )
+        .preferredColorScheme(.dark)
+    }
+}

--- a/Views/Updates/UpdateWindowView.swift
+++ b/Views/Updates/UpdateWindowView.swift
@@ -1,15 +1,60 @@
+import AppKit
 import SwiftUI
 
 struct UpdateWindowView: View {
-    @ObservedObject var coordinator: AppUpdateCoordinator
+    private struct HeightPreferenceKey: PreferenceKey {
+        static var defaultValue: CGFloat = UpdateWindowView.preferredWindowSize.height
 
-    static let preferredWindowSize = CGSize(width: 520, height: 500)
+        static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+            value = max(value, nextValue())
+        }
+    }
+
+    @ObservedObject var coordinator: AppUpdateCoordinator
+    var onPreferredHeightChange: (CGFloat) -> Void = { _ in }
+
+    static let preferredWindowSize = CGSize(width: 520, height: 300)
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 16) {
+            draggableContent
+            actionRow
+                .padding(.top, 6)
+                .padding(.bottom, 10)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 24)
+        .padding(.top, 28)
+        .padding(.bottom, 28)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(
+            GeometryReader { geometry in
+                Color.clear.preference(
+                    key: HeightPreferenceKey.self,
+                    value: geometry.size.height
+                )
+            }
+        )
+        .frame(width: Self.preferredWindowSize.width)
+        .frame(minHeight: Self.preferredWindowSize.height)
+        .background(
+            Color.indigo.opacity(0.15)
+                .background(Color(white: 0.01))
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
+        .preferredColorScheme(.dark)
+        .onPreferenceChange(HeightPreferenceKey.self) { height in
+            onPreferredHeightChange(max(Self.preferredWindowSize.height, height))
+        }
+    }
+
+    private var draggableContent: some View {
+        VStack(alignment: .leading, spacing: 16) {
             AnimatedWaveHeader {
                 StatusBadge(title: "Updater", color: .indigo)
             }
+            .padding(.top, 10)
+            .background(WindowDragRegion())
 
             UpdateHeaderCard(
                 currentVersion: coordinator.currentVersion,
@@ -17,10 +62,6 @@ struct UpdateWindowView: View {
                 statusMessage: coordinator.statusMessage,
                 state: coordinator.state
             )
-
-            if !coordinator.releaseNotesPreview.isEmpty {
-                UpdateReleaseNotesCard(releaseNotes: coordinator.releaseNotesPreview)
-            }
 
             if coordinator.state == .requiresApplicationsInstall {
                 UpdateApplicationsRequirementCard()
@@ -44,33 +85,43 @@ struct UpdateWindowView: View {
                coordinator.state == .failed {
                 UpdateFailureCard(message: failureMessage)
             }
+        }
+    }
 
-            Spacer(minLength: 0)
+    private var actionRow: some View {
+        HStack(spacing: 10) {
+            AppActionButton(
+                title: coordinator.secondaryButtonTitle,
+                style: .secondary,
+                minWidth: 190
+            ) {
+                coordinator.secondaryAction()
+            }
 
-            HStack(spacing: 10) {
-                Button(coordinator.secondaryButtonTitle) {
-                    coordinator.secondaryAction()
-                }
-                .buttonStyle(.bordered)
+            Spacer()
 
-                Spacer()
-
-                Button(coordinator.primaryButtonTitle) {
-                    coordinator.primaryAction()
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(.indigo)
-                .disabled(!coordinator.canTriggerPrimaryAction)
+            AppActionButton(
+                title: coordinator.primaryButtonTitle,
+                style: .primary,
+                minWidth: 190,
+                isEnabled: coordinator.canTriggerPrimaryAction
+            ) {
+                coordinator.primaryAction()
             }
         }
-        .padding(20)
-        .frame(width: Self.preferredWindowSize.width, height: Self.preferredWindowSize.height)
-        .background(
-            ZStack {
-                VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
-                Color.black.opacity(0.94)
-            }
-        )
-        .preferredColorScheme(.dark)
+    }
+}
+
+private struct WindowDragRegion: NSViewRepresentable {
+    func makeNSView(context: Context) -> DragRegionView {
+        DragRegionView()
+    }
+
+    func updateNSView(_ nsView: DragRegionView, context: Context) {}
+}
+
+private final class DragRegionView: NSView {
+    override func mouseDown(with event: NSEvent) {
+        window?.performDrag(with: event)
     }
 }


### PR DESCRIPTION
- add dedicated updater services, coordinator state, staging paths, checksum verification, archive extraction, bundle verification, and install launching
- wire GitHub release parsing to require zip plus manifest assets and route update prompts into the updater window instead of manual browser installs
- bundle and harden updater.sh for app replacement, rollback, relaunch, and cleanup during background installs
- add updater window UI, progress components, Applications-move prerequisite flow, and post-update notice presentation
- persist update resume and launch-notice state so installs continue after moving into /Applications and notify once on first launch after update
- update the macOS app shell and Xcode project wiring to register the new updater resources, views, and services
- add updater-focused tests for release parsing, service prompting, checksum verification, Applications prereflight, and post-update notice behavior
- fix the post-move resume path so it suppresses duplicate update prompts, resumes install automatically, and avoids install-button flicker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in updater with automatic checks at launch and a manual "Open Updater" flow
  * Updater window: header, release notes, progress bar, actionable primary/secondary buttons
  * Real-time download progress with byte counts, verification, extraction, signature checks, and install stages
  * Post-update notice shown after updates and prompt to move the app into /Applications with an updater script for in-place installs

* **Tests**
  * Added unit tests for manifest parsing, checksum verification, install resume, and notice logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->