### PR TITLE
fix(tests): re-align whisper tests and codebase, move iOS tests to macos-26

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: Tools/Quality/check_core_coverage.sh /tmp/keyvox-tests.xcresult
 
   ios-app-tests:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
             -project "iOS/KeyVox iOS.xcodeproj" \
             -scheme "KeyVox iOS DEBUG" \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,OS=latest,name=iPhone 17' \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             -resultBundlePath /tmp/keyvox-ios-tests.xcresult \

--- a/Packages/KeyVoxWhisper/Sources/KeyVoxWhisper/Whisper.swift
+++ b/Packages/KeyVoxWhisper/Sources/KeyVoxWhisper/Whisper.swift
@@ -225,8 +225,10 @@ public final class Whisper {
         let isVentura = osVersion.majorVersion == venturaMajorVersion
         #if os(iOS)
         let shouldDisableGPU = true
+        let shouldRetryWithCPUFallback = false
         #else
         let shouldDisableGPU = isVentura
+        let shouldRetryWithCPUFallback = isVentura
         #endif
 
         var contextParams = runtime.contextDefaultParams()
@@ -241,7 +243,7 @@ public final class Whisper {
             runtime.initFromFileWithParams(path, contextParams)
         }
 
-        if context != nil || shouldDisableGPU == true {
+        if context != nil || shouldRetryWithCPUFallback == false {
             return context
         }
 

--- a/iOS/KeyVox iOS/Views/Onboarding/Tour/OnboardingKeyboardTourSceneCView.swift
+++ b/iOS/KeyVox iOS/Views/Onboarding/Tour/OnboardingKeyboardTourSceneCView.swift
@@ -136,7 +136,7 @@ struct OnboardingKeyboardTourSceneCView: View {
 
     private func animateParticles() {
         for index in 0..<Metrics.particleCount {
-            let angle = Double(index) * (2 * .pi / Double(Metrics.particleCount))
+            let angle = CGFloat(index) * (2 * .pi / CGFloat(Metrics.particleCount))
             let distance: CGFloat = 50 + CGFloat.random(in: 10...30)
 
             let endOffset = CGSize(

--- a/iOS/KeyVoxiOSTests/App/ModelManagerTests.swift
+++ b/iOS/KeyVoxiOSTests/App/ModelManagerTests.swift
@@ -274,14 +274,6 @@ struct ModelManagerTests {
                 stagedCoreMLZipURLProvider: { stagedCoreMLZipURL }
             )
             : nil
-        let unzip: ModelManager.UnzipClosure = { _, _, fileManager, progress in
-            progress(0, 1)
-            if !fileManager.fileExists(atPath: coreMLDirectoryURL.path) {
-                try fileManager.createDirectory(at: coreMLDirectoryURL, withIntermediateDirectories: true)
-            }
-            try Data("coreml".utf8).write(to: coreMLDirectoryURL.appendingPathComponent("Manifest.plist"))
-            progress(1, 1)
-        }
         let manager = ModelManager(
             fileManager: fileManager,
             whisperService: whisperService,
@@ -305,7 +297,7 @@ struct ModelManagerTests {
                 }
                 return coreMLZipFixtureURL
             },
-            unzip: unzip
+            unzip: Self.makeUnzipStub(coreMLDirectoryURL: coreMLDirectoryURL)
         )
 
         return ModelManagerHarness(
@@ -340,6 +332,17 @@ struct ModelManagerTests {
     nonisolated private static func sha256Hex(forFileAt url: URL) -> String {
         let data = (try? Data(contentsOf: url)) ?? Data()
         return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    nonisolated private static func makeUnzipStub(coreMLDirectoryURL: URL) -> ModelManager.UnzipClosure {
+        { _, _, fileManager, progress in
+            progress(0, 1)
+            if !fileManager.fileExists(atPath: coreMLDirectoryURL.path) {
+                try fileManager.createDirectory(at: coreMLDirectoryURL, withIntermediateDirectories: true)
+            }
+            try Data("coreml".utf8).write(to: coreMLDirectoryURL.appendingPathComponent("Manifest.plist"))
+            progress(1, 1)
+        }
     }
 
 }

--- a/iOS/KeyVoxiOSTests/App/ModelManagerTests.swift
+++ b/iOS/KeyVoxiOSTests/App/ModelManagerTests.swift
@@ -274,6 +274,14 @@ struct ModelManagerTests {
                 stagedCoreMLZipURLProvider: { stagedCoreMLZipURL }
             )
             : nil
+        let unzip: ModelManager.UnzipClosure = { _, _, fileManager, progress in
+            progress(0, 1)
+            if !fileManager.fileExists(atPath: coreMLDirectoryURL.path) {
+                try fileManager.createDirectory(at: coreMLDirectoryURL, withIntermediateDirectories: true)
+            }
+            try Data("coreml".utf8).write(to: coreMLDirectoryURL.appendingPathComponent("Manifest.plist"))
+            progress(1, 1)
+        }
         let manager = ModelManager(
             fileManager: fileManager,
             whisperService: whisperService,
@@ -297,14 +305,7 @@ struct ModelManagerTests {
                 }
                 return coreMLZipFixtureURL
             },
-            unzip: { _, _, fileManager, progress in
-                progress(0, 1)
-                if !fileManager.fileExists(atPath: coreMLDirectoryURL.path) {
-                    try fileManager.createDirectory(at: coreMLDirectoryURL, withIntermediateDirectories: true)
-                }
-                try Data("coreml".utf8).write(to: coreMLDirectoryURL.appendingPathComponent("Manifest.plist"))
-                progress(1, 1)
-            }
+            unzip: unzip
         )
 
         return ModelManagerHarness(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI testing configuration to run iOS tests on the newer macOS/simulator image.

* **Bug Fixes / Improvements**
  * Improved platform-specific fallback selection for speech processing to reduce failures.
  * Adjusted onboarding particle animation calculations for consistent rendering.

* **Tests**
  * Consolidated test harness setup by centralizing unzip stub logic into a reusable helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->