### PR TITLE
feat(mac-paste): normalize leading transcription capitalization before paste

### DIFF
--- a/Core/Services/Paste/Accessibility/PasteAXInspector.swift
+++ b/Core/Services/Paste/Accessibility/PasteAXInspector.swift
@@ -17,6 +17,8 @@ protocol PasteAXInspecting {
 }
 
 final class PasteAXInspector: PasteAXInspecting {
+    private let maxPreviousNonWhitespaceScanLength = 100
+
     func focusedInsertionContext() -> PasteInsertionContext? {
         guard let focusedElement = focusedUIElement() else { return nil }
 
@@ -147,7 +149,8 @@ final class PasteAXInspector: PasteAXInspecting {
         }
 
         var candidateLocation = caretLocation - 1
-        while candidateLocation >= 0 {
+        var scannedCharacterCount = 0
+        while candidateLocation >= 0 && scannedCharacterCount < maxPreviousNonWhitespaceScanLength {
             let candidate = stringForRange(
                 CFRange(location: candidateLocation, length: 1),
                 element: element
@@ -156,6 +159,7 @@ final class PasteAXInspector: PasteAXInspecting {
                 return candidate
             }
             candidateLocation -= 1
+            scannedCharacterCount += 1
         }
 
         return nil

--- a/Core/Services/Paste/Accessibility/PasteAXInspector.swift
+++ b/Core/Services/Paste/Accessibility/PasteAXInspector.swift
@@ -135,9 +135,8 @@ final class PasteAXInspector: PasteAXInspecting {
 
         if let value = valueString(for: element) {
             let nsValue = value as NSString
-            guard caretLocation <= nsValue.length else { return nil }
-
-            var candidateLocation = caretLocation - 1
+            let startingLocation = min(caretLocation, nsValue.length) - 1
+            var candidateLocation = startingLocation
             while candidateLocation >= 0 {
                 let candidate = nsValue.substring(with: NSRange(location: candidateLocation, length: 1))
                 if let character = candidate.first, !character.isWhitespace {

--- a/Core/Services/Paste/Accessibility/PasteAXInspector.swift
+++ b/Core/Services/Paste/Accessibility/PasteAXInspector.swift
@@ -26,6 +26,7 @@ final class PasteAXInspector: PasteAXInspecting {
         let selectionLength = selectedRange.map { max(0, $0.length) }
 
         var previousCharacter: Character?
+        var previousNonWhitespaceCharacter: Character?
         if let caretLocation, caretLocation > 0 {
             previousCharacter = previousCharacterFromValueAttribute(element: focusedElement, caretLocation: caretLocation)
             if previousCharacter == nil {
@@ -34,12 +35,18 @@ final class PasteAXInspector: PasteAXInspecting {
                     element: focusedElement
                 )?.first
             }
+
+            previousNonWhitespaceCharacter = computePreviousNonWhitespaceCharacter(
+                element: focusedElement,
+                caretLocation: caretLocation
+            )
         }
 
         return PasteInsertionContext(
             selectionLength: selectionLength,
             caretLocation: caretLocation,
-            previousCharacter: previousCharacter
+            previousCharacter: previousCharacter,
+            previousNonWhitespaceCharacter: previousNonWhitespaceCharacter
         )
     }
 
@@ -116,6 +123,54 @@ final class PasteAXInspector: PasteAXInspecting {
 
         let previousText = nsValue.substring(with: NSRange(location: caretLocation - 1, length: 1))
         return previousText.first
+    }
+
+    private func computePreviousNonWhitespaceCharacter(
+        element: AXUIElement,
+        caretLocation: Int
+    ) -> Character? {
+        guard caretLocation > 0 else { return nil }
+
+        if let value = valueString(for: element) {
+            let nsValue = value as NSString
+            guard caretLocation <= nsValue.length else { return nil }
+
+            var candidateLocation = caretLocation - 1
+            while candidateLocation >= 0 {
+                let candidate = nsValue.substring(with: NSRange(location: candidateLocation, length: 1))
+                if let character = candidate.first, !character.isWhitespace {
+                    return character
+                }
+                candidateLocation -= 1
+            }
+            return nil
+        }
+
+        var candidateLocation = caretLocation - 1
+        while candidateLocation >= 0 {
+            let candidate = stringForRange(
+                CFRange(location: candidateLocation, length: 1),
+                element: element
+            )?.first
+            if let candidate, !candidate.isWhitespace {
+                return candidate
+            }
+            candidateLocation -= 1
+        }
+
+        return nil
+    }
+
+    private func valueString(for element: AXUIElement) -> String? {
+        var valueRef: CFTypeRef?
+        let valueResult = AXUIElementCopyAttributeValue(
+            element,
+            kAXValueAttribute as CFString,
+            &valueRef
+        )
+
+        guard valueResult == .success, let value = valueRef as? String else { return nil }
+        return value
     }
 
     func valueLengthForMenuVerification(element: AXUIElement) -> Int? {

--- a/Core/Services/Paste/Heuristics/PasteCapitalizationHeuristics.swift
+++ b/Core/Services/Paste/Heuristics/PasteCapitalizationHeuristics.swift
@@ -7,6 +7,7 @@ protocol PasteCapitalizationHeuristicApplying {
         lastInsertionAppIdentity: PasteAppIdentity?,
         lastInsertionAt: Date,
         lastInsertedTrailingCharacter: Character?,
+        lastInsertedTrailingNonWhitespaceCharacter: Character?,
         identityMatcher: (PasteAppIdentity, PasteAppIdentity) -> Bool,
         shouldPreserveLeadingCapitalization: (String) -> Bool
     ) -> String
@@ -33,6 +34,7 @@ final class PasteCapitalizationHeuristics: PasteCapitalizationHeuristicApplying 
         lastInsertionAppIdentity: PasteAppIdentity?,
         lastInsertionAt: Date,
         lastInsertedTrailingCharacter: Character?,
+        lastInsertedTrailingNonWhitespaceCharacter: Character?,
         identityMatcher: (PasteAppIdentity, PasteAppIdentity) -> Bool,
         shouldPreserveLeadingCapitalization: (String) -> Bool
     ) -> String {
@@ -48,6 +50,7 @@ final class PasteCapitalizationHeuristics: PasteCapitalizationHeuristicApplying 
             lastInsertionAppIdentity: lastInsertionAppIdentity,
             lastInsertionAt: lastInsertionAt,
             lastInsertedTrailingCharacter: lastInsertedTrailingCharacter,
+            lastInsertedTrailingNonWhitespaceCharacter: lastInsertedTrailingNonWhitespaceCharacter,
             identityMatcher: identityMatcher
         ) else {
             return text
@@ -67,15 +70,19 @@ final class PasteCapitalizationHeuristics: PasteCapitalizationHeuristicApplying 
         lastInsertionAppIdentity: PasteAppIdentity?,
         lastInsertionAt: Date,
         lastInsertedTrailingCharacter: Character?,
+        lastInsertedTrailingNonWhitespaceCharacter: Character?,
         identityMatcher: (PasteAppIdentity, PasteAppIdentity) -> Bool
     ) -> Bool {
         if let context = axInspector.focusedInsertionContext() {
-            if context.caretLocation == 0 {
+            if let caretLocation = context.caretLocation, caretLocation == 0 {
                 return true
             }
 
-            guard context.selectionLength == 0 else { return false }
-            return context.previousCharacter.map(isSentenceBoundary) ?? false
+            if let selectionLength = context.selectionLength,
+               let previousNonWhitespaceCharacter = context.previousNonWhitespaceCharacter,
+               selectionLength == 0 {
+                return isSentenceBoundary(previousNonWhitespaceCharacter)
+            }
         }
 
         guard let currentIdentity,
@@ -85,7 +92,9 @@ final class PasteCapitalizationHeuristics: PasteCapitalizationHeuristicApplying 
             return true
         }
 
-        return lastInsertedTrailingCharacter.map(isSentenceBoundary) ?? false
+        let boundaryCharacter = lastInsertedTrailingNonWhitespaceCharacter
+            ?? lastInsertedTrailingCharacter.flatMap { $0.isWhitespace ? nil : $0 }
+        return boundaryCharacter.map(isSentenceBoundary) ?? false
     }
 
     private func isSentenceBoundary(_ character: Character) -> Bool {

--- a/Core/Services/Paste/Heuristics/PasteCapitalizationHeuristics.swift
+++ b/Core/Services/Paste/Heuristics/PasteCapitalizationHeuristics.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+protocol PasteCapitalizationHeuristicApplying {
+    func normalizeLeadingCapitalizationIfNeeded(
+        in text: String,
+        currentIdentity: PasteAppIdentity?,
+        lastInsertionAppIdentity: PasteAppIdentity?,
+        lastInsertionAt: Date,
+        lastInsertedTrailingCharacter: Character?,
+        identityMatcher: (PasteAppIdentity, PasteAppIdentity) -> Bool,
+        shouldPreserveLeadingCapitalization: (String) -> Bool
+    ) -> String
+}
+
+final class PasteCapitalizationHeuristics: PasteCapitalizationHeuristicApplying {
+    private let axInspector: PasteAXInspecting
+    private let heuristicTTL: TimeInterval
+    private let clockNow: () -> Date
+
+    init(
+        axInspector: PasteAXInspecting,
+        heuristicTTL: TimeInterval,
+        clockNow: @escaping () -> Date = Date.init
+    ) {
+        self.axInspector = axInspector
+        self.heuristicTTL = heuristicTTL
+        self.clockNow = clockNow
+    }
+
+    func normalizeLeadingCapitalizationIfNeeded(
+        in text: String,
+        currentIdentity: PasteAppIdentity?,
+        lastInsertionAppIdentity: PasteAppIdentity?,
+        lastInsertionAt: Date,
+        lastInsertedTrailingCharacter: Character?,
+        identityMatcher: (PasteAppIdentity, PasteAppIdentity) -> Bool,
+        shouldPreserveLeadingCapitalization: (String) -> Bool
+    ) -> String {
+        guard !text.isEmpty else { return text }
+        guard let firstLetterIndex = text.firstIndex(where: \.isLetter) else { return text }
+        guard text[..<firstLetterIndex].allSatisfy(\.isWhitespace) else { return text }
+        guard !shouldPreserveLeadingCapitalization(text) else { return text }
+
+        let leadingWord = text[firstLetterIndex...].prefix(while: \.isLetter)
+        guard isDefaultSentenceCase(word: leadingWord) else { return text }
+        guard !isSentenceStart(
+            currentIdentity: currentIdentity,
+            lastInsertionAppIdentity: lastInsertionAppIdentity,
+            lastInsertionAt: lastInsertionAt,
+            lastInsertedTrailingCharacter: lastInsertedTrailingCharacter,
+            identityMatcher: identityMatcher
+        ) else {
+            return text
+        }
+
+        var output = text
+        let firstCharacter = output[firstLetterIndex]
+        output.replaceSubrange(
+            firstLetterIndex...firstLetterIndex,
+            with: String(firstCharacter).lowercased()
+        )
+        return output
+    }
+
+    private func isSentenceStart(
+        currentIdentity: PasteAppIdentity?,
+        lastInsertionAppIdentity: PasteAppIdentity?,
+        lastInsertionAt: Date,
+        lastInsertedTrailingCharacter: Character?,
+        identityMatcher: (PasteAppIdentity, PasteAppIdentity) -> Bool
+    ) -> Bool {
+        if let context = axInspector.focusedInsertionContext() {
+            if context.caretLocation == 0 {
+                return true
+            }
+
+            guard context.selectionLength == 0 else { return false }
+            return context.previousCharacter.map(isSentenceBoundary) ?? false
+        }
+
+        guard let currentIdentity,
+              let lastInsertionAppIdentity,
+              identityMatcher(currentIdentity, lastInsertionAppIdentity),
+              clockNow().timeIntervalSince(lastInsertionAt) <= heuristicTTL else {
+            return true
+        }
+
+        return lastInsertedTrailingCharacter.map(isSentenceBoundary) ?? false
+    }
+
+    private func isSentenceBoundary(_ character: Character) -> Bool {
+        character == "." || character == "?" || character == "!"
+    }
+
+    private func isDefaultSentenceCase<S: StringProtocol>(word: S) -> Bool {
+        guard let firstCharacter = word.first else { return false }
+        guard firstCharacter.isUppercase else { return false }
+
+        let remainder = word.dropFirst()
+        guard !remainder.isEmpty else { return false }
+        return remainder.allSatisfy { !$0.isUppercase }
+    }
+}

--- a/Core/Services/Paste/Heuristics/PasteDictionaryCasingStore.swift
+++ b/Core/Services/Paste/Heuristics/PasteDictionaryCasingStore.swift
@@ -3,32 +3,55 @@ import Foundation
 struct PasteDictionaryCasingStore {
     private let dictionaryFileURL: URL
     private let fileManager: FileManager
-    private let decoder: JSONDecoder
 
     init(
         dictionaryFileURL: URL? = nil,
-        fileManager: FileManager = .default,
-        decoder: JSONDecoder = JSONDecoder()
+        fileManager: FileManager = .default
     ) {
         self.dictionaryFileURL = dictionaryFileURL
             ?? fileManager.homeDirectoryForCurrentUser
                 .appendingPathComponent("Library/Application Support/KeyVox/Dictionary/dictionary.json")
         self.fileManager = fileManager
-        self.decoder = decoder
     }
 
     func shouldPreserveLeadingCapitalization(in text: String) -> Bool {
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedText.isEmpty else { return false }
 
-        guard let data = try? Data(contentsOf: dictionaryFileURL),
-              let payload = try? decoder.decode(DictionaryPayload.self, from: data) else {
-            return false
+        let cacheKey = dictionaryFileURL.path
+        reloadIfNeeded(cacheKey: cacheKey)
+        let cachedEntries = Self.cachedEntriesByPath[cacheKey] ?? []
+
+        return cachedEntries.contains { phrase in
+            hasLeadingPhraseMatch(trimmedText, phrase: phrase)
+        }
+    }
+
+    private func reloadIfNeeded(cacheKey: String) {
+        let modificationDate = fileModificationDate()
+        let hasLoadedEntries = Self.loadedPaths.contains(cacheKey)
+        let cachedModificationDate = Self.cachedModificationDateByPath[cacheKey]
+        guard !hasLoadedEntries || cachedModificationDate != modificationDate else {
+            return
         }
 
-        return payload.entries.contains { entry in
-            hasLeadingPhraseMatch(trimmedText, phrase: entry.phrase)
+        Self.loadedPaths.insert(cacheKey)
+        Self.cachedModificationDateByPath[cacheKey] = modificationDate
+
+        guard let data = try? Data(contentsOf: dictionaryFileURL) else {
+            Self.cachedEntriesByPath[cacheKey] = []
+            return
         }
+
+        Self.cachedEntriesByPath[cacheKey] = extractPhrases(from: data)
+    }
+
+    private func fileModificationDate() -> Date? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: dictionaryFileURL.path) else {
+            return nil
+        }
+
+        return attributes[.modificationDate] as? Date
     }
 
     private func hasLeadingPhraseMatch(_ text: String, phrase: String) -> Bool {
@@ -41,14 +64,20 @@ struct PasteDictionaryCasingStore {
         let boundaryCharacter = text[boundaryIndex]
         return boundaryCharacter.isWhitespace || boundaryCharacter.isPunctuation
     }
-}
 
-private struct DictionaryPayload: Decodable {
-    let version: Int
-    let entries: [DictionaryEntryRecord]
-}
+    private func extractPhrases(from data: Data) -> [String] {
+        guard let rootObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let entries = rootObject["entries"] as? [[String: Any]] else {
+            return []
+        }
 
-private struct DictionaryEntryRecord: Decodable {
-    let id: UUID?
-    let phrase: String
+        return entries.compactMap { entry in
+            guard let phrase = entry["phrase"] as? String else { return nil }
+            return phrase
+        }
+    }
+
+    private static var cachedEntriesByPath: [String: [String]] = [:]
+    private static var cachedModificationDateByPath: [String: Date?] = [:]
+    private static var loadedPaths: Set<String> = []
 }

--- a/Core/Services/Paste/Heuristics/PasteDictionaryCasingStore.swift
+++ b/Core/Services/Paste/Heuristics/PasteDictionaryCasingStore.swift
@@ -19,31 +19,34 @@ struct PasteDictionaryCasingStore {
         guard !trimmedText.isEmpty else { return false }
 
         let cacheKey = dictionaryFileURL.path
-        reloadIfNeeded(cacheKey: cacheKey)
-        let cachedEntries = Self.cachedEntriesByPath[cacheKey] ?? []
+        let cachedEntries = reloadIfNeeded(cacheKey: cacheKey)
 
         return cachedEntries.contains { phrase in
             hasLeadingPhraseMatch(trimmedText, phrase: phrase)
         }
     }
 
-    private func reloadIfNeeded(cacheKey: String) {
+    private func reloadIfNeeded(cacheKey: String) -> [String] {
         let modificationDate = fileModificationDate()
-        let hasLoadedEntries = Self.loadedPaths.contains(cacheKey)
-        let cachedModificationDate = Self.cachedModificationDateByPath[cacheKey]
-        guard !hasLoadedEntries || cachedModificationDate != modificationDate else {
-            return
+        return Self.cacheQueue.sync {
+            let hasLoadedEntries = Self.loadedPaths.contains(cacheKey)
+            let cachedModificationDate = Self.cachedModificationDateByPath[cacheKey]
+            guard !hasLoadedEntries || cachedModificationDate != modificationDate else {
+                return Self.cachedEntriesByPath[cacheKey] ?? []
+            }
+
+            Self.loadedPaths.insert(cacheKey)
+            Self.cachedModificationDateByPath[cacheKey] = modificationDate
+
+            guard let data = try? Data(contentsOf: dictionaryFileURL) else {
+                Self.cachedEntriesByPath[cacheKey] = []
+                return []
+            }
+
+            let entries = extractPhrases(from: data)
+            Self.cachedEntriesByPath[cacheKey] = entries
+            return entries
         }
-
-        Self.loadedPaths.insert(cacheKey)
-        Self.cachedModificationDateByPath[cacheKey] = modificationDate
-
-        guard let data = try? Data(contentsOf: dictionaryFileURL) else {
-            Self.cachedEntriesByPath[cacheKey] = []
-            return
-        }
-
-        Self.cachedEntriesByPath[cacheKey] = extractPhrases(from: data)
     }
 
     private func fileModificationDate() -> Date? {
@@ -77,6 +80,15 @@ struct PasteDictionaryCasingStore {
         }
     }
 
+    static func resetCaches() {
+        cacheQueue.sync {
+            cachedEntriesByPath.removeAll()
+            cachedModificationDateByPath.removeAll()
+            loadedPaths.removeAll()
+        }
+    }
+
+    private static let cacheQueue = DispatchQueue(label: "PasteDictionaryCasingStore.cacheQueue")
     private static var cachedEntriesByPath: [String: [String]] = [:]
     private static var cachedModificationDateByPath: [String: Date?] = [:]
     private static var loadedPaths: Set<String> = []

--- a/Core/Services/Paste/Heuristics/PasteDictionaryCasingStore.swift
+++ b/Core/Services/Paste/Heuristics/PasteDictionaryCasingStore.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+struct PasteDictionaryCasingStore {
+    private let dictionaryFileURL: URL
+    private let fileManager: FileManager
+    private let decoder: JSONDecoder
+
+    init(
+        dictionaryFileURL: URL? = nil,
+        fileManager: FileManager = .default,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.dictionaryFileURL = dictionaryFileURL
+            ?? fileManager.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Application Support/KeyVox/Dictionary/dictionary.json")
+        self.fileManager = fileManager
+        self.decoder = decoder
+    }
+
+    func shouldPreserveLeadingCapitalization(in text: String) -> Bool {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else { return false }
+
+        guard let data = try? Data(contentsOf: dictionaryFileURL),
+              let payload = try? decoder.decode(DictionaryPayload.self, from: data) else {
+            return false
+        }
+
+        return payload.entries.contains { entry in
+            hasLeadingPhraseMatch(trimmedText, phrase: entry.phrase)
+        }
+    }
+
+    private func hasLeadingPhraseMatch(_ text: String, phrase: String) -> Bool {
+        let trimmedPhrase = phrase.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPhrase.isEmpty else { return false }
+        guard text.hasPrefix(trimmedPhrase) else { return false }
+        guard text.count > trimmedPhrase.count else { return true }
+
+        let boundaryIndex = text.index(text.startIndex, offsetBy: trimmedPhrase.count)
+        let boundaryCharacter = text[boundaryIndex]
+        return boundaryCharacter.isWhitespace || boundaryCharacter.isPunctuation
+    }
+}
+
+private struct DictionaryPayload: Decodable {
+    let version: Int
+    let entries: [DictionaryEntryRecord]
+}
+
+private struct DictionaryEntryRecord: Decodable {
+    let id: UUID?
+    let phrase: String
+}

--- a/Core/Services/Paste/PasteService.swift
+++ b/Core/Services/Paste/PasteService.swift
@@ -15,6 +15,8 @@ class PasteService {
     private let accessibilityInjector: PasteAccessibilityInjecting
     private let menuFallbackExecutor: PasteMenuFallbackExecuting
     private let menuFallbackCoordinator: PasteMenuFallbackCoordinating
+    private let dictionaryCasingStore: PasteDictionaryCasingStore
+    private let capitalizationHeuristics: PasteCapitalizationHeuristicApplying
     private let spacingHeuristics: PasteSpacingHeuristicApplying
     private let clipboardAdapter: PasteClipboardAdapting
     private let failureRecoveryController: PasteFailureRecoveryControlling
@@ -36,6 +38,8 @@ class PasteService {
         accessibilityInjector: PasteAccessibilityInjecting? = nil,
         menuFallbackExecutor: PasteMenuFallbackExecuting? = nil,
         menuFallbackCoordinator: PasteMenuFallbackCoordinating = PasteMenuFallbackCoordinator(),
+        dictionaryCasingStore: PasteDictionaryCasingStore = PasteDictionaryCasingStore(),
+        capitalizationHeuristics: PasteCapitalizationHeuristicApplying? = nil,
         spacingHeuristics: PasteSpacingHeuristicApplying? = nil
     ) {
         self.pasteQueue = pasteQueue
@@ -57,6 +61,13 @@ class PasteService {
                 verificationPollInterval: menuFallbackVerificationPollInterval
             )
         self.menuFallbackCoordinator = menuFallbackCoordinator
+        self.dictionaryCasingStore = dictionaryCasingStore
+        self.capitalizationHeuristics = capitalizationHeuristics
+            ?? PasteCapitalizationHeuristics(
+                axInspector: axInspector,
+                heuristicTTL: heuristicTTL,
+                clockNow: clockNow
+            )
         self.spacingHeuristics = spacingHeuristics
             ?? PasteSpacingHeuristics(
                 axInspector: axInspector,
@@ -70,8 +81,19 @@ class PasteService {
         cancelActiveRecoveryOnMainThread()
 
         let targetAppIdentity = frontmostAppIdentity()
+        let capitalizationNormalizedText = capitalizationHeuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: text,
+            currentIdentity: targetAppIdentity,
+            lastInsertionAppIdentity: lastInsertionAppIdentity,
+            lastInsertionAt: lastInsertionAt,
+            lastInsertedTrailingCharacter: lastInsertedTrailingCharacter,
+            identityMatcher: appIdentityMatches,
+            shouldPreserveLeadingCapitalization: { [dictionaryCasingStore] incomingText in
+                dictionaryCasingStore.shouldPreserveLeadingCapitalization(in: incomingText)
+            }
+        )
         let insertionText = spacingHeuristics.applySmartLeadingSeparatorIfNeeded(
-            to: text,
+            to: capitalizationNormalizedText,
             currentIdentity: targetAppIdentity,
             lastInsertionAppIdentity: lastInsertionAppIdentity,
             lastInsertionAt: lastInsertionAt,

--- a/Core/Services/Paste/PasteService.swift
+++ b/Core/Services/Paste/PasteService.swift
@@ -10,6 +10,7 @@ class PasteService {
     private var lastInsertionAppIdentity: PasteAppIdentity?
     private var lastInsertionAt: Date = .distantPast
     private var lastInsertedTrailingCharacter: Character?
+    private var lastInsertedTrailingNonWhitespaceCharacter: Character?
 
     private let axInspector: PasteAXInspecting
     private let accessibilityInjector: PasteAccessibilityInjecting
@@ -87,6 +88,7 @@ class PasteService {
             lastInsertionAppIdentity: lastInsertionAppIdentity,
             lastInsertionAt: lastInsertionAt,
             lastInsertedTrailingCharacter: lastInsertedTrailingCharacter,
+            lastInsertedTrailingNonWhitespaceCharacter: lastInsertedTrailingNonWhitespaceCharacter,
             identityMatcher: appIdentityMatches,
             shouldPreserveLeadingCapitalization: { [dictionaryCasingStore] incomingText in
                 dictionaryCasingStore.shouldPreserveLeadingCapitalization(in: incomingText)
@@ -209,6 +211,7 @@ class PasteService {
         lastInsertionAppIdentity = appIdentity
         lastInsertionAt = clockNow()
         lastInsertedTrailingCharacter = text.last
+        lastInsertedTrailingNonWhitespaceCharacter = text.last { !$0.isWhitespace }
     }
 
     private func cancelActiveRecoveryOnMainThread() {

--- a/Core/Services/Paste/Pipeline/PasteModels.swift
+++ b/Core/Services/Paste/Pipeline/PasteModels.swift
@@ -10,6 +10,19 @@ struct PasteInsertionContext {
     let selectionLength: Int?
     let caretLocation: Int?
     let previousCharacter: Character?
+    let previousNonWhitespaceCharacter: Character?
+
+    init(
+        selectionLength: Int?,
+        caretLocation: Int?,
+        previousCharacter: Character?,
+        previousNonWhitespaceCharacter: Character? = nil
+    ) {
+        self.selectionLength = selectionLength
+        self.caretLocation = caretLocation
+        self.previousCharacter = previousCharacter
+        self.previousNonWhitespaceCharacter = previousNonWhitespaceCharacter
+    }
 }
 
 enum PasteAccessibilityInjectionOutcome {

--- a/Docs/CODEMAP.md
+++ b/Docs/CODEMAP.md
@@ -94,7 +94,7 @@ KeyVox/
 4. `Packages/KeyVoxCore/Sources/KeyVoxCore/Services/Whisper/WhisperAudioParagraphChunker.swift` detects long internal silence and computes conservative chunk boundaries.
 5. `Packages/KeyVoxCore/Sources/KeyVoxCore/Services/Whisper/WhisperService.swift` transcribes each chunk through `KeyVoxWhisper` and stitches chunks with paragraph or space separators.
 6. `Packages/KeyVoxCore/Sources/KeyVoxCore/Transcription/TranscriptionPostProcessor.swift` orchestrates dictionary correction, list formatting, and specialized normalization helpers under `Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/`, including four-digit quantity grouping.
-7. `Core/Services/Paste/PasteService.swift` inserts text via Accessibility first, then menu-bar Paste fallback.
+7. `Core/Services/Paste/PasteService.swift` normalizes leading capitalization and spacing, then inserts text via Accessibility first and menu-bar Paste fallback second.
 8. `Core/Overlay/OverlayManager.swift` owns overlay lifecycle orchestration and delegates motion/persistence helpers.
 9. `Core/Overlay/AudioIndicatorDriver.swift` owns generic indicator timing, smoothing, stale-sample handling, and published timeline state.
 10. `Views/RecordingOverlay.swift` hosts overlay visibility behavior and feeds generic indicator state into the branded renderer.
@@ -423,7 +423,7 @@ KeyVox/
 - `Tools/README.md`
   - Maintainer/contributor guide for all scripts in `Tools/`.
 - `Core/Services/Paste/PasteService.swift`
-  - Orchestrates paste pipeline (AX injection, menu fallback, recovery, clipboard restore).
+  - Orchestrates paste pipeline (dictionary-aware leading-cap normalization, smart spacing, AX injection, menu fallback, recovery, clipboard restore).
   - Determines preferred list render mode from focused AX role for single-line graceful fallback.
 - `Core/Services/Paste/Clipboard/PasteFailureRecoveryCoordinator.swift`
   - Manages active paste-failure recovery session lifecycle, timers, and Command-V detection.
@@ -445,6 +445,11 @@ KeyVox/
   - Encapsulates AXObserver lifecycle used for live value-change verification during menu fallback.
 - `Core/Services/Paste/Clipboard/PasteClipboardSnapshot.swift`
   - Full-fidelity clipboard snapshot capture/restore utilities.
+- `Core/Services/Paste/Heuristics/PasteCapitalizationHeuristics.swift`
+  - Sentence-boundary-aware leading-cap normalization for finalized transcription right before insertion.
+  - Preserves dictionary-backed and structurally intentional casing while removing Whisper-style sentence casing mid-sentence.
+- `Core/Services/Paste/Heuristics/PasteDictionaryCasingStore.swift`
+  - Reads the persisted macOS dictionary snapshot to preserve exact leading phrase casing during paste-time normalization.
 - `Core/Services/Paste/Heuristics/PasteSpacingHeuristics.swift`
   - Smart leading separator logic and cross-dictation spacing heuristics.
 - `Core/Services/Paste/Pipeline/PastePolicies.swift`

--- a/Docs/ENGINEERING.md
+++ b/Docs/ENGINEERING.md
@@ -65,7 +65,7 @@ For the full file-level map, see [`CODEMAP.md`](CODEMAP.md).
 5. List formatting applies numeric list rendering when confidence gates pass.
 6. Late cleanup normalizes residual model output after list rendering: `LaughterNormalizer`, `CharacterSpamNormalizer`, `TimeExpressionNormalizer`, final email boundary repair, `WebsiteNormalizer`, and `ThousandsGroupingNormalizer`.
 7. Final finishers apply render-mode whitespace cleanup, capitalization guards (including URL/domain/email and technical-token safety checks), terminal-time punctuation completion, and the optional `AllCapsOverrideNormalizer`.
-8. Final text is inserted via the paste service.
+8. Final text is inserted via the paste service, where macOS applies final insertion-time heuristics such as dictionary-aware leading-cap normalization and smart spacing based on the focused target context.
 
 ## Update Feed and Release Checks
 

--- a/KeyVox.xcodeproj/project.pbxproj
+++ b/KeyVox.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		9A1000152F4B000100AA0001 /* PasteMenuFallbackExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1000052F4B000100AA0001 /* PasteMenuFallbackExecutor.swift */; };
 		9A1000162F4B000100AA0001 /* PasteClipboardSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1000062F4B000100AA0001 /* PasteClipboardSnapshot.swift */; };
 		9A1000172F4B000100AA0001 /* PasteSpacingHeuristics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1000072F4B000100AA0001 /* PasteSpacingHeuristics.swift */; };
+		9A1000222F4B000100AA0001 /* PasteCapitalizationHeuristics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1000232F4B000100AA0001 /* PasteCapitalizationHeuristics.swift */; };
+		9A1000242F4B000100AA0001 /* PasteDictionaryCasingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1000252F4B000100AA0001 /* PasteDictionaryCasingStore.swift */; };
 		9A1000182F4B000100AA0001 /* PastePolicies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1000082F4B000100AA0001 /* PastePolicies.swift */; };
 		9A1000192F4B000100AA0001 /* PasteMenuScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1000092F4B000100AA0001 /* PasteMenuScanner.swift */; };
 		9A1000202F4B000100AA0001 /* PasteAXLiveSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1000102F4B000100AA0001 /* PasteAXLiveSession.swift */; };
@@ -99,6 +101,7 @@
 		AB3000282F60000100AA0001 /* PasteWarningGuardrailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000282F60000100AA0001 /* PasteWarningGuardrailTests.swift */; };
 		AB3000302F60000100AA0001 /* ModelDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000302F60000100AA0001 /* ModelDownloaderTests.swift */; };
 		AB3000312F60000100AA0001 /* PasteSpacingHeuristicsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000312F60000100AA0001 /* PasteSpacingHeuristicsTests.swift */; };
+		AB3000402F60000100AA0001 /* PasteCapitalizationHeuristicsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000402F60000100AA0001 /* PasteCapitalizationHeuristicsTests.swift */; };
 		AB3000322F60000100AA0001 /* PasteMenuFallbackCoordinatorExecutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000322F60000100AA0001 /* PasteMenuFallbackCoordinatorExecutionTests.swift */; };
 		AB3000332F60000100AA0001 /* PasteClipboardSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000332F60000100AA0001 /* PasteClipboardSnapshotTests.swift */; };
 		AB3000342F60000100AA0001 /* AppSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000342F60000100AA0001 /* AppSettingsStoreTests.swift */; };
@@ -215,6 +218,8 @@
 		9A1000052F4B000100AA0001 /* PasteMenuFallbackExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteMenuFallbackExecutor.swift; sourceTree = "<group>"; };
 		9A1000062F4B000100AA0001 /* PasteClipboardSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteClipboardSnapshot.swift; sourceTree = "<group>"; };
 		9A1000072F4B000100AA0001 /* PasteSpacingHeuristics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteSpacingHeuristics.swift; sourceTree = "<group>"; };
+		9A1000232F4B000100AA0001 /* PasteCapitalizationHeuristics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteCapitalizationHeuristics.swift; sourceTree = "<group>"; };
+		9A1000252F4B000100AA0001 /* PasteDictionaryCasingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteDictionaryCasingStore.swift; sourceTree = "<group>"; };
 		9A1000082F4B000100AA0001 /* PastePolicies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PastePolicies.swift; sourceTree = "<group>"; };
 		9A1000092F4B000100AA0001 /* PasteMenuScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteMenuScanner.swift; sourceTree = "<group>"; };
 		9A1000102F4B000100AA0001 /* PasteAXLiveSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteAXLiveSession.swift; sourceTree = "<group>"; };
@@ -255,6 +260,7 @@
 		AB2000282F60000100AA0001 /* PasteWarningGuardrailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteWarningGuardrailTests.swift; sourceTree = "<group>"; };
 		AB2000302F60000100AA0001 /* ModelDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDownloaderTests.swift; sourceTree = "<group>"; };
 		AB2000312F60000100AA0001 /* PasteSpacingHeuristicsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteSpacingHeuristicsTests.swift; sourceTree = "<group>"; };
+		AB2000402F60000100AA0001 /* PasteCapitalizationHeuristicsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteCapitalizationHeuristicsTests.swift; sourceTree = "<group>"; };
 		AB2000322F60000100AA0001 /* PasteMenuFallbackCoordinatorExecutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteMenuFallbackCoordinatorExecutionTests.swift; sourceTree = "<group>"; };
 		AB2000332F60000100AA0001 /* PasteClipboardSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteClipboardSnapshotTests.swift; sourceTree = "<group>"; };
 		AB2000342F60000100AA0001 /* AppSettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStoreTests.swift; sourceTree = "<group>"; };
@@ -565,6 +571,7 @@
 				AB2000172F60000100AA0001 /* PasteFailureRecoveryPolicyTests.swift */,
 				AB2000322F60000100AA0001 /* PasteMenuFallbackCoordinatorExecutionTests.swift */,
 				AB2000272F60000100AA0001 /* PasteMenuFallbackExecutorTests.swift */,
+				AB2000402F60000100AA0001 /* PasteCapitalizationHeuristicsTests.swift */,
 				AB2000252F60000100AA0001 /* PastePoliciesStabilityTests.swift */,
 				AB2000352F60000100AA0001 /* PasteServiceExecutionTests.swift */,
 				AB2000162F60000100AA0001 /* PasteServiceListRenderModeTests.swift */,
@@ -656,6 +663,8 @@
 		C12000052F91000100AA0001 /* Heuristics */ = {
 			isa = PBXGroup;
 			children = (
+				9A1000232F4B000100AA0001 /* PasteCapitalizationHeuristics.swift */,
+				9A1000252F4B000100AA0001 /* PasteDictionaryCasingStore.swift */,
 				9A1000072F4B000100AA0001 /* PasteSpacingHeuristics.swift */,
 			);
 			path = Heuristics;
@@ -926,6 +935,8 @@
 				9A1000212F4B000100AA0001 /* PasteMenuFallbackCoordinator.swift in Sources */,
 				9A1000192F4B000100AA0001 /* PasteMenuScanner.swift in Sources */,
 				9A1000162F4B000100AA0001 /* PasteClipboardSnapshot.swift in Sources */,
+				9A1000222F4B000100AA0001 /* PasteCapitalizationHeuristics.swift in Sources */,
+				9A1000242F4B000100AA0001 /* PasteDictionaryCasingStore.swift in Sources */,
 				9A1000172F4B000100AA0001 /* PasteSpacingHeuristics.swift in Sources */,
 				9A1000182F4B000100AA0001 /* PastePolicies.swift in Sources */,
 				8F7702012F49010000117701 /* PasteFailureRecoveryCoordinator.swift in Sources */,
@@ -960,6 +971,7 @@
 				AB3000322F60000100AA0001 /* PasteMenuFallbackCoordinatorExecutionTests.swift in Sources */,
 				AB3000272F60000100AA0001 /* PasteMenuFallbackExecutorTests.swift in Sources */,
 				AB3000352F60000100AA0001 /* PasteServiceExecutionTests.swift in Sources */,
+				AB3000402F60000100AA0001 /* PasteCapitalizationHeuristicsTests.swift in Sources */,
 				AB3000312F60000100AA0001 /* PasteSpacingHeuristicsTests.swift in Sources */,
 				F20000062FB0000100AA0001 /* AudioIndicatorDriverTests.swift in Sources */,
 				8E03671C2F49848500017017 /* PasteServiceExecutionMocks.swift in Sources */,

--- a/KeyVoxTests/Services/PasteCapitalizationHeuristicsTests.swift
+++ b/KeyVoxTests/Services/PasteCapitalizationHeuristicsTests.swift
@@ -1,0 +1,277 @@
+import ApplicationServices
+import Foundation
+import XCTest
+@testable import KeyVox
+
+@MainActor
+final class PasteCapitalizationHeuristicsTests: XCTestCase {
+    private static var retainedHeuristics: [PasteCapitalizationHeuristics] = []
+
+    func testKeepsCapitalizationAtFieldStart() {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(selectionLength: 0, caretLocation: 0, previousCharacter: nil)
+            )
+        )
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "Hello")
+    }
+
+    func testKeepsCapitalizationAfterPeriod() {
+        assertSentenceBoundaryPreservesCapitalization(previousCharacter: ".")
+    }
+
+    func testKeepsCapitalizationAfterQuestionMark() {
+        assertSentenceBoundaryPreservesCapitalization(previousCharacter: "?")
+    }
+
+    func testKeepsCapitalizationAfterExclamationPoint() {
+        assertSentenceBoundaryPreservesCapitalization(previousCharacter: "!")
+    }
+
+    func testLowercasesDefaultSentenceCaseMidSentence() {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(selectionLength: 0, caretLocation: 4, previousCharacter: "x")
+            )
+        )
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "hello")
+    }
+
+    func testLowercasesDefaultSentenceCaseWithLeadingWhitespace() {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(selectionLength: 0, caretLocation: 4, previousCharacter: "x")
+            )
+        )
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "  Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "  hello")
+    }
+
+    func testPreservesAllCapsMidSentence() {
+        let output = normalizeMidSentence("NASA")
+        XCTAssertEqual(output, "NASA")
+    }
+
+    func testPreservesMixedCaseMidSentence() {
+        let output = normalizeMidSentence("OpenAI")
+        XCTAssertEqual(output, "OpenAI")
+    }
+
+    func testPreservesLeadingNonLetterMidSentence() {
+        let output = normalizeMidSentence("(Hello")
+        XCTAssertEqual(output, "(Hello")
+    }
+
+    func testSelectionReplacementStillNormalizesMidSentence() {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(selectionLength: 3, caretLocation: 4, previousCharacter: "x")
+            )
+        )
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "hello")
+    }
+
+    func testFallbackHeuristicLowercasesWithinTTLForMatchingIdentity() {
+        let heuristics = makeRetainedHeuristics(axInspector: MockPasteAXInspector(focusedContext: nil), heuristicTTL: 10)
+        let now = Date()
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: identity("com.example.app", 1),
+            lastInsertionAt: now.addingTimeInterval(-1),
+            lastInsertedTrailingCharacter: "x",
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "hello")
+    }
+
+    func testUnknownContextKeepsCapitalizationWithoutFallbackSignal() {
+        let heuristics = makeRetainedHeuristics(axInspector: MockPasteAXInspector(focusedContext: nil), heuristicTTL: 10)
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "Hello")
+    }
+
+    func testPreservesDictionaryCasedNameMidSentence() {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(selectionLength: 0, caretLocation: 4, previousCharacter: "x")
+            )
+        )
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Dom Esposito.",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { $0.hasPrefix("Dom Esposito") }
+        )
+
+        XCTAssertEqual(output, "Dom Esposito.")
+    }
+
+    func testDictionaryCasingStoreReadsPersistedDictionaryPayload() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let fileURL = directoryURL.appendingPathComponent("dictionary.json")
+        let payload = """
+        {
+          "version": 1,
+          "entries": [
+            {
+              "id": "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",
+              "phrase": "Dom Esposito"
+            }
+          ]
+        }
+        """
+        try Data(payload.utf8).write(to: fileURL)
+
+        let store = PasteDictionaryCasingStore(dictionaryFileURL: fileURL)
+
+        XCTAssertTrue(store.shouldPreserveLeadingCapitalization(in: "Dom Esposito."))
+        XCTAssertFalse(store.shouldPreserveLeadingCapitalization(in: "Hello world"))
+    }
+
+    private func assertSentenceBoundaryPreservesCapitalization(previousCharacter: Character) {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(selectionLength: 0, caretLocation: 4, previousCharacter: previousCharacter)
+            )
+        )
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "Hello")
+    }
+
+    private func normalizeMidSentence(_ text: String) -> String {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(selectionLength: 0, caretLocation: 4, previousCharacter: "x")
+            )
+        )
+
+        return heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: text,
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+    }
+
+    private func identity(_ bundleID: String, _ pid: pid_t) -> PasteAppIdentity {
+        PasteAppIdentity(bundleID: bundleID, pid: pid)
+    }
+
+    private var identityMatcher: (PasteAppIdentity, PasteAppIdentity) -> Bool {
+        { lhs, rhs in
+            lhs.bundleID == rhs.bundleID && lhs.pid == rhs.pid
+        }
+    }
+
+    private func makeRetainedHeuristics(
+        axInspector: PasteAXInspecting,
+        heuristicTTL: TimeInterval = 10
+    ) -> PasteCapitalizationHeuristics {
+        let heuristics = PasteCapitalizationHeuristics(
+            axInspector: axInspector,
+            heuristicTTL: heuristicTTL
+        )
+        Self.retainedHeuristics.append(heuristics)
+        return heuristics
+    }
+}
+
+private final class MockPasteAXInspector: PasteAXInspecting {
+    var focusedContext: PasteInsertionContext?
+
+    init(focusedContext: PasteInsertionContext?) {
+        self.focusedContext = focusedContext
+    }
+
+    func focusedInsertionContext() -> PasteInsertionContext? { focusedContext }
+    func focusedUIElement() -> AXUIElement? { nil }
+    func roleString(for element: AXUIElement) -> String? { nil }
+    func selectedRange(for element: AXUIElement) -> CFRange? { nil }
+    func stringForRange(_ range: CFRange, element: AXUIElement) -> String? { nil }
+    func previousCharacterFromValueAttribute(element: AXUIElement, caretLocation: Int) -> Character? { nil }
+    func valueLengthForMenuVerification(element: AXUIElement) -> Int? { nil }
+    func candidateVerificationElements(
+        for pid: pid_t,
+        maxDepth: Int,
+        maxNodes: Int,
+        maxCandidates: Int
+    ) -> [AXUIElement] {
+        []
+    }
+}

