### PR TITLE
feat(keyboard): add call-state warning for iOS dictation

### DIFF
--- a/iOS/Docs/CODEMAP.md
+++ b/iOS/Docs/CODEMAP.md
@@ -1,12 +1,12 @@
 # KeyVox iOS Code Map
-**Last Updated: 2026-03-16**
+**Last Updated: 2026-03-20**
 
 ## Project Overview
 
 KeyVox iOS ships as three cooperating targets:
 
 - The containing app owns onboarding, settings, model lifecycle, microphone capture, interrupted-capture recovery, session policy, weekly stats, iCloud sync, and the SwiftUI shell.
-- The keyboard extension owns the visible custom keyboard, warm/cold app handoff, text insertion, full-access warning UI, and keyboard-only interaction behavior.
+- The keyboard extension owns the visible custom keyboard, warm/cold app handoff, text insertion, warning-toolbar presentation, and keyboard-only interaction behavior.
 - The widget extension owns the Live Activity and Dynamic Island presentation plus the stop-session App Intent.
 
 Shared speech and text behavior still lives in `../Packages/KeyVoxCore`, including `DictationPipeline`, `WhisperService`, dictionary persistence primitives, and post-processing order.
@@ -27,7 +27,7 @@ The current default runtime flow is:
 ## Architecture
 
 - **`KeyVox iOS/`**: app lifecycle, composition root, onboarding state, URL routing, App Group storage, iCloud sync, model background downloads, audio capture, transcription/session management, Live Activity coordination, and the SwiftUI shell.
-- **`KeyVox Keyboard/`**: custom keyboard controller, toolbar modes, key grid UI, full-access instructional surface, live indicator rendering, host-app launch handoff, haptics, cursor trackpad behavior, and final insertion heuristics.
+- **`KeyVox Keyboard/`**: custom keyboard controller, toolbar modes, call-aware warning detection, key grid UI, full-access instructional surface, live indicator rendering, host-app launch handoff, haptics, cursor trackpad behavior, and final insertion heuristics.
 - **`KeyVox Widget/`**: ActivityKit/WidgetKit surface for the lock screen and Dynamic Island, plus the stop-session App Intent.
 - **`../Packages/KeyVoxCore/`**: shared dictation pipeline, Whisper integration, dictionary store, post-processing order, silence heuristics, and list formatting behavior.
 - **`KeyVoxiOSTests/`**: deterministic tests for onboarding state, keyboard-tour routing, settings persistence, iCloud sync, weekly stats, model lifecycle, model download recovery, microphone permission handling, text input helpers, cursor-trackpad behavior, and transcription/session orchestration.
@@ -39,7 +39,7 @@ The current default runtime flow is:
 - Keep the keyboard extension thin. It should transport commands, render keyboard UI, and insert final text, not become an alternate owner of model, microphone, or onboarding state.
 - Keep app-extension and app-widget contracts centralized in `KeyVoxIPCBridge`; do not duplicate App Group keys, timestamps, or Darwin notification names.
 - Keep onboarding state separate from settings state. `OnboardingStore` is the routing owner for onboarding progress and launch flags.
-- Keep the keyboard root layout stable. The full-access warning is intentionally layered as an overlay instead of participating in the main keyboard stack layout.
+- Keep the keyboard root layout stable. The warning toolbar is intentionally layered as an overlay instead of participating in the main keyboard stack layout.
 - Update [`ENGINEERING.md`](ENGINEERING.md) whenever lifecycle rules, IPC contracts, onboarding routing, Live Activity behavior, or model recovery behavior change.
 
 ## Directory Index
@@ -167,6 +167,7 @@ iOS/
 │   ├── Core/
 │   │   ├── AudioIndicatorDriver.swift
 │   │   ├── KeyboardCapsLockStateStore.swift
+│   │   ├── KeyboardCallObserver.swift
 │   │   ├── KeyboardCursorTrackpadSupport.swift
 │   │   ├── KeyboardDictationController.swift
 │   │   ├── KeyboardDictionaryCasingStore.swift
