### PR TITLE
fix(keyboard): lazy load full access instructions and align popup key labels

### DIFF
--- a/iOS/KeyVox Keyboard/App/KeyboardViewController.swift
+++ b/iOS/KeyVox Keyboard/App/KeyboardViewController.swift
@@ -9,7 +9,7 @@ final class KeyboardViewController: UIInputViewController {
     private let indicatorDriver = AudioIndicatorDriver()
     private let startRecordingURL = URL(string: "keyvoxios://record/start")
     private let dictionaryCasingStore = KeyboardDictionaryCasingStore()
-    private let callObserver = KeyboardCallObserver()
+    private let callObserver =  KeyboardCallObserver()
     private lazy var containingAppLauncher = KeyboardContainingAppLauncher(responderProvider: { [weak self] in
         self
     })
@@ -51,7 +51,7 @@ final class KeyboardViewController: UIInputViewController {
 
     private var rootContainerView: KeyboardRootView!
     private let popupOverlayView = UIView()
-    private var fullAccessView: FullAccessView!
+    private var fullAccessView: FullAccessView?
     private var cursorTrackpadInteractor = KeyboardCursorTrackpadInteractor()
     private var isTrackpadModeActive = false
     private var extensionHostIsActive = true
@@ -140,17 +140,8 @@ final class KeyboardViewController: UIInputViewController {
             popupOverlayView.isUserInteractionEnabled = false
             popupOverlayView.clipsToBounds = false
 
-            let fullAccessView = FullAccessView()
-            fullAccessView.translatesAutoresizingMaskIntoConstraints = false
-            fullAccessView.isHidden = true
-            fullAccessView.onBack = { [weak self] in
-                self?.setFullAccessInstructionsPresented(false)
-            }
-            self.fullAccessView = fullAccessView
-
             view.addSubview(rootView)
             view.addSubview(popupOverlayView)
-            view.addSubview(fullAccessView)
 
             NSLayoutConstraint.activate([
                 rootView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -162,11 +153,6 @@ final class KeyboardViewController: UIInputViewController {
                 popupOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 popupOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
                 popupOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-
-                fullAccessView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                fullAccessView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                fullAccessView.topAnchor.constraint(equalTo: view.topAnchor),
-                fullAccessView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             ])
         }
 
@@ -276,6 +262,30 @@ final class KeyboardViewController: UIInputViewController {
         )
     }
 
+    private func ensureFullAccessView() -> FullAccessView {
+        if let fullAccessView {
+            return fullAccessView
+        }
+
+        let fullAccessView = FullAccessView()
+        fullAccessView.translatesAutoresizingMaskIntoConstraints = false
+        fullAccessView.isHidden = true
+        fullAccessView.onBack = { [weak self] in
+            self?.setFullAccessInstructionsPresented(false)
+        }
+
+        view.addSubview(fullAccessView)
+        NSLayoutConstraint.activate([
+            fullAccessView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            fullAccessView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            fullAccessView.topAnchor.constraint(equalTo: view.topAnchor),
+            fullAccessView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        self.fullAccessView = fullAccessView
+        return fullAccessView
+    }
+
     private var hasMicrophonePermission: Bool {
         switch AVAudioApplication.shared.recordPermission {
         case .granted:
@@ -288,7 +298,11 @@ final class KeyboardViewController: UIInputViewController {
     }
 
     private func setFullAccessInstructionsPresented(_ isPresented: Bool) {
-        fullAccessView?.isHidden = !isPresented
+        if isPresented {
+            ensureFullAccessView().isHidden = false
+        } else {
+            fullAccessView?.isHidden = true
+        }
         rootContainerView?.isHidden = isPresented
         popupOverlayView.isHidden = isPresented
     }

--- a/iOS/KeyVox Keyboard/Core/KeyboardSymbolLayout.swift
+++ b/iOS/KeyVox Keyboard/Core/KeyboardSymbolLayout.swift
@@ -111,6 +111,13 @@ struct KeyboardKeyModel: Equatable {
             return 0
         }
     }
+
+    func attributedTitle(for text: String? = nil) -> NSAttributedString {
+        NSAttributedString(
+            string: text ?? title,
+            attributes: [.baselineOffset: titleBaselineOffset]
+        )
+    }
 }
 
 enum KeyboardSymbolLayout {

--- a/iOS/KeyVox Keyboard/Views/Components/KeyboardKeyPopupView.swift
+++ b/iOS/KeyVox Keyboard/Views/Components/KeyboardKeyPopupView.swift
@@ -52,7 +52,7 @@ final class KeyboardKeyPopupView: UIView {
     }
 
     func present(text: String, from keyView: KeyboardKeyView, in container: UIView) {
-        titleLabel.text = text
+        titleLabel.attributedText = keyView.model.attributedTitle(for: text)
 
         let keyFrame = keyView.convert(keyView.bounds, to: container)
         let popupSize = CGSize(

--- a/iOS/KeyVox Keyboard/Views/Components/KeyboardKeyView.swift
+++ b/iOS/KeyVox Keyboard/Views/Components/KeyboardKeyView.swift
@@ -67,10 +67,7 @@ final class KeyboardKeyView: UIView {
 
         titleLabel.font = model.titleFont
         if model.systemImageName == nil {
-            let attributes: [NSAttributedString.Key: Any] = [
-                .baselineOffset: model.titleBaselineOffset
-            ]
-            titleLabel.attributedText = NSAttributedString(string: model.title, attributes: attributes)
+            titleLabel.attributedText = model.attributedTitle()
         } else {
             titleLabel.attributedText = nil
         }


### PR DESCRIPTION
## Summary
Reduce keyboard launch-time memory by deferring `FullAccessView` creation until the instructions are actually presented, and keep popup key titles visually aligned with the main keyboard keys.

## What Changed
- make `fullAccessView` optional and create it on demand in `KeyboardViewController`
- remove the hidden full-screen `FullAccessView` from the default keyboard launch path
- preserve full access instructions presentation by instantiating and constraining the view only when needed
- add `KeyboardKeyModel.attributedTitle(...)` to centralize baseline-offset styling for key labels
- update `KeyboardKeyView` and `KeyboardKeyPopupView` to share the same attributed title rendering

## Why
- the keyboard extension was hitting device-specific launch-time memory crash
- the hidden full access instructions view was being built even when never shown
- popup labels should match the baseline alignment already used in the key grid


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized full access view loading to reduce initial memory usage.
  * Improved keyboard key text rendering with proper baseline offset styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->