### PR TITLE
fix(ios-app): delete behavior in single-line fields and refine dictionary autocapitalization

### DIFF
--- a/iOS/KeyVox Keyboard/Core/KeyboardTextInputController.swift
+++ b/iOS/KeyVox Keyboard/Core/KeyboardTextInputController.swift
@@ -2,6 +2,8 @@ import UIKit
 
 protocol KeyboardTextDocumentProxying: AnyObject {
     var documentContextBeforeInput: String? { get }
+    var documentContextAfterInput: String? { get }
+    var hasText: Bool { get }
     var selectedText: String? { get }
     func insertText(_ text: String)
     func deleteBackward()
@@ -17,6 +19,14 @@ final class KeyboardTextDocumentProxyAdapter: KeyboardTextDocumentProxying {
 
     var documentContextBeforeInput: String? {
         proxyProvider()?.documentContextBeforeInput
+    }
+
+    var documentContextAfterInput: String? {
+        proxyProvider()?.documentContextAfterInput
+    }
+
+    var hasText: Bool {
+        proxyProvider()?.hasText ?? false
     }
 
     var selectedText: String? {
@@ -41,6 +51,9 @@ final class KeyboardTextInputController {
     private let emitKeypress: () -> Void
     private let shouldPreserveLeadingCapitalization: (String) -> Bool
 
+    private var emptyContextDeleteAttempts = 0
+    private var lastDeleteTimestamp: TimeInterval = 0
+
     init(
         documentProxy: any KeyboardTextDocumentProxying,
         emitKeypress: @escaping () -> Void,
@@ -64,10 +77,34 @@ final class KeyboardTextInputController {
             documentProxy.insertText(value)
             return true
         case .delete:
-            guard canDeleteBackward else { return false }
-            emitKeypress()
-            documentProxy.deleteBackward()
-            return true
+            let now = Date().timeIntervalSince1970
+            let isNewDeleteSession = now - lastDeleteTimestamp > 0.5
+            if isNewDeleteSession {
+                emptyContextDeleteAttempts = 0
+            }
+            lastDeleteTimestamp = now
+            
+            let proxySeemsEmpty = (documentProxy.documentContextBeforeInput?.isEmpty ?? true) &&
+                                  (documentProxy.selectedText?.isEmpty ?? true) &&
+                                  !documentProxy.hasText
+
+            if !proxySeemsEmpty {
+                emptyContextDeleteAttempts = 0
+                emitKeypress()
+                documentProxy.deleteBackward()
+                return true
+            } else {
+                if emptyContextDeleteAttempts < 3 {
+                    if emptyContextDeleteAttempts == 0 && isNewDeleteSession {
+                        emitKeypress()
+                    }
+                    emptyContextDeleteAttempts += 1
+                    documentProxy.deleteBackward()
+                    return true
+                } else {
+                    return false
+                }
+            }
         case .space:
             emitKeypress()
             if handleDoubleSpacePeriodInsertionIfNeeded() {
@@ -125,17 +162,6 @@ final class KeyboardTextInputController {
         }
     }
 
-    private var canDeleteBackward: Bool {
-        if let selectedText = documentProxy.selectedText, selectedText.isEmpty == false {
-            return true
-        }
-
-        guard let context = documentProxy.documentContextBeforeInput else {
-            return false
-        }
-
-        return !context.isEmpty
-    }
 
     private func handleDoubleSpacePeriodInsertionIfNeeded() -> Bool {
         guard let context = documentProxy.documentContextBeforeInput else {

--- a/iOS/KeyVox iOS/Views/Dictionary/AutoFocusTextField.swift
+++ b/iOS/KeyVox iOS/Views/Dictionary/AutoFocusTextField.swift
@@ -18,7 +18,7 @@ struct AutoFocusTextField: UIViewRepresentable {
         textField.backgroundColor = .clear
         textField.placeholder = placeholder
         textField.returnKeyType = .done
-        textField.autocapitalizationType = .words
+        textField.autocapitalizationType = .sentences
         textField.autocorrectionType = .no
         textField.font = resolvedFont(size: 16)
         textField.text = text

--- a/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardTextInputControllerTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardTextInputControllerTests.swift
@@ -69,6 +69,87 @@ struct KeyboardTextInputControllerTests {
         #expect(haptics.emissionCount == 1)
     }
 
+    @Test func deleteKeyUsesHasTextWhenLeadingContextIsUnavailableAtDocumentEnd() {
+        let documentProxy = KeyboardTextDocumentProxySpy()
+        documentProxy.documentContextBeforeInput = ""
+        documentProxy.documentContextAfterInput = ""
+        documentProxy.hasText = true
+        let haptics = KeyboardKeypressHapticsSpy()
+        let controller = KeyboardTextInputController(
+            documentProxy: documentProxy,
+            emitKeypress: haptics.emitKeypressIfEnabled
+        )
+        var symbolPage = KeyboardSymbolPage.primary
+
+        let handled = controller.handleKeyActivation(
+            .delete,
+            symbolPage: &symbolPage,
+            resetCapsLockStateIfNeeded: {},
+            advanceToNextInputMode: {}
+        )
+
+        #expect(handled == true)
+        #expect(documentProxy.deleteBackwardCallCount == 1)
+        #expect(haptics.emissionCount == 1)
+    }
+
+    @Test func deleteKeyPerformsPhantomDeleteWhenFieldSeemsEmpty() {
+        let documentProxy = KeyboardTextDocumentProxySpy()
+        documentProxy.documentContextBeforeInput = ""
+        documentProxy.documentContextAfterInput = ""
+        documentProxy.hasText = false
+        let haptics = KeyboardKeypressHapticsSpy()
+        let controller = KeyboardTextInputController(
+            documentProxy: documentProxy,
+            emitKeypress: haptics.emitKeypressIfEnabled
+        )
+        var symbolPage = KeyboardSymbolPage.primary
+
+        // Attempt 1: Ghost delete, emits haptic
+        let handled1 = controller.handleKeyActivation(.delete, symbolPage: &symbolPage, resetCapsLockStateIfNeeded: {}, advanceToNextInputMode: {})
+        #expect(handled1 == true)
+        #expect(documentProxy.deleteBackwardCallCount == 1)
+        #expect(haptics.emissionCount == 1)
+
+        // Attempt 2: Ghost delete, silent
+        let handled2 = controller.handleKeyActivation(.delete, symbolPage: &symbolPage, resetCapsLockStateIfNeeded: {}, advanceToNextInputMode: {})
+        #expect(handled2 == true)
+        #expect(documentProxy.deleteBackwardCallCount == 2)
+        #expect(haptics.emissionCount == 1)
+
+        // Attempt 3: Ghost delete, silent
+        let handled3 = controller.handleKeyActivation(.delete, symbolPage: &symbolPage, resetCapsLockStateIfNeeded: {}, advanceToNextInputMode: {})
+        #expect(handled3 == true)
+        #expect(documentProxy.deleteBackwardCallCount == 3)
+        #expect(haptics.emissionCount == 1)
+
+        // Attempt 4: Exhausted phantom deletes, cancels repeater
+        let handled4 = controller.handleKeyActivation(.delete, symbolPage: &symbolPage, resetCapsLockStateIfNeeded: {}, advanceToNextInputMode: {})
+        #expect(handled4 == false)
+        #expect(documentProxy.deleteBackwardCallCount == 3)
+        #expect(haptics.emissionCount == 1)
+    }
+
+    @Test func deleteKeyIgnoresTrailingContextToBypassIOSBugs() {
+        let documentProxy = KeyboardTextDocumentProxySpy()
+        documentProxy.documentContextBeforeInput = ""
+        documentProxy.documentContextAfterInput = "phantom text"
+        documentProxy.hasText = true
+        let haptics = KeyboardKeypressHapticsSpy()
+        let controller = KeyboardTextInputController(
+            documentProxy: documentProxy,
+            emitKeypress: haptics.emitKeypressIfEnabled
+        )
+        var symbolPage = KeyboardSymbolPage.primary
+
+        // Should return true to allow deletion logic to proceed, bypassing buggy trailing contexts
+        let handled = controller.handleKeyActivation(.delete, symbolPage: &symbolPage, resetCapsLockStateIfNeeded: {}, advanceToNextInputMode: {})
+
+        #expect(handled == true)
+        #expect(documentProxy.deleteBackwardCallCount == 1)
+        #expect(haptics.emissionCount == 1)
+    }
+
     @Test func abcKeyTriggersCapsResetAndInputModeAdvance() {
         let documentProxy = KeyboardTextDocumentProxySpy()
         let haptics = KeyboardKeypressHapticsSpy()
@@ -350,6 +431,8 @@ struct KeyboardTextInputControllerTests {
 
 private final class KeyboardTextDocumentProxySpy: KeyboardTextDocumentProxying {
     var documentContextBeforeInput: String?
+    var documentContextAfterInput: String?
+    var hasText = false
     var selectedText: String?
     var insertedTexts: [String] = []
     var deleteBackwardCallCount = 0


### PR DESCRIPTION
## Summary

This PR addresses a critical UX issue where the iOS custom keyboard's delete key would freeze and become unresponsive when repeatedly deleting text across sentence boundaries in single-line host apps (like Messages or iOS Search). It also includes a quick quality-of-life fix for adding new words to the personal dictionary.

## What Changed
iOS's out-of-process text input (`UITextDocumentProxy`) frequently suffers from transient state desyncs in single-line fields—erroneously reporting that `documentContextBeforeInput` is empty and `hasText` is `false` when hitting a sentence boundary.

* Extended the text document proxy adapter to track `documentContextAfterInput` and `hasText`.
* Implemented a "phantom delete" debounce mechanism that tolerates these transient empty-context states. 
* If the proxy falsely claims the field is empty during a repeating sweep, the keyboard will now perform up to 3 silent fallback deletes to seamlessly bust through the buggy boundary and force a proxy resync without emitting infinite haptics.
* Added comprehensive unit tests covering the new phantom delete retries, hidden leading contexts, and misleading trailing-context behaviors.
 
## iOS App fixes 

* Updated the `AutoFocusTextField` inside the Dictionary sheet to use `.sentences` autocapitalization instead of `.words`. 
* This ensures that when adding a new phrase to the dictionary, only the very first letter is capitalized automatically, rather than aggressively capitalizing every word after a space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved delete key behavior to better handle edge cases when text input is unavailable, including repeated delete attempts on empty fields.
  * Changed text input capitalization from word-based to sentence-based.

* **Tests**
  * Added comprehensive test coverage for delete key behavior in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->