--- a/KeyVoxTests/Services/PasteCapitalizationHeuristicsTests.swift
+++ b/KeyVoxTests/Services/PasteCapitalizationHeuristicsTests.swift
@@ -20,6 +20,7 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
             lastInsertionAppIdentity: nil,
             lastInsertionAt: .distantPast,
             lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
             identityMatcher: identityMatcher,
             shouldPreserveLeadingCapitalization: { _ in false }
         )
@@ -39,10 +40,15 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
         assertSentenceBoundaryPreservesCapitalization(previousCharacter: "!")
     }
 
-    func testLowercasesDefaultSentenceCaseMidSentence() {
+    func testKeepsCapitalizationAfterPunctuationAndSpace() {
         let heuristics = makeRetainedHeuristics(
             axInspector: MockPasteAXInspector(
-                focusedContext: PasteInsertionContext(selectionLength: 0, caretLocation: 4, previousCharacter: "x")
+                focusedContext: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 5,
+                    previousCharacter: " ",
+                    previousNonWhitespaceCharacter: "."
+                )
             )
         )
 
@@ -52,6 +58,33 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
             lastInsertionAppIdentity: nil,
             lastInsertionAt: .distantPast,
             lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "Hello")
+    }
+
+    func testLowercasesDefaultSentenceCaseMidSentence() {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 4,
+                    previousCharacter: "x",
+                    previousNonWhitespaceCharacter: "x"
+                )
+            )
+        )
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
             identityMatcher: identityMatcher,
             shouldPreserveLeadingCapitalization: { _ in false }
         )
