### PR TITLE
fix(core): improve spoken colon normalization and list false-positive handling

### DIFF
--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternRunSelector.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternRunSelector.swift
@@ -254,7 +254,7 @@ public struct ListPatternRunSelector {
     }
 
     private func containsSentenceBoundaryPunctuation(_ text: String) -> Bool {
-        let sentenceBoundaryPattern = #"[!?]|(?:^|[^A-Z0-9])\.(?:\s|$)"#
+        let sentenceBoundaryPattern = #"[!?]|(?:^|[A-Z0-9])\.(?:\s|$)"#
         return text.range(of: sentenceBoundaryPattern, options: [.regularExpression, .caseInsensitive]) != nil
     }
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternRunSelector.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternRunSelector.swift
@@ -46,14 +46,14 @@ public struct ListPatternRunSelector {
         guard !markers.isEmpty else { return nil }
         let nsText = text as NSString
 
-        // Build best monotonic subsequence ending at each marker, so we can
-        // skip noise markers (e.g. incidental "one" in prose) and still keep
-        // the intended 1->2->3 list flow.
+        // Intentionally require consecutive numbering for detected lists.
+        // Supporting skipped numbering (for example 1, 2, 4) created too many
+        // prose false positives for too little real-world value.
         var bestEndingAt = Array(repeating: [ListPatternMarker](), count: markers.count)
 
         for i in markers.indices {
             var bestForCurrent: [ListPatternMarker] = [markers[i]]
-            for j in 0..<i where markers[i].number > markers[j].number {
+            for j in 0..<i where markers[i].number == markers[j].number + 1 {
                 let previousRun = bestEndingAt[j]
                 guard !previousRun.isEmpty else { continue }
                 let candidate = previousRun + [markers[i]]
@@ -71,8 +71,7 @@ public struct ListPatternRunSelector {
 
         guard best.count >= 2 else { return nil }
         guard isCredibleRunStart(run: best, in: nsText) else { return nil }
-        guard isCredibleTwoItemGap(run: best, in: nsText, languageCode: languageCode) else { return nil }
-        guard hasCredibleSkippedNumberProgression(run: best, in: nsText, languageCode: languageCode) else { return nil }
+        guard hasNoCredibleTrailingSkippedMarkers(after: best, from: markers, in: nsText) else { return nil }
         guard hasCredibleAmbiguousTwoItemSpokenContent(run: best, in: nsText, languageCode: languageCode) else { return nil }
         guard hasCredibleRunCadence(run: best, in: nsText) else { return nil }
         return best
@@ -84,46 +83,6 @@ public struct ListPatternRunSelector {
         guard let first = run.first else { return false }
         guard first.number > 1 else { return true }
         return markerHasBoundaryBefore(first, in: nsText)
-    }
-
-    // Prevent prose like "one for X and three for Y" from being detected as a
-    // two-item list while still allowing explicit skipped numbering ("1. ... 3. ...").
-    private func isCredibleTwoItemGap(
-        run: [ListPatternMarker],
-        in nsText: NSString,
-        languageCode: String?
-    ) -> Bool {
-        guard run.count == 2 else { return true }
-        if run[0].number > 1 && !run.allSatisfy({ markerHasExplicitDelimiter($0, in: nsText, languageCode: languageCode) }) {
-            return false
-        }
-        let delta = run[1].number - run[0].number
-        guard delta > 1 else { return true }
-        return run.allSatisfy { markerHasExplicitDelimiter($0, in: nsText, languageCode: languageCode) }
-    }
-
-    private func hasCredibleSkippedNumberProgression(
-        run: [ListPatternMarker],
-        in nsText: NSString,
-        languageCode: String?
-    ) -> Bool {
-        guard run.count >= 2 else { return true }
-
-        for index in 1..<run.count {
-            let previous = run[index - 1]
-            let current = run[index]
-            let delta = current.number - previous.number
-
-            guard delta > 2 else { continue }
-
-            let previousExplicit = markerHasExplicitDelimiter(previous, in: nsText, languageCode: languageCode)
-            let currentExplicit = markerHasExplicitDelimiter(current, in: nsText, languageCode: languageCode)
-            guard previousExplicit && currentExplicit else {
-                return false
-            }
-        }
-
-        return true
     }
 
     private func hasCredibleAmbiguousTwoItemSpokenContent(
@@ -159,6 +118,27 @@ public struct ListPatternRunSelector {
 
         guard hasCredibleAmbiguousTwoItemPhraseShape(firstItemText) else {
             return false
+        }
+
+        return true
+    }
+
+    private func hasNoCredibleTrailingSkippedMarkers(
+        after run: [ListPatternMarker],
+        from markers: [ListPatternMarker],
+        in nsText: NSString
+    ) -> Bool {
+        guard let last = run.last else { return true }
+
+        // Intentionally reject a shorter consecutive run when a nearby later
+        // marker skips ahead (for example 1, 2, 4). We no longer support
+        // skipped numbering, so a trailing skipped marker should invalidate
+        // detection instead of being silently absorbed into commentary.
+        for marker in markers where marker.markerTokenStart > last.markerTokenStart {
+            guard marker.number > last.number + 1 else { continue }
+            if isCredibleAdjacentMarkerCadence(from: last, to: marker, in: nsText) {
+                return false
+            }
         }
 
         return true
@@ -358,14 +338,12 @@ public struct ListPatternRunSelector {
             return score
         }
 
-        // Prefer naturally contiguous counting while still allowing skipped
-        // numbers (e.g. 1, 2, 4) so later markers remain list items.
+        // Intentionally favor contiguous counting only. Skipped numbering was
+        // removed because it made prose/list ambiguity much harder to control.
         for index in 1..<run.count {
             let delta = run[index].number - run[index - 1].number
             if delta == 1 {
                 score += 2
-            } else if delta == 2 {
-                score += 1
             }
         }
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternRunSelector.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternRunSelector.swift
@@ -72,6 +72,7 @@ public struct ListPatternRunSelector {
         guard best.count >= 2 else { return nil }
         guard isCredibleRunStart(run: best, in: nsText) else { return nil }
         guard isCredibleTwoItemGap(run: best, in: nsText, languageCode: languageCode) else { return nil }
+        guard hasCredibleSkippedNumberProgression(run: best, in: nsText, languageCode: languageCode) else { return nil }
         guard hasCredibleAmbiguousTwoItemSpokenContent(run: best, in: nsText, languageCode: languageCode) else { return nil }
         guard hasCredibleRunCadence(run: best, in: nsText) else { return nil }
         return best
@@ -99,6 +100,30 @@ public struct ListPatternRunSelector {
         let delta = run[1].number - run[0].number
         guard delta > 1 else { return true }
         return run.allSatisfy { markerHasExplicitDelimiter($0, in: nsText, languageCode: languageCode) }
+    }
+
+    private func hasCredibleSkippedNumberProgression(
+        run: [ListPatternMarker],
+        in nsText: NSString,
+        languageCode: String?
+    ) -> Bool {
+        guard run.count >= 2 else { return true }
+
+        for index in 1..<run.count {
+            let previous = run[index - 1]
+            let current = run[index]
+            let delta = current.number - previous.number
+
+            guard delta > 2 else { continue }
+
+            let previousExplicit = markerHasExplicitDelimiter(previous, in: nsText, languageCode: languageCode)
+            let currentExplicit = markerHasExplicitDelimiter(current, in: nsText, languageCode: languageCode)
+            guard previousExplicit && currentExplicit else {
+                return false
+            }
+        }
+
+        return true
     }
 
     private func hasCredibleAmbiguousTwoItemSpokenContent(
@@ -132,10 +157,18 @@ public struct ListPatternRunSelector {
             return false
         }
 
+        guard hasCredibleAmbiguousTwoItemPhraseShape(firstItemText) else {
+            return false
+        }
+
         return true
     }
 
     private func hasCredibleAmbiguousItemOpening(_ text: String) -> Bool {
+        if looksLikeAmbiguousEmailOrDomainItem(text) {
+            return true
+        }
+
         let nsText = text as NSString
         let tagger = NSLinguisticTagger(tagSchemes: [.lexicalClass], options: 0)
         tagger.string = text
@@ -166,6 +199,63 @@ public struct ListPatternRunSelector {
         }
 
         return sawContentToken
+    }
+
+    private func hasCredibleAmbiguousTwoItemPhraseShape(_ text: String) -> Bool {
+        guard !containsSentenceBoundaryPunctuation(text) else {
+            return false
+        }
+
+        let nsText = text as NSString
+        let tagger = NSLinguisticTagger(tagSchemes: [.lexicalClass], options: 0)
+        tagger.string = text
+
+        var lexicalTags: [NSLinguisticTag] = []
+        let fullRange = NSRange(location: 0, length: nsText.length)
+
+        tagger.enumerateTags(
+            in: fullRange,
+            unit: .word,
+            scheme: .lexicalClass,
+            options: [.omitWhitespace, .omitPunctuation, .joinNames]
+        ) { tag, tokenRange, _ in
+            let token = nsText.substring(with: tokenRange)
+            guard token.rangeOfCharacter(from: .letters) != nil else { return }
+            if let tag {
+                lexicalTags.append(tag)
+            }
+        }
+
+        guard lexicalTags.count > 1 else { return true }
+        return !lexicalTags.dropFirst().contains(.pronoun)
+    }
+
+    private func looksLikeAmbiguousEmailOrDomainItem(_ text: String) -> Bool {
+        let collapsed = text
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsed.isEmpty else { return false }
+
+        let punctuationStripped = collapsed
+            .replacingOccurrences(
+                of: #"[\"'”’\)\]\}]*[.,;:!?…]+[\"'”’\)\]\}]*$"#,
+                with: "",
+                options: .regularExpression
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let emailLikePattern =
+            #"(?i)^(?:[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}|[A-Z0-9._%+'\-]+(?:\s+[A-Z0-9._%+'\-]+){0,3}\s+at\s+[A-Z0-9\-]+(?:\.[A-Z0-9\-]+)+)$"#
+        if punctuationStripped.range(of: emailLikePattern, options: .regularExpression) != nil {
+            return true
+        }
+
+        return WebsiteNormalizer.isCompactDomainToken(punctuationStripped)
+    }
+
+    private func containsSentenceBoundaryPunctuation(_ text: String) -> Bool {
+        let sentenceBoundaryPattern = #"[!?]|(?:^|[^A-Z0-9])\.(?:\s|$)"#
+        return text.range(of: sentenceBoundaryPattern, options: [.regularExpression, .caseInsensitive]) != nil
     }
 
     private func lexicalClassCountsAsContent(_ tag: NSLinguisticTag?) -> Bool {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ColonNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ColonNormalizer.swift
@@ -13,6 +13,15 @@ public struct ColonNormalizer {
         pattern: #"\s{2,}"#,
         options: []
     )
+    private static let newlineCodeUnit = utf16CodeUnit(for: "\n")
+    private static let periodCodeUnit = utf16CodeUnit(for: ".")
+    private static let exclamationCodeUnit = utf16CodeUnit(for: "!")
+    private static let questionCodeUnit = utf16CodeUnit(for: "?")
+
+    private static func utf16CodeUnit(for character: Character) -> unichar {
+        let text = String(character)
+        return text.utf16[text.utf16.startIndex]
+    }
 
     public init() {}
 
@@ -308,7 +317,10 @@ public struct ColonNormalizer {
 
         while index >= 0 {
             let scalar = text.character(at: index)
-            if scalar == 10 || scalar == 46 || scalar == 33 || scalar == 63 {
+            if scalar == Self.newlineCodeUnit ||
+                scalar == Self.periodCodeUnit ||
+                scalar == Self.exclamationCodeUnit ||
+                scalar == Self.questionCodeUnit {
                 return index + 1
             }
             if index == 0 { break }
@@ -324,7 +336,10 @@ public struct ColonNormalizer {
 
         while index < text.length {
             let scalar = text.character(at: index)
-            if scalar == 10 || scalar == 46 || scalar == 33 || scalar == 63 {
+            if scalar == Self.newlineCodeUnit ||
+                scalar == Self.periodCodeUnit ||
+                scalar == Self.exclamationCodeUnit ||
+                scalar == Self.questionCodeUnit {
                 return index
             }
             index += 1

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ColonNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ColonNormalizer.swift
@@ -133,12 +133,14 @@ public struct ColonNormalizer {
 
         var replacementStart = tokenRange.location
         while replacementStart > sentenceStart {
-            let scalar = text.character(at: replacementStart - 1)
-            if CharacterSet.whitespacesAndNewlines.contains(UnicodeScalar(scalar)!) {
+            let codeUnitIndex = replacementStart - 1
+            let scalar = unicodeScalar(in: text, at: codeUnitIndex)
+            let codeUnit = text.character(at: codeUnitIndex)
+            if let scalar, CharacterSet.whitespacesAndNewlines.contains(scalar) {
                 replacementStart -= 1
                 continue
             }
-            if scalar == 44 {
+            if codeUnit == 44 {
                 replacementStart -= 1
             }
             break
@@ -146,12 +148,13 @@ public struct ColonNormalizer {
 
         var replacementEnd = NSMaxRange(tokenRange)
         while replacementEnd < text.length {
-            let scalar = text.character(at: replacementEnd)
-            if scalar == 44 || scalar == 46 {
+            let scalar = unicodeScalar(in: text, at: replacementEnd)
+            let codeUnit = text.character(at: replacementEnd)
+            if codeUnit == 44 || codeUnit == 46 {
                 replacementEnd += 1
                 continue
             }
-            if CharacterSet.whitespacesAndNewlines.contains(UnicodeScalar(scalar)!) {
+            if let scalar, CharacterSet.whitespacesAndNewlines.contains(scalar) {
                 replacementEnd += 1
                 continue
             }
@@ -170,6 +173,42 @@ public struct ColonNormalizer {
         guard isLikelyAssociationValue(rightSegment) else { return nil }
 
         return NSRange(location: replacementStart, length: replacementEnd - replacementStart)
+    }
+
+    private func unicodeScalar(in text: NSString, at index: Int) -> UnicodeScalar? {
+        guard index >= 0, index < text.length else { return nil }
+
+        let codeUnit = text.character(at: index)
+        if let scalar = UnicodeScalar(codeUnit) {
+            return scalar
+        }
+
+        let leadSurrogateRange: ClosedRange<unichar> = 0xD800...0xDBFF
+        let trailSurrogateRange: ClosedRange<unichar> = 0xDC00...0xDFFF
+
+        if leadSurrogateRange.contains(codeUnit) {
+            let nextIndex = index + 1
+            guard nextIndex < text.length else { return nil }
+            let trailingCodeUnit = text.character(at: nextIndex)
+            guard trailSurrogateRange.contains(trailingCodeUnit) else { return nil }
+
+            let highBits = UInt32(codeUnit) - 0xD800
+            let lowBits = UInt32(trailingCodeUnit) - 0xDC00
+            return UnicodeScalar(0x10000 + ((highBits << 10) | lowBits))
+        }
+
+        if trailSurrogateRange.contains(codeUnit) {
+            let previousIndex = index - 1
+            guard previousIndex >= 0 else { return nil }
+            let leadingCodeUnit = text.character(at: previousIndex)
+            guard leadSurrogateRange.contains(leadingCodeUnit) else { return nil }
+
+            let highBits = UInt32(leadingCodeUnit) - 0xD800
+            let lowBits = UInt32(codeUnit) - 0xDC00
+            return UnicodeScalar(0x10000 + ((highBits << 10) | lowBits))
+        }
+
+        return nil
     }
 
     private func isColonHomophone(_ token: String) -> Bool {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ColonNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ColonNormalizer.swift
@@ -5,6 +5,10 @@ public struct ColonNormalizer {
         pattern: #"([,;:—\-])\s*["'“”‘’\(\[\{]*\s*([A-Za-z][A-Za-z'’\-]{2,})\s*["'“”‘’\)\]\}]*\s*([,;:—\-])"#,
         options: []
     )
+    private static let wordTokenRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\b[A-Za-z][A-Za-z'’\-]{2,}\b"#,
+        options: []
+    )
     private static let collapsedWhitespaceRegex: NSRegularExpression? = try? NSRegularExpression(
         pattern: #"\s{2,}"#,
         options: []
@@ -14,12 +18,36 @@ public struct ColonNormalizer {
 
     public func normalize(in text: String) -> String {
         guard !text.isEmpty else { return text }
-        guard let regex = Self.delimiterWrappedTokenRegex else { return text }
+        let explicitResult = normalizeExplicitDelimiterWrappedTokens(in: text)
+        let associationResult = normalizeAssociationStyleTokens(in: explicitResult.text)
+        let replacedSpokenColon = explicitResult.replacedSpokenColon || associationResult.replacedSpokenColon
+
+        guard replacedSpokenColon, let collapsedWhitespaceRegex = Self.collapsedWhitespaceRegex else {
+            let normalized = associationResult.text
+            return stripTerminalPunctuationForShortStandaloneAssociation(in: normalized, replacedSpokenColon: replacedSpokenColon)
+        }
+        let normalized = associationResult.text
+        let collapsedRange = NSRange(location: 0, length: (normalized as NSString).length)
+        let collapsed = collapsedWhitespaceRegex.stringByReplacingMatches(
+            in: normalized,
+            options: [],
+            range: collapsedRange,
+            withTemplate: " "
+        )
+        return stripTerminalPunctuationForShortStandaloneAssociation(in: collapsed, replacedSpokenColon: replacedSpokenColon)
+    }
+
+    private func normalizeExplicitDelimiterWrappedTokens(in text: String) -> (text: String, replacedSpokenColon: Bool) {
+        guard let regex = Self.delimiterWrappedTokenRegex else {
+            return (text, false)
+        }
 
         let nsText = text as NSString
         let fullRange = NSRange(location: 0, length: nsText.length)
         let matches = regex.matches(in: text, options: [], range: fullRange)
-        guard !matches.isEmpty else { return text }
+        guard !matches.isEmpty else {
+            return (text, false)
+        }
 
         let mutable = NSMutableString(string: text)
         var replacedSpokenColon = false
@@ -32,19 +60,35 @@ public struct ColonNormalizer {
             replacedSpokenColon = true
         }
 
-        guard replacedSpokenColon, let collapsedWhitespaceRegex = Self.collapsedWhitespaceRegex else {
-            let normalized = mutable as String
-            return stripTerminalPunctuationForShortStandaloneAssociation(in: normalized, replacedSpokenColon: replacedSpokenColon)
+        return (mutable as String, replacedSpokenColon)
+    }
+
+    private func normalizeAssociationStyleTokens(in text: String) -> (text: String, replacedSpokenColon: Bool) {
+        guard let regex = Self.wordTokenRegex else {
+            return (text, false)
         }
-        let normalized = mutable as String
-        let collapsedRange = NSRange(location: 0, length: (normalized as NSString).length)
-        let collapsed = collapsedWhitespaceRegex.stringByReplacingMatches(
-            in: normalized,
-            options: [],
-            range: collapsedRange,
-            withTemplate: " "
-        )
-        return stripTerminalPunctuationForShortStandaloneAssociation(in: collapsed, replacedSpokenColon: replacedSpokenColon)
+
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        let matches = regex.matches(in: text, options: [], range: fullRange)
+        guard !matches.isEmpty else {
+            return (text, false)
+        }
+
+        let mutable = NSMutableString(string: text)
+        var replacedSpokenColon = false
+
+        for match in matches.reversed() {
+            let tokenRange = match.range
+            guard tokenRange.location != NSNotFound, tokenRange.length > 0 else { continue }
+            let token = nsText.substring(with: tokenRange)
+            guard isColonHomophone(token) else { continue }
+            guard let replacementRange = associationReplacementRange(in: nsText, tokenRange: tokenRange) else { continue }
+            mutable.replaceCharacters(in: replacementRange, with: ": ")
+            replacedSpokenColon = true
+        }
+
+        return (mutable as String, replacedSpokenColon)
     }
 
     private func stripTerminalPunctuationForShortStandaloneAssociation(
@@ -84,6 +128,50 @@ public struct ColonNormalizer {
         return true
     }
 
+    private func associationReplacementRange(in text: NSString, tokenRange: NSRange) -> NSRange? {
+        let sentenceStart = sentenceBoundaryBefore(in: text, location: tokenRange.location)
+
+        var replacementStart = tokenRange.location
+        while replacementStart > sentenceStart {
+            let scalar = text.character(at: replacementStart - 1)
+            if CharacterSet.whitespacesAndNewlines.contains(UnicodeScalar(scalar)!) {
+                replacementStart -= 1
+                continue
+            }
+            if scalar == 44 {
+                replacementStart -= 1
+            }
+            break
+        }
+
+        var replacementEnd = NSMaxRange(tokenRange)
+        while replacementEnd < text.length {
+            let scalar = text.character(at: replacementEnd)
+            if scalar == 44 || scalar == 46 {
+                replacementEnd += 1
+                continue
+            }
+            if CharacterSet.whitespacesAndNewlines.contains(UnicodeScalar(scalar)!) {
+                replacementEnd += 1
+                continue
+            }
+            break
+        }
+
+        let sentenceEnd = sentenceBoundaryAfter(in: text, location: replacementEnd)
+
+        let leftRange = NSRange(location: sentenceStart, length: max(0, replacementStart - sentenceStart))
+        let rightRange = NSRange(location: replacementEnd, length: max(0, sentenceEnd - replacementEnd))
+
+        let leftSegment = normalizeAssociationSegment(text.substring(with: leftRange))
+        let rightSegment = normalizeAssociationSegment(text.substring(with: rightRange))
+
+        guard isLikelyAssociationLabel(leftSegment) else { return nil }
+        guard isLikelyAssociationValue(rightSegment) else { return nil }
+
+        return NSRange(location: replacementStart, length: replacementEnd - replacementStart)
+    }
+
     private func isColonHomophone(_ token: String) -> Bool {
         let letters = token.lowercased().unicodeScalars.filter { CharacterSet.letters.contains($0) }
         let simplified = String(String.UnicodeScalarView(letters))
@@ -103,6 +191,107 @@ public struct ColonNormalizer {
             return false
         }
         return !sentenceBoundaryCharacterSet.contains(previousScalar)
+    }
+
+    private func normalizeAssociationSegment(_ text: String) -> String {
+        text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines.union(CharacterSet(charactersIn: ",.;:—-")))
+    }
+
+    private func isLikelyAssociationLabel(_ text: String) -> Bool {
+        let words = wordCount(in: text)
+        guard (1...4).contains(words) else { return false }
+        guard !text.isEmpty else { return false }
+
+        let tags = lexicalTags(in: text)
+        guard !tags.contains(.pronoun) else { return false }
+        guard !tags.contains(.preposition) else { return false }
+        guard !tags.contains(.interjection) else { return false }
+
+        let verbCount = tags.filter { $0 == .verb }.count
+        if verbCount == 0 {
+            return true
+        }
+
+        return verbCount == 1 && words <= 2 && startsWithUppercaseWord(in: text)
+    }
+
+    private func isLikelyAssociationValue(_ text: String) -> Bool {
+        let words = wordCount(in: text)
+        guard (1...6).contains(words) else { return false }
+        guard !text.isEmpty else { return false }
+
+        let tags = lexicalTags(in: text)
+        guard !tags.contains(.pronoun) else { return false }
+        guard !tags.contains(.verb) else { return false }
+        guard !tags.contains(.preposition) else { return false }
+        guard !tags.contains(.interjection) else { return false }
+        return true
+    }
+
+    private func lexicalTags(in text: String) -> [NSLinguisticTag] {
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        let tagger = NSLinguisticTagger(tagSchemes: [.lexicalClass], options: 0)
+        tagger.string = text
+
+        var tags: [NSLinguisticTag] = []
+        tagger.enumerateTags(
+            in: fullRange,
+            unit: .word,
+            scheme: .lexicalClass,
+            options: [.omitWhitespace, .omitPunctuation, .joinNames]
+        ) { tag, tokenRange, _ in
+            let token = nsText.substring(with: tokenRange)
+            guard token.rangeOfCharacter(from: .letters) != nil else { return }
+            if let tag {
+                tags.append(tag)
+            }
+        }
+
+        return tags
+    }
+
+    private func wordCount(in text: String) -> Int {
+        text.split(whereSeparator: \.isWhitespace).count
+    }
+
+    private func startsWithUppercaseWord(in text: String) -> Bool {
+        guard let firstWord = text.split(whereSeparator: \.isWhitespace).first,
+              let firstCharacter = firstWord.first else {
+            return false
+        }
+        return firstCharacter.isUppercase
+    }
+
+    private func sentenceBoundaryBefore(in text: NSString, location: Int) -> Int {
+        guard location > 0 else { return 0 }
+        var index = location - 1
+
+        while index >= 0 {
+            let scalar = text.character(at: index)
+            if scalar == 10 || scalar == 46 || scalar == 33 || scalar == 63 {
+                return index + 1
+            }
+            if index == 0 { break }
+            index -= 1
+        }
+
+        return 0
+    }
+
+    private func sentenceBoundaryAfter(in text: NSString, location: Int) -> Int {
+        guard location < text.length else { return text.length }
+        var index = location
+
+        while index < text.length {
+            let scalar = text.character(at: index)
+            if scalar == 10 || scalar == 46 || scalar == 33 || scalar == 63 {
+                return index
+            }
+            index += 1
+        }
+
+        return text.length
     }
 
     private func previousNonWhitespaceScalar(in text: NSString, before location: Int) -> UnicodeScalar? {

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+LanguageHeuristics.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+LanguageHeuristics.swift
@@ -297,6 +297,94 @@ extension TranscriptionPostProcessorTests {
 
         XCTAssertEqual(output, "Next task, Colin.")
     }
+    func testNormalizesBareColonAssociationLabel() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Event Colon Wedding reception",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Event: Wedding reception")
+    }
+    func testNormalizesCapitalizedColinAssociationLabel() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Announcement Colin, new baby.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Announcement: New baby")
+    }
+    func testKeepsLiteralColonPunctuationAssociation() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Big announcement: New baby",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Big announcement: New baby")
+    }
+    func testNormalizesCapitalizedColonAssociationWithoutCommas() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Jumping Jacks Colon an amusement park",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Jumping Jacks: An amusement park")
+    }
+    func testNormalizesCapitalizedColinAssociationWithTrailingComma() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Jumping Jacks Colin, an amusement park.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Jumping Jacks: An amusement park")
+    }
+    func testNormalizesCapitalizedColonAssociationWithTrailingPeriod() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Wild Ride Colon. Nature's Adventures.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Wild Ride: Nature's Adventures")
+    }
+    func testKeepsLiteralColonAssociationTitle() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Disneyland: A new adventure",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Disneyland: A new adventure")
+    }
+    func testNormalizesCommaDelimitedCapitalizedColinAssociationLabel() {
+        let processor = TranscriptionPostProcessor()
+
+        let output = processor.process(
+            "Fantastic Saturdays, Colin, another day.",
+            dictionaryEntries: [],
+            renderMode: .singleLineInline
+        )
+
+        XCTAssertEqual(output, "Fantastic Saturdays: Another day")
+    }
     func testDoesNotRewriteSingleWordGreetingColin() {
         let processor = TranscriptionPostProcessor()
 

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
@@ -20,12 +20,12 @@ final class ListFormattingEngineTests: XCTestCase {
         XCTAssertTrue(output == text)
     }
 
-    func testFormatsListWhenNumberingSkipsAhead() {
+    func testLeavesTextUnchangedWhenNumberingSkipsAhead() {
         let engine = ListFormattingEngine()
         let text = "Need to do this one buy groceries two walk dog four call mom"
 
         let output = engine.formatIfNeeded(text, renderMode: .multiline)
-        XCTAssertTrue(output == "Need to do this:\n\n1. Buy groceries\n2. Walk dog\n4. Call mom")
+        XCTAssertEqual(output, text)
     }
 
     func testLeavesUncertainNumericRangeInProseUnchanged() {

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
@@ -280,14 +280,12 @@ final class ListPatternDetectorTests: XCTestCase {
         ])
     }
 
-    func testKeepsFormattingWhenSpokenNumberSkipsAhead() {
+    func testDoesNotDetectListWhenSpokenNumberSkipsAhead() {
         let detector = ListPatternDetector()
         let text = "Today one buy groceries two walk dog four call mom five charge phone"
 
         let detected = detector.detectList(in: text)
-        XCTAssertTrue(detected != nil)
-        XCTAssertTrue(detected?.items.map(\.spokenIndex) == [1, 2, 4, 5])
-        XCTAssertTrue(detected?.items.map(\.content) == ["Buy groceries", "Walk dog", "Call mom", "Charge phone"])
+        XCTAssertNil(detected)
     }
 
     func testDoesNotDetectTwoItemNonConsecutiveProseNumbers() {
@@ -383,14 +381,12 @@ final class ListPatternDetectorTests: XCTestCase {
         ])
     }
 
-    func testDetectsExplicitTwoItemNonConsecutiveListMarkers() {
+    func testDoesNotDetectExplicitTwoItemNonConsecutiveListMarkers() {
         let detector = ListPatternDetector()
         let text = "1. buy groceries 3. call mom"
 
         let detected = detector.detectList(in: text)
-        XCTAssertNotNil(detected)
-        XCTAssertEqual(detected?.items.map(\.spokenIndex), [1, 3])
-        XCTAssertEqual(detected?.items.map(\.content), ["Buy groceries", "Call mom"])
+        XCTAssertNil(detected)
     }
 
     func testDetectsSpokenMarkersBeyondTwelveWithoutHardCap() {

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
@@ -298,6 +298,14 @@ final class ListPatternDetectorTests: XCTestCase {
         XCTAssertNil(detected)
     }
 
+    func testDoesNotDetectOrdinalFractionPhraseInProse() {
+        let detector = ListPatternDetector()
+        let text = "Now the key is about one third too wide and it bleeds into the nine key next to it"
+
+        let detected = detector.detectList(in: text)
+        XCTAssertNil(detected)
+    }
+
     func testDoesNotDetectListWhenSecondMarkerArrivesAfterLongProseSpan() {
         let detector = ListPatternDetector()
         let text = """
@@ -312,6 +320,22 @@ final class ListPatternDetectorTests: XCTestCase {
     func testDoesNotDetectTwoItemSpokenNumbersInsideLongProseSentence() {
         let detector = ListPatternDetector()
         let text = "I was testing dictation with a long form YouTube video where the user said the number one initially and then later on after long prose they said the number two and they just kept going"
+
+        let detected = detector.detectList(in: text)
+        XCTAssertNil(detected)
+    }
+
+    func testDoesNotDetectTwoItemSpokenNumbersAcrossSentenceBoundaryInProse() {
+        let detector = ListPatternDetector()
+        let text = "If I double click into the mirror, it only shows me the one single half. It's not two separate shapes"
+
+        let detected = detector.detectList(in: text)
+        XCTAssertNil(detected)
+    }
+
+    func testDoesNotDetectTwoItemSpokenNumbersInRequestProse() {
+        let detector = ListPatternDetector()
+        let text = "Why is it that I ask you for one pie you always bring two apples"
 
         let detected = detector.detectList(in: text)
         XCTAssertNil(detected)


### PR DESCRIPTION
## Summary

This branch fixes two normalization regressions in `KeyVoxCore`:

- reduces false list detection for spoken-number prose that should remain inline
- improves colon normalization for title/subtitle-style phrases across Whisper and Parakeet outputs

## What Changed

- tightened ambiguous list detection in `ListPatternRunSelector`
- added skipped-number progression guards so prose like `one third ... nine key` is no longer reformatted as a list
- preserved explicit email/domain list handling while blocking ambiguous spoken-number false positives
- expanded `ColonNormalizer` with a separate association-style path for bare `colon` / `colin` separators
- used Apple linguistic tagging to better distinguish real title/subtitle associations from literal names or ordinary prose
- kept the existing delimiter-wrapped spoken-colon behavior intact
- added verbatim regression coverage for the reported list false positives
- added regression coverage for colon-association examples such as:
  - `Event Colon Wedding reception`
  - `Announcement Colin, new baby.`
  - `Jumping Jacks Colon an amusement park`
  - `Wild Ride Colon. Nature's Adventures.`
  - `Fantastic Saturdays, Colin, another day.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stricter list detection: consecutive numbering only; skipped-number sequences no longer detected as lists.
  * Smarter colon normalization: broader association-style handling for titles/labels/values.
  * Better handling of email/domain-like tokens and ambiguous two-item phrases to reduce false positives.
* **Tests**
  * Added and updated unit tests to cover new colon heuristics and revised list-detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->