@@ -227,6 +228,7 @@ iOS/
 │   │   ├── Keyboard/
 │   │   │   ├── KeyboardCursorTrackpadSupportTests.swift
 │   │   │   ├── KeyboardDictationControllerTests.swift
+│   │   │   ├── KeyboardToolbarModeTests.swift
 │   │   │   └── KeyboardTextInputControllerTests.swift
 │   │   └── Transcription/
 │   │       └── TranscriptionManagerTests.swift
@@ -369,7 +371,9 @@ Packages/
 
 - `KeyVox Keyboard/App/KeyboardViewController.swift`
   - Extension controller and top-level keyboard surface owner.
-  - Owns toolbar mode switching, full-access instructions presentation, warm/cold app launch behavior, onboarding presentation reporting, Caps Lock, symbol page, trackpad mode, and insertion.
+  - Owns toolbar mode switching, call-aware warning presentation, full-access instructions presentation, warm/cold app launch behavior, onboarding presentation reporting, Caps Lock, symbol page, trackpad mode, and insertion.
+- `KeyVox Keyboard/Core/KeyboardCallObserver.swift`
+  - Tracks active phone-call state through `CallKit` so the keyboard can warn before dictation is attempted during a call.
 - `KeyVox Keyboard/Core/KeyboardDictationController.swift`
   - Keyboard-local state machine for shared recording state and app launch handoff.
 - `KeyVox Keyboard/Core/KeyboardIPCManager.swift`
@@ -386,7 +390,7 @@ Packages/
   - Lightweight installed-model gate used by the extension toolbar.
 - `KeyVox Keyboard/Views/KeyboardRootView.swift`
   - Stable keyboard chrome and key grid.
-  - Hosts the branded toolbar row and the full-access warning overlay.
+  - Hosts the branded toolbar row and the shared warning overlay for Full Access, microphone permission, and active phone calls.
 - `KeyVox Keyboard/Views/FullAccessView.swift`
   - Full-screen keyboard-only instructional view shown when the user needs to enable Full Access.
 
@@ -397,7 +401,7 @@ Packages/
 - `KeyVoxiOSTests/Core/Audio/`
   - Audio input preference resolution and stop-time capture processing.
 - `KeyVoxiOSTests/Core/Keyboard/`
-  - Keyboard dictation control, text insertion behavior, and cursor-trackpad helpers.
+  - Keyboard dictation control, toolbar warning precedence, text insertion behavior, and cursor-trackpad helpers.
 - `KeyVoxiOSTests/Core/Transcription/`
   - Transcription/session lifecycle and interrupted-capture recovery behavior.
 

--- a/iOS/Docs/ENGINEERING.md
+++ b/iOS/Docs/ENGINEERING.md
@@ -2,7 +2,7 @@
 
 This document captures the current implementation rules and maintainer-facing architecture for the iOS app, keyboard extension, and widget extension.
 
-**Last Updated: 2026-03-16**
+**Last Updated: 2026-03-20**
 
 ## Design Philosophy
 
@@ -40,7 +40,7 @@ The containing app owns:
 The keyboard extension owns:
 
 - visible keyboard UI
-- toolbar mode selection and full-access warning presentation
+- toolbar mode selection and warning presentation
 - warm/cold launch handoff into the containing app
 - text insertion into host apps
 - keyboard-only interaction helpers like trackpad mode, delete repeat, and haptics
@@ -546,6 +546,7 @@ The extension is a transport and insertion surface, not the transcription owner.
 
 - UI event handling
 - toolbar mode switching
+- call-state observation for warning presentation
 - full-access instructions presentation
 - keyboard state transitions
 - warm/cold app handoff
@@ -560,21 +561,25 @@ Toolbar modes are:
 - hidden
 - branded
 - full-access warning
+- microphone warning
+- phone-call warning
 
 The keyboard root layout has an important invariant:
 
 - the stable non-flashing keyboard structure lives in the main keyboard stack