@@ -62,7 +95,12 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
     func testLowercasesDefaultSentenceCaseWithLeadingWhitespace() {
         let heuristics = makeRetainedHeuristics(
             axInspector: MockPasteAXInspector(
-                focusedContext: PasteInsertionContext(selectionLength: 0, caretLocation: 4, previousCharacter: "x")
+                focusedContext: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 4,
+                    previousCharacter: "x",
+                    previousNonWhitespaceCharacter: "x"
+                )
             )
         )
 
@@ -72,6 +110,7 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
             lastInsertionAppIdentity: nil,
             lastInsertionAt: .distantPast,
             lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
             identityMatcher: identityMatcher,
             shouldPreserveLeadingCapitalization: { _ in false }
         )
@@ -97,16 +136,22 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
     func testSelectionReplacementStillNormalizesMidSentence() {
         let heuristics = makeRetainedHeuristics(
             axInspector: MockPasteAXInspector(
-                focusedContext: PasteInsertionContext(selectionLength: 3, caretLocation: 4, previousCharacter: "x")
+                focusedContext: PasteInsertionContext(
+                    selectionLength: 3,
+                    caretLocation: 4,
+                    previousCharacter: "x",
+                    previousNonWhitespaceCharacter: "x"
+                )
             )
         )
 
         let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
             in: "Hello",
             currentIdentity: identity("com.example.app", 1),
-            lastInsertionAppIdentity: nil,
-            lastInsertionAt: .distantPast,
-            lastInsertedTrailingCharacter: nil,
+            lastInsertionAppIdentity: identity("com.example.app", 1),
+            lastInsertionAt: Date().addingTimeInterval(-1),
+            lastInsertedTrailingCharacter: "x",
+            lastInsertedTrailingNonWhitespaceCharacter: "x",
             identityMatcher: identityMatcher,
             shouldPreserveLeadingCapitalization: { _ in false }
         )
