### PR TITLE
fix: preserve leading capitalization at new line starts on macOS and iOS paste flows

### DIFF
--- a/iOS/KeyVox Keyboard/Core/KeyboardInsertionCapitalizationHeuristics.swift
+++ b/iOS/KeyVox Keyboard/Core/KeyboardInsertionCapitalizationHeuristics.swift
@@ -42,13 +42,23 @@ enum KeyboardInsertionCapitalizationHeuristics {
     }
 
     private static func isSentenceStart(documentContextBeforeInput: String?) -> Bool {
-        guard let context = documentContextBeforeInput?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-              let previousCharacter = context.last else {
+        guard let context = documentContextBeforeInput, context.isEmpty == false else {
             return true
         }
 
-        return previousCharacter == "." || previousCharacter == "?" || previousCharacter == "!"
+        for character in context.reversed() {
+            if character.isNewline {
+                return true
+            }
+
+            if character.isWhitespace {
+                continue
+            }
+
+            return character == "." || character == "?" || character == "!"
+        }
+
+        return true
     }
 
     private static func leadingWordRun(in text: String) -> Substring? {
@@ -67,5 +77,11 @@ enum KeyboardInsertionCapitalizationHeuristics {
         }
 
         return remainingCharacters.allSatisfy(\.isLowercase)
+    }
+}
+
+private extension Character {
+    var isNewline: Bool {
+        unicodeScalars.allSatisfy(CharacterSet.newlines.contains)
     }
 }

--- a/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardTextInputControllerTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardTextInputControllerTests.swift
@@ -193,6 +193,36 @@ struct KeyboardTextInputControllerTests {
         #expect(documentProxy.insertedTexts == ["Hello"])
     }
 
+    @Test func transcriptionInsertionKeepsLeadingCapitalizationAtStartOfNewLine() {
+        let documentProxy = KeyboardTextDocumentProxySpy()
+        documentProxy.documentContextBeforeInput = "hello there\n"
+        let haptics = KeyboardKeypressHapticsSpy()
+        let controller = KeyboardTextInputController(
+            documentProxy: documentProxy,
+            emitKeypress: haptics.emitKeypressIfEnabled
+        )
+
+        let inserted = controller.insertTranscription("Hello")
+
+        #expect(inserted == true)
+        #expect(documentProxy.insertedTexts == ["Hello"])
+    }
+
+    @Test func transcriptionInsertionKeepsLeadingCapitalizationAfterNewLineAndIndentation() {
+        let documentProxy = KeyboardTextDocumentProxySpy()
+        documentProxy.documentContextBeforeInput = "hello there\n   "
+        let haptics = KeyboardKeypressHapticsSpy()
+        let controller = KeyboardTextInputController(
+            documentProxy: documentProxy,
+            emitKeypress: haptics.emitKeypressIfEnabled
+        )
+
+        let inserted = controller.insertTranscription("Hello")
+
+        #expect(inserted == true)
+        #expect(documentProxy.insertedTexts == ["Hello"])
+    }
+
     @Test func transcriptionInsertionLowercasesDefaultSentenceCaseMidSentence() {
         let documentProxy = KeyboardTextDocumentProxySpy()
         documentProxy.documentContextBeforeInput = "hello there"

--- a/macOS/Core/Services/Paste/Heuristics/PasteCapitalizationHeuristics.swift
+++ b/macOS/Core/Services/Paste/Heuristics/PasteCapitalizationHeuristics.swift
@@ -78,11 +78,19 @@ final class PasteCapitalizationHeuristics: PasteCapitalizationHeuristicApplying 
                 return true
             }
 
-            if let selectionLength = context.selectionLength,
-               let previousNonWhitespaceCharacter = context.previousNonWhitespaceCharacter,
-               selectionLength == 0 {
-                return isSentenceBoundary(previousNonWhitespaceCharacter)
+            if let selectionLength = context.selectionLength, selectionLength == 0 {
+                if context.previousCharacter?.isNewline == true {
+                    return true
+                }
+
+                if let previousNonWhitespaceCharacter = context.previousNonWhitespaceCharacter {
+                    return isSentenceBoundary(previousNonWhitespaceCharacter)
+                }
             }
+        }
+
+        if lastInsertedTrailingCharacter?.isNewline == true {
+            return true
         }
 
         guard let currentIdentity,
@@ -100,8 +108,16 @@ final class PasteCapitalizationHeuristics: PasteCapitalizationHeuristicApplying 
     private func isSentenceBoundary(_ character: Character) -> Bool {
         character == "." || character == "?" || character == "!"
     }
+}
 
-    private func isDefaultSentenceCase<S: StringProtocol>(word: S) -> Bool {
+private extension Character {
+    var isNewline: Bool {
+        unicodeScalars.allSatisfy(CharacterSet.newlines.contains)
+    }
+}
+
+private extension PasteCapitalizationHeuristics {
+    func isDefaultSentenceCase<S: StringProtocol>(word: S) -> Bool {
         guard let firstCharacter = word.first else { return false }
         guard firstCharacter.isUppercase else { return false }
 

--- a/macOS/KeyVoxTests/Services/PasteCapitalizationHeuristicsTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteCapitalizationHeuristicsTests.swift
@@ -40,6 +40,32 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
         assertSentenceBoundaryPreservesCapitalization(previousCharacter: "!")
     }
 
+    func testKeepsCapitalizationAtStartOfNewLine() {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 5,
+                    previousCharacter: "\n",
+                    previousNonWhitespaceCharacter: "x"
+                )
+            )
+        )
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "Hello")
+    }
+
     func testKeepsCapitalizationAfterPunctuationAndSpace() {
         let heuristics = makeRetainedHeuristics(
             axInspector: MockPasteAXInspector(
@@ -175,6 +201,24 @@ final class PasteCapitalizationHeuristicsTests: XCTestCase {
         )
 
         XCTAssertEqual(output, "hello")
+    }
+
+    func testFallbackHeuristicKeepsCapitalizationAfterTrailingNewLine() {
+        let heuristics = makeRetainedHeuristics(axInspector: MockPasteAXInspector(focusedContext: nil), heuristicTTL: 10)
+        let now = Date()
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: identity("com.example.app", 1),
+            lastInsertionAt: now.addingTimeInterval(-1),
+            lastInsertedTrailingCharacter: "\n",
+            lastInsertedTrailingNonWhitespaceCharacter: "x",
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "Hello")
     }
 
     func testUnknownContextKeepsCapitalizationWithoutFallbackSignal() {


### PR DESCRIPTION
## Summary
This updates the macOS paste heuristics and the iOS keyboard insertion heuristics so a newline is treated as a sentence start. That keeps the first word on a new line capitalized even when the previous non-whitespace character on the prior line is not terminal punctuation.

## What Changed
- macOS: treat a literal newline as a sentence start in paste capitalization heuristics
- macOS: apply the same newline-aware behavior in the fallback insertion heuristic path
- iOS: scan keyboard document context backwards so trailing newlines start a new sentence
- iOS: preserve capitalization after newline-plus-indentation, not just newline alone

## Tests
- macOS: added regression tests for AX-context newline handling and fallback newline handling
- iOS: added regression tests for newline and newline-plus-indentation keyboard insertion cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced capitalization logic for text inserted at the start of new lines in iOS keyboard input.
  * Enhanced capitalization logic for text pasted after newlines on macOS.

* **Tests**
  * Added test coverage verifying proper capitalization when text insertion occurs following newlines across iOS keyboard and macOS paste features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->