-- the full-access warning UI is layered as an overlay on top of the toolbar row
+- the warning UI is layered as an overlay on top of the toolbar row
 - the warning must **not** be moved into the root arranged-subview layout path again
 
 That separation exists because putting the warning UI into the main root layout reintroduced the keyboard launch flash.
 
-### Full Access Rules
+### Warning Toolbar Rules
 
 The branded toolbar requires:
 
 - installed model
 - `hasFullAccess == true`
+- microphone permission granted
+- no active phone call reported by `KeyboardCallObserver`
 
 When the model is installed but Full Access is missing:
 
@@ -582,6 +587,28 @@ When the model is installed but Full Access is missing:
 - hide the branded toolbar controls
 - show the red warning toolbar
 - allow the user to open the full-screen `FullAccessView`
+
+When the model is installed and Full Access is granted but microphone permission is missing:
+
+- keep the key grid visible
+- hide the branded toolbar controls
+- show the red warning toolbar with the microphone message
+- do not show the Full Access instructional button
+
+When the model is installed, Full Access is granted, microphone permission is granted, and an active phone call is reported:
+
+- keep the key grid visible
+- hide the branded toolbar controls
+- show the red warning toolbar with `Use KeyVox after this call.`
+- do not launch any separate instructional surface
+
+Warning precedence must remain:
+
+1. model unavailable -> hidden toolbar
+2. Full Access missing -> full-access warning
+3. microphone permission missing -> microphone warning
+4. active phone call -> phone-call warning
+5. otherwise -> branded toolbar
 
 `FullAccessView` is keyboard-only instructional UI. It does not route through onboarding state or the containing app.
 