@@ -124,6 +169,7 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
             lastInsertionAppIdentity: identity("com.example.app", 1),
             lastInsertionAt: now.addingTimeInterval(-1),
             lastInsertedTrailingCharacter: "x",
+            lastInsertedTrailingNonWhitespaceCharacter: "x",
             identityMatcher: identityMatcher,
             shouldPreserveLeadingCapitalization: { _ in false }
         )
@@ -140,6 +186,7 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
             lastInsertionAppIdentity: nil,
             lastInsertionAt: .distantPast,
             lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
             identityMatcher: identityMatcher,
             shouldPreserveLeadingCapitalization: { _ in false }
         )
@@ -147,10 +194,43 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
         XCTAssertEqual(output, "Hello")
     }
 
+    func testPartialAXContextFallsBackToTTLSignal() {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(
+                    selectionLength: nil,
+                    caretLocation: 8,
+                    previousCharacter: nil,
+                    previousNonWhitespaceCharacter: nil
+                )
+            ),
+            heuristicTTL: 10
+        )
+        let now = Date()
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: identity("com.example.app", 1),
+            lastInsertionAt: now.addingTimeInterval(-1),
+            lastInsertedTrailingCharacter: "x",
+            lastInsertedTrailingNonWhitespaceCharacter: "x",
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "hello")
+    }
+
     func testPreservesDictionaryCasedNameMidSentence() {
         let heuristics = makeRetainedHeuristics(
             axInspector: MockPasteAXInspector(
-                focusedContext: PasteInsertionContext(selectionLength: 0, caretLocation: 4, previousCharacter: "x")
+                focusedContext: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 4,
+                    previousCharacter: "x",
+                    previousNonWhitespaceCharacter: "x"
+                )
             )
         )
 
@@ -160,6 +240,7 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
             lastInsertionAppIdentity: nil,
             lastInsertionAt: .distantPast,
             lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
             identityMatcher: identityMatcher,
             shouldPreserveLeadingCapitalization: { $0.hasPrefix("Dom Esposito") }
         )
@@ -194,7 +275,12 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
     private func assertSentenceBoundaryPreservesCapitalization(previousCharacter: Character) {
         let heuristics = makeRetainedHeuristics(
             axInspector: MockPasteAXInspector(
-                focusedContext: PasteInsertionContext(selectionLength: 0, caretLocation: 4, previousCharacter: previousCharacter)
+                focusedContext: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 4,
+                    previousCharacter: previousCharacter,
+                    previousNonWhitespaceCharacter: previousCharacter
+                )
             )
         )
 
@@ -204,6 +290,7 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
             lastInsertionAppIdentity: nil,
             lastInsertionAt: .distantPast,
             lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
             identityMatcher: identityMatcher,
             shouldPreserveLeadingCapitalization: { _ in false }
         )
@@ -214,7 +301,12 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
     private func normalizeMidSentence(_ text: String) -> String {
         let heuristics = makeRetainedHeuristics(
             axInspector: MockPasteAXInspector(
-                focusedContext: PasteInsertionContext(selectionLength: 0, caretLocation: 4, previousCharacter: "x")
+                focusedContext: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 4,
+                    previousCharacter: "x",
+                    previousNonWhitespaceCharacter: "x"
+                )
             )
         )
 