--- a/iOS/KeyVox Keyboard/App/KeyboardViewController.swift
+++ b/iOS/KeyVox Keyboard/App/KeyboardViewController.swift
@@ -9,6 +9,7 @@ final class KeyboardViewController: UIInputViewController {
     private let indicatorDriver = AudioIndicatorDriver()
     private let startRecordingURL = URL(string: "keyvoxios://record/start")
     private let dictionaryCasingStore = KeyboardDictionaryCasingStore()
+    private let callObserver = KeyboardCallObserver()
     private lazy var containingAppLauncher = KeyboardContainingAppLauncher(responderProvider: { [weak self] in
         self
     })
@@ -77,6 +78,7 @@ final class KeyboardViewController: UIInputViewController {
         configureIndicatorDriver()
         configureDictationController()
         configureHostLifecycleObservers()
+        configureCallObserver()
         syncCapsLockState()
         dictationController.syncStateFromSharedState()
         updateUI()
@@ -86,6 +88,7 @@ final class KeyboardViewController: UIInputViewController {
         super.viewWillAppear(animated)
         KeyVoxIPCBridge.reportKeyboardOnboardingState(hasFullAccess: hasFullAccess)
         configureDictationBehavior()
+        callObserver.refreshState()
         rootContainerView?.keyGridView.resetInteractionState()
         indicatorDriver.start()
         configurePrimaryViewHeight()
@@ -219,6 +222,12 @@ final class KeyboardViewController: UIInputViewController {
         dictationController.registerObservers()
     }
 
+    private func configureCallObserver() {
+        callObserver.onCallStateChange = { [weak self] in
+            self?.updateUI()
+        }
+    }
+
     private func configureHostLifecycleObservers() {
         guard hostWillResignActiveObserver == nil, hostDidBecomeActiveObserver == nil else { return }
 
@@ -259,19 +268,12 @@ final class KeyboardViewController: UIInputViewController {
     }
 
     private func currentToolbarMode() -> KeyboardToolbarMode {
-        guard KeyboardModelAvailability.isInstalled() else {
-            return .hidden
-        }
-
-        guard hasFullAccess else {
-            return .fullAccessWarning
-        }
-
-        guard hasMicrophonePermission else {
-            return .microphoneWarning
-        }
-
-        return .branded
+        KeyboardToolbarMode.resolve(
+            isModelInstalled: KeyboardModelAvailability.isInstalled(),
+            hasFullAccess: hasFullAccess,
+            hasMicrophonePermission: hasMicrophonePermission,
+            hasActivePhoneCall: callObserver.hasActivePhoneCall
+        )
     }
 
     private var hasMicrophonePermission: Bool {

--- a/iOS/KeyVox Keyboard/Core/KeyboardCallObserver.swift
+++ b/iOS/KeyVox Keyboard/Core/KeyboardCallObserver.swift
@@ -1,0 +1,29 @@
+import CallKit
+import Foundation
+
+final class KeyboardCallObserver: NSObject, CXCallObserverDelegate {
+    var onCallStateChange: (() -> Void)?
+
+    private let callObserver: CXCallObserver
+    private(set) var hasActivePhoneCall = false {
+        didSet {
+            guard oldValue != hasActivePhoneCall else { return }
+            onCallStateChange?()
+        }
+    }
+
+    init(callObserver: CXCallObserver = CXCallObserver()) {
+        self.callObserver = callObserver
+        super.init()
+        callObserver.setDelegate(self, queue: .main)
+        refreshState()
+    }
+
+    func refreshState() {
+        hasActivePhoneCall = callObserver.calls.contains(where: { $0.hasEnded == false })
+    }
+
+    func callObserver(_ callObserver: CXCallObserver, callChanged _: CXCall) {
+        refreshState()
+    }
+}

--- a/iOS/KeyVox Keyboard/Core/KeyboardToolbarMode.swift
+++ b/iOS/KeyVox Keyboard/Core/KeyboardToolbarMode.swift
@@ -39,7 +39,7 @@ enum KeyboardToolbarMode {
         case .microphoneWarning:
             return "Allow Microphone Access for dictation"
         case .phoneCallWarning:
-            return "Use KeyVox after this call."
+            return "Use KeyVox after this call"
         case .hidden, .branded:
             return nil
         }

--- a/iOS/KeyVox Keyboard/Core/KeyboardToolbarMode.swift
+++ b/iOS/KeyVox Keyboard/Core/KeyboardToolbarMode.swift
@@ -39,7 +39,7 @@ enum KeyboardToolbarMode {
         case .microphoneWarning:
             return "Allow Microphone Access for dictation"
         case .phoneCallWarning:
-            return "Use KeyVox after this call"
+            return "Use KeyVox after this call."
         case .hidden, .branded:
             return nil
         }

--- a/iOS/KeyVox Keyboard/Core/KeyboardToolbarMode.swift
+++ b/iOS/KeyVox Keyboard/Core/KeyboardToolbarMode.swift
@@ -5,6 +5,32 @@ enum KeyboardToolbarMode {
     case branded
     case fullAccessWarning
     case microphoneWarning
+    case phoneCallWarning
+
+    static func resolve(
+        isModelInstalled: Bool,
+        hasFullAccess: Bool,
+        hasMicrophonePermission: Bool,
+        hasActivePhoneCall: Bool
+    ) -> KeyboardToolbarMode {
+        guard isModelInstalled else {
+            return .hidden
+        }
+
+        guard hasFullAccess else {
+            return .fullAccessWarning
+        }
+
+        guard hasMicrophonePermission else {
+            return .microphoneWarning
+        }
+
+        guard hasActivePhoneCall == false else {
+            return .phoneCallWarning
+        }
+
+        return .branded
+    }
 
     var warningText: String? {
         switch self {
@@ -12,6 +38,8 @@ enum KeyboardToolbarMode {
             return "Allow Full Access for dictation"
         case .microphoneWarning:
             return "Allow Microphone Access for dictation"
+        case .phoneCallWarning:
+            return "Use KeyVox after this call"
         case .hidden, .branded:
             return nil
         }

--- a/iOS/KeyVox iOS.xcodeproj/project.pbxproj
+++ b/iOS/KeyVox iOS.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 				App/KeyboardViewController.swift,
 				Core/AudioIndicatorDriver.swift,
 				Core/KeyboardCapsLockStateStore.swift,
+				Core/KeyboardCallObserver.swift,
 				Core/KeyboardCursorTrackpadSupport.swift,
 				Core/KeyboardDictationController.swift,
 				Core/KeyboardDictionaryCasingStore.swift,

--- a/iOS/KeyVox iOS/Views/SettingsTabView.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView.swift
@@ -5,6 +5,19 @@ struct SettingsTabView: View {
     @Environment(\.appHaptics) private var appHaptics
     @EnvironmentObject private var modelManager: ModelManager
     @EnvironmentObject private var settingsStore: AppSettingsStore
+    
+    private var appVersionBuildText: String? {
+        guard
+            let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String,
+            !version.isEmpty,
+            !build.isEmpty
+        else {
+            return nil
+        }
+        
+        return "v\(version) (\(build))"
+    }
 
     var body: some View {
         AppScrollScreen {
@@ -17,6 +30,7 @@ struct SettingsTabView: View {
                 #if DEBUG
                 modelSection
                 #endif
+                versionFooter
             }
         }
         .task {
@@ -200,6 +214,18 @@ struct SettingsTabView: View {
         appHaptics.light()
         if let url = URL(string: "https://github.com/sponsors/macmixing/") {
             UIApplication.shared.open(url)
+        }
+    }
+    
+    @ViewBuilder
+    private var versionFooter: some View {
+        if let appVersionBuildText {
+            Text(appVersionBuildText)
+                .font(.appFont(12))
+                .foregroundStyle(.white.opacity(0.5))
+                .frame(maxWidth: .infinity)
+                .padding(.top, 12)
+                .padding(.bottom, 12)
         }
     }
 

--- a/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardToolbarModeTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardToolbarModeTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import KeyVox_iOS
+
+struct KeyboardToolbarModeTests {
+    @Test func activePhoneCallUsesPhoneCallWarning() {
+        let mode = KeyboardToolbarMode.resolve(
+            isModelInstalled: true,
+            hasFullAccess: true,
+            hasMicrophonePermission: true,
+            hasActivePhoneCall: true
+        )
+
+        #expect(mode == .phoneCallWarning)
+        #expect(mode.warningText == "Use KeyVox after this call.")
+    }
+
+    @Test func activePhoneCallDoesNotOverrideHigherPriorityWarnings() {
+        let fullAccessMode = KeyboardToolbarMode.resolve(
+            isModelInstalled: true,
+            hasFullAccess: false,
+            hasMicrophonePermission: true,
+            hasActivePhoneCall: true
+        )
+        let microphoneMode = KeyboardToolbarMode.resolve(
+            isModelInstalled: true,
+            hasFullAccess: true,
+            hasMicrophonePermission: false,
+            hasActivePhoneCall: true
+        )
+
+        #expect(fullAccessMode == .fullAccessWarning)
+        #expect(microphoneMode == .microphoneWarning)
+    }
+}

--- a/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardToolbarModeTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardToolbarModeTests.swift
@@ -11,7 +11,8 @@ struct KeyboardToolbarModeTests {
         )
 
         #expect(mode == .phoneCallWarning)
-        #expect(mode.warningText == "Use KeyVox after this call.")
+        #expect(mode.warningText != nil)
+        #expect(mode.showsWarningInfoButton == false)
     }
 
     @Test func activePhoneCallDoesNotOverrideHigherPriorityWarnings() {


### PR DESCRIPTION
- add a CallKit-backed keyboard observer to detect active phone calls
- extend keyboard toolbar mode resolution with phone-call warning precedence alongside full-access and microphone warnings
- wire the keyboard controller and test target project membership for the new warning path
- add toolbar mode coverage for active-call warning behavior and precedence
- update the iOS code map and engineering notes to document the shared warning toolbar contract

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phone-call aware warning: keyboard shows a “Use KeyVox after this call.” toolbar warning during active calls.
  * Toolbar now includes distinct modes (full-access, microphone, phone-call, branded) with defined precedence.

* **Documentation**
  * Updated guidance and rules describing the warning-toolbar behavior, layering, and mode matrix.

* **Tests**
  * Added tests validating toolbar-mode resolution and warning precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->