@@ -224,6 +316,7 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
             lastInsertionAppIdentity: nil,
             lastInsertionAt: .distantPast,
             lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
             identityMatcher: identityMatcher,
             shouldPreserveLeadingCapitalization: { _ in false }
         )

--- a/KeyVoxTests/Services/PasteCapitalizationHeuristicsTests.swift
+++ b/KeyVoxTests/Services/PasteCapitalizationHeuristicsTests.swift
@@ -249,8 +249,13 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
     }
 
     func testDictionaryCasingStoreReadsPersistedDictionaryPayload() throws {
+        PasteDictionaryCasingStore.resetCaches()
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        addTeardownBlock {
+            PasteDictionaryCasingStore.resetCaches()
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
         try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
         let fileURL = directoryURL.appendingPathComponent("dictionary.json")
         let payload = """

--- a/KeyVoxTests/Services/PasteServiceExecutionMocks.swift
+++ b/KeyVoxTests/Services/PasteServiceExecutionMocks.swift
@@ -71,6 +71,48 @@ final class MockSpacingHeuristics: PasteSpacingHeuristicApplying {
     }
 }
 
+final class MockCapitalizationHeuristics: PasteCapitalizationHeuristicApplying {
+    struct Input {
+        let text: String
+        let currentIdentity: PasteAppIdentity?
+        let lastInsertionAppIdentity: PasteAppIdentity?
+        let lastInsertionAt: Date
+        let lastInsertedTrailingCharacter: Character?
+    }
+
+    private let outputText: String
+    private(set) var inputs: [Input] = []
+    private(set) var preserveChecks: [String] = []
+
+    init(outputText: String) {
+        self.outputText = outputText
+    }
+
+    func normalizeLeadingCapitalizationIfNeeded(
+        in text: String,
+        currentIdentity: PasteAppIdentity?,
+        lastInsertionAppIdentity: PasteAppIdentity?,
+        lastInsertionAt: Date,
+        lastInsertedTrailingCharacter: Character?,
+        identityMatcher: (PasteAppIdentity, PasteAppIdentity) -> Bool,
+        shouldPreserveLeadingCapitalization: (String) -> Bool
+    ) -> String {
+        _ = identityMatcher
+        inputs.append(
+            Input(
+                text: text,
+                currentIdentity: currentIdentity,
+                lastInsertionAppIdentity: lastInsertionAppIdentity,
+                lastInsertionAt: lastInsertionAt,
+                lastInsertedTrailingCharacter: lastInsertedTrailingCharacter
+            )
+        )
+        preserveChecks.append(text)
+        _ = shouldPreserveLeadingCapitalization(text)
+        return outputText
+    }
+}
+
 final class MockAccessibilityInjector: PasteAccessibilityInjecting {
     private let outcome: PasteAccessibilityInjectionOutcome
 

--- a/KeyVoxTests/Services/PasteServiceExecutionMocks.swift
+++ b/KeyVoxTests/Services/PasteServiceExecutionMocks.swift
@@ -78,6 +78,7 @@ final class MockCapitalizationHeuristics: PasteCapitalizationHeuristicApplying {
         let lastInsertionAppIdentity: PasteAppIdentity?
         let lastInsertionAt: Date
         let lastInsertedTrailingCharacter: Character?
+        let lastInsertedTrailingNonWhitespaceCharacter: Character?
     }
 
     private let outputText: String
@@ -94,6 +95,7 @@ final class MockCapitalizationHeuristics: PasteCapitalizationHeuristicApplying {
         lastInsertionAppIdentity: PasteAppIdentity?,
         lastInsertionAt: Date,
         lastInsertedTrailingCharacter: Character?,
+        lastInsertedTrailingNonWhitespaceCharacter: Character?,
         identityMatcher: (PasteAppIdentity, PasteAppIdentity) -> Bool,
         shouldPreserveLeadingCapitalization: (String) -> Bool
     ) -> String {
@@ -104,7 +106,8 @@ final class MockCapitalizationHeuristics: PasteCapitalizationHeuristicApplying {
                 currentIdentity: currentIdentity,
                 lastInsertionAppIdentity: lastInsertionAppIdentity,
                 lastInsertionAt: lastInsertionAt,
-                lastInsertedTrailingCharacter: lastInsertedTrailingCharacter
+                lastInsertedTrailingCharacter: lastInsertedTrailingCharacter,
+                lastInsertedTrailingNonWhitespaceCharacter: lastInsertedTrailingNonWhitespaceCharacter
             )
         )
         preserveChecks.append(text)

--- a/KeyVoxTests/Services/PasteServiceExecutionTests.swift
+++ b/KeyVoxTests/Services/PasteServiceExecutionTests.swift
@@ -8,6 +8,7 @@ final class PasteServiceExecutionTests: XCTestCase {
     func testAccessibilityVerifiedSuccessRestoresClipboardAndSkipsRecovery() async throws {
         let clipboard = MockClipboardAdapter(snapshot: [[:]])
         let recovery = MockFailureRecoveryController()
+        let capitalization = MockCapitalizationHeuristics(outputText: "hello")
         let spacing = MockSpacingHeuristics()
         let injector = MockAccessibilityInjector(outcome: .verifiedSuccess)
         let coordinator = MockMenuFallbackCoordinator(result: .init(
@@ -18,6 +19,7 @@ final class PasteServiceExecutionTests: XCTestCase {
         let service = makeService(
             clipboard: clipboard,
             recovery: recovery,
+            capitalization: capitalization,
             spacing: spacing,
             injector: injector,
             coordinator: coordinator,
@@ -34,12 +36,47 @@ final class PasteServiceExecutionTests: XCTestCase {
         XCTAssertEqual(recovery.cancelCalls, 1)
         XCTAssertEqual(recovery.startCalls, 0)
         XCTAssertEqual(coordinator.executeCalls, 0)
+        XCTAssertEqual(capitalization.inputs.map(\.text), ["hello"])
+        XCTAssertEqual(clipboard.writes, ["hello"])
+    }
+
+    func testCapitalizationNormalizationFeedsSpacingHeuristics() async throws {
+        let clipboard = MockClipboardAdapter(snapshot: [[:]])
+        let recovery = MockFailureRecoveryController()
+        let capitalization = MockCapitalizationHeuristics(outputText: "hello")
+        let spacing = MockSpacingHeuristics()
+        let injector = MockAccessibilityInjector(outcome: .verifiedSuccess)
+        let coordinator = MockMenuFallbackCoordinator(result: .init(
+            didMenuFallbackInsert: false,
+            menuAttempt: nil,
+            suppressFirstWarmupFailureWarning: false
+        ))
+        let service = makeService(
+            clipboard: clipboard,
+            recovery: recovery,
+            capitalization: capitalization,
+            spacing: spacing,
+            injector: injector,
+            coordinator: coordinator,
+            restoreDelayAfterMenuFallback: 0.5,
+            restoreDelayAfterAccessibilityInjection: 0
+        )
+
+        service.pasteText("Hello")
+
+        try await waitForCondition {
+            clipboard.restoreCalls == 1
+        }
+
+        XCTAssertEqual(capitalization.inputs.map(\.text), ["Hello"])
+        XCTAssertEqual(spacing.inputs.map(\.text), ["hello"])
         XCTAssertEqual(clipboard.writes, ["hello"])
     }
 
     func testMenuFallbackSuccessRestoresClipboardAndSkipsRecovery() async throws {
         let clipboard = MockClipboardAdapter(snapshot: [[:]])
         let recovery = MockFailureRecoveryController()
+        let capitalization = MockCapitalizationHeuristics(outputText: "hello")
         let spacing = MockSpacingHeuristics()
         let injector = MockAccessibilityInjector(outcome: .failureNeedsFallback)
         let coordinator = MockMenuFallbackCoordinator(result: .init(
@@ -50,6 +87,7 @@ final class PasteServiceExecutionTests: XCTestCase {
         let service = makeService(
             clipboard: clipboard,
             recovery: recovery,
+            capitalization: capitalization,
             spacing: spacing,
             injector: injector,
             coordinator: coordinator,
@@ -70,6 +108,7 @@ final class PasteServiceExecutionTests: XCTestCase {
     func testMenuFallbackFailureStartsRecoveryWhenNotSuppressed() async throws {
         let clipboard = MockClipboardAdapter(snapshot: [[:]])
         let recovery = MockFailureRecoveryController()
+        let capitalization = MockCapitalizationHeuristics(outputText: "hello")
         let injector = MockAccessibilityInjector(outcome: .failureNeedsFallback)
         let coordinator = MockMenuFallbackCoordinator(result: .init(
             didMenuFallbackInsert: false,
@@ -79,6 +118,7 @@ final class PasteServiceExecutionTests: XCTestCase {
         let service = makeService(
             clipboard: clipboard,
             recovery: recovery,
+            capitalization: capitalization,
             spacing: MockSpacingHeuristics(),
             injector: injector,
             coordinator: coordinator,
@@ -98,6 +138,7 @@ final class PasteServiceExecutionTests: XCTestCase {
     func testMenuFallbackFailureSuppressedRestoresClipboardWithoutRecovery() async throws {
         let clipboard = MockClipboardAdapter(snapshot: [[:]])
         let recovery = MockFailureRecoveryController()
+        let capitalization = MockCapitalizationHeuristics(outputText: "hello")
         let injector = MockAccessibilityInjector(outcome: .failureNeedsFallback)
         let coordinator = MockMenuFallbackCoordinator(result: .init(
             didMenuFallbackInsert: false,
@@ -107,6 +148,7 @@ final class PasteServiceExecutionTests: XCTestCase {
         let service = makeService(
             clipboard: clipboard,
             recovery: recovery,
+            capitalization: capitalization,
             spacing: MockSpacingHeuristics(),
             injector: injector,
             coordinator: coordinator,
@@ -126,6 +168,7 @@ final class PasteServiceExecutionTests: XCTestCase {
     func testSuccessfulInsertionMemoryFeedsNextSpacingDecision() async throws {
         let clipboard = MockClipboardAdapter(snapshot: [[:]])
         let recovery = MockFailureRecoveryController()
+        let capitalization = MockCapitalizationHeuristics(outputText: "hello.")
         let spacing = MockSpacingHeuristics()
         let injector = MockAccessibilityInjector(outcome: .verifiedSuccess)
         let coordinator = MockMenuFallbackCoordinator(result: .init(
@@ -141,6 +184,7 @@ final class PasteServiceExecutionTests: XCTestCase {
         let service = makeService(
             clipboard: clipboard,
             recovery: recovery,
+            capitalization: capitalization,
             spacing: spacing,
             injector: injector,
             coordinator: coordinator,
@@ -194,6 +238,7 @@ final class PasteServiceExecutionTests: XCTestCase {
     private func makeService(
         clipboard: MockClipboardAdapter,
         recovery: MockFailureRecoveryController,
+        capitalization: MockCapitalizationHeuristics,
         spacing: MockSpacingHeuristics,
         injector: MockAccessibilityInjector,
         coordinator: MockMenuFallbackCoordinator,
@@ -217,6 +262,7 @@ final class PasteServiceExecutionTests: XCTestCase {
             accessibilityInjector: injector,
             menuFallbackExecutor: PasteServiceNoopFallbackExecutor(),
             menuFallbackCoordinator: coordinator,
+            capitalizationHeuristics: capitalization,
             spacingHeuristics: spacing
         )
         Self.retainedServices.append(service)

--- a/KeyVoxTests/Services/PasteServiceExecutionTests.swift
+++ b/KeyVoxTests/Services/PasteServiceExecutionTests.swift
@@ -17,7 +17,7 @@ final class PasteServiceExecutionTests: XCTestCase {
             menuAttempt: nil,
             suppressFirstWarmupFailureWarning: false
         ))
-        let service = makeService(
+        let service = try makeService(
             clipboard: clipboard,
             recovery: recovery,
             capitalization: capitalization,
@@ -52,7 +52,7 @@ final class PasteServiceExecutionTests: XCTestCase {
             menuAttempt: nil,
             suppressFirstWarmupFailureWarning: false
         ))
-        let service = makeService(
+        let service = try makeService(
             clipboard: clipboard,
             recovery: recovery,
             capitalization: capitalization,
@@ -85,7 +85,7 @@ final class PasteServiceExecutionTests: XCTestCase {
             menuAttempt: .actionSucceeded,
             suppressFirstWarmupFailureWarning: false
         ))
-        let service = makeService(
+        let service = try makeService(
             clipboard: clipboard,
             recovery: recovery,
             capitalization: capitalization,
@@ -116,7 +116,7 @@ final class PasteServiceExecutionTests: XCTestCase {
             menuAttempt: .actionErrored,
             suppressFirstWarmupFailureWarning: false
         ))
-        let service = makeService(
+        let service = try makeService(
             clipboard: clipboard,
             recovery: recovery,
             capitalization: capitalization,
@@ -146,7 +146,7 @@ final class PasteServiceExecutionTests: XCTestCase {
             menuAttempt: .actionSucceeded,
             suppressFirstWarmupFailureWarning: true
         ))
-        let service = makeService(
+        let service = try makeService(
             clipboard: clipboard,
             recovery: recovery,
             capitalization: capitalization,
@@ -182,7 +182,7 @@ final class PasteServiceExecutionTests: XCTestCase {
         let secondTimestamp = Date(timeIntervalSince1970: 200)
         let timestamps = MutableDateSequence([firstTimestamp, secondTimestamp])
 
-        let service = makeService(
+        let service = try makeService(
             clipboard: clipboard,
             recovery: recovery,
             capitalization: capitalization,
@@ -246,9 +246,9 @@ final class PasteServiceExecutionTests: XCTestCase {
         restoreDelayAfterMenuFallback: TimeInterval,
         restoreDelayAfterAccessibilityInjection: TimeInterval,
         clockNow: @escaping () -> Date = Date.init
-    ) -> PasteService {
+    ) throws -> PasteService {
         let queue = DispatchQueue(label: "PasteServiceExecutionTests.queue")
-        let dictionaryFileURL = makeIsolatedDictionaryFileURL()
+        let dictionaryFileURL = try makeIsolatedDictionaryFileURL()
         let service = PasteService(
             pasteQueue: queue,
             heuristicTTL: 10,
@@ -272,10 +272,15 @@ final class PasteServiceExecutionTests: XCTestCase {
         return service
     }
 
-    private func makeIsolatedDictionaryFileURL() -> URL {
+    private func makeIsolatedDictionaryFileURL() throws -> URL {
+        PasteDictionaryCasingStore.resetCaches()
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        addTeardownBlock {
+            PasteDictionaryCasingStore.resetCaches()
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
 
         let fileURL = directoryURL.appendingPathComponent("dictionary.json")
         let payload = """
@@ -284,7 +289,7 @@ final class PasteServiceExecutionTests: XCTestCase {
           "entries": []
         }
         """
-        try? Data(payload.utf8).write(to: fileURL)
+        try Data(payload.utf8).write(to: fileURL)
         return fileURL
     }
 }

--- a/KeyVoxTests/Services/PasteServiceExecutionTests.swift
+++ b/KeyVoxTests/Services/PasteServiceExecutionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import KeyVox
+import Foundation
 
 @MainActor
 final class PasteServiceExecutionTests: XCTestCase {
@@ -247,6 +248,7 @@ final class PasteServiceExecutionTests: XCTestCase {
         clockNow: @escaping () -> Date = Date.init
     ) -> PasteService {
         let queue = DispatchQueue(label: "PasteServiceExecutionTests.queue")
+        let dictionaryFileURL = makeIsolatedDictionaryFileURL()
         let service = PasteService(
             pasteQueue: queue,
             heuristicTTL: 10,
@@ -262,10 +264,27 @@ final class PasteServiceExecutionTests: XCTestCase {
             accessibilityInjector: injector,
             menuFallbackExecutor: PasteServiceNoopFallbackExecutor(),
             menuFallbackCoordinator: coordinator,
+            dictionaryCasingStore: PasteDictionaryCasingStore(dictionaryFileURL: dictionaryFileURL),
             capitalizationHeuristics: capitalization,
             spacingHeuristics: spacing
         )
         Self.retainedServices.append(service)
         return service
+    }
+
+    private func makeIsolatedDictionaryFileURL() -> URL {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+        let fileURL = directoryURL.appendingPathComponent("dictionary.json")
+        let payload = """
+        {
+          "version": 1,
+          "entries": []
+        }
+        """
+        try? Data(payload.utf8).write(to: fileURL)
+        return fileURL
     }
 }


### PR DESCRIPTION
- add mac-side paste capitalization heuristics that preserve sentence starts and lower Whisper-style default caps only when context proves the insertion is mid-sentence
- preserve dictionary-backed leading phrase casing during paste-time normalization with a dedicated mac dictionary casing store
- run capitalization normalization before existing spacing heuristics in PasteService and cover the ordering with paste execution tests
- add focused mac capitalization tests for sentence boundaries, fallback behavior, structural casing preservation, and dictionary-cased names
- update the Mac code map, engineering notes, README, and Xcode target wiring for the new paste-side capitalization layer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved paste handling: sentence-aware leading-capitalization normalization using focused context and previous non-whitespace character, with dictionary-backed preservation of intentional casing.

* **Documentation**
  * Updated docs to describe the new capitalization heuristics and dictionary-aware preprocessing in the paste workflow.

* **Tests**
  * Added unit tests and mocks covering capitalization heuristics and PasteService integration.

* **Chores**
  * Project/build updates to include new heuristic sources and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->