### PR TITLE
fix(lists): handle spoken time tails and short final item commentary splits

### DIFF
--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternMarkerParser.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternMarkerParser.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct ListPatternMarkerParser {
     private static let markerTokenPattern = #"(?:\d+|[\p{L}]+(?:-[\p{L}]+)?)"#
+    private static let meridiemPattern = #"(?i)^(?:a\.?m\.?|p\.?m\.?)\b"#
 
     private static let leadingMarkerRegex: NSRegularExpression = {
         let pattern = "(?i)^\\s*(\(markerTokenPattern))"
@@ -157,6 +158,9 @@ struct ListPatternMarkerParser {
             if resolved.isDigitToken && isLikelyTimeComponent(at: resolved.markerTokenStart, in: nsText) {
                 return nil
             }
+            if isLikelySimpleHourClockTime(number: resolved.number, contentStart: resolved.contentStart, in: nsText) {
+                return nil
+            }
             if resolved.isDigitToken && isLikelyCompactClockTime(token: resolved.token, contentStart: resolved.contentStart, in: nsText) {
                 return nil
             }
@@ -176,6 +180,9 @@ struct ListPatternMarkerParser {
             let tokenRange = match.range(at: 1)
             guard tokenRange.location != NSNotFound else { return nil }
             guard let resolved = resolvedMarker(in: nsText, tokenRange: tokenRange, languageCode: languageCode) else {
+                return nil
+            }
+            if isLikelySimpleHourClockTime(number: resolved.number, contentStart: resolved.contentStart, in: nsText) {
                 return nil
             }
             if resolved.isDigitToken && isLikelyCompactClockTime(token: resolved.token, contentStart: resolved.contentStart, in: nsText) {
@@ -400,11 +407,20 @@ struct ListPatternMarkerParser {
             minute = Int(token.suffix(2)) ?? -1
         }
         guard (1...12).contains(hour), (0...59).contains(minute) else { return false }
+        return previewStartsWithMeridiem(from: contentStart, in: nsText)
+    }
+
+    private func isLikelySimpleHourClockTime(number: Int, contentStart: Int, in nsText: NSString) -> Bool {
+        guard (1...12).contains(number) else { return false }
+        return previewStartsWithMeridiem(from: contentStart, in: nsText)
+    }
+
+    private func previewStartsWithMeridiem(from contentStart: Int, in nsText: NSString) -> Bool {
         guard contentStart < nsText.length else { return false }
 
         let previewLength = min(12, nsText.length - contentStart)
         let preview = nsText.substring(with: NSRange(location: contentStart, length: previewLength))
-        return preview.range(of: #"(?i)^(?:a\.?m\.?|p\.?m\.?)\b"#, options: .regularExpression) != nil
+        return preview.range(of: Self.meridiemPattern, options: .regularExpression) != nil
     }
 
     private static func leadingMarker(in text: String, languageCode: String?) -> (value: Int, tokenRange: NSRange)? {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternTrailingSplitter.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternTrailingSplitter.swift
@@ -166,7 +166,23 @@ public struct ListPatternTrailingSplitter {
         guard let split = firstRegexSplit(text, pattern: #"(?i)^(.+?[.!?])\s+(.+)$"#) else {
             return nil
         }
-        return makeCandidate(item: split.0, trailing: split.1, score: 100, languageCode: languageCode)
+
+        if let candidate = makeCandidate(item: split.0, trailing: split.1, score: 100, languageCode: languageCode) {
+            return candidate
+        }
+
+        let shortNominalItem = looksLikeShortNominalItem(split.0)
+        let sentenceLikeTrailing = looksLikeSentenceStyleCommentary(split.1)
+        let supportsShortNominalSplit = shortNominalItem && (sentenceLikeTrailing || looksLikeContinuationStart(split.1))
+        guard supportsShortNominalSplit else { return nil }
+
+        return makeCandidate(
+            item: split.0,
+            trailing: split.1,
+            score: 100,
+            minItemWords: 1,
+            languageCode: languageCode
+        )
     }
 
     private func paragraphBoundaryCandidate(

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
@@ -77,6 +77,23 @@ final class ListFormattingEngineTests: XCTestCase {
         )
     }
 
+    func testSplitsSingleWordLastItemFromSentenceStyleCommentaryAfterExplicitListMarker() {
+        let engine = ListFormattingEngine()
+        let text = """
+        I'm going out of town next week and I need to buy a few things from Walmart:
+
+        1. Socks
+        2. Razor blades
+        3. Soda. And remind me to buy an extra bottle of shampoo for my suitcase before I leave on my flight tomorrow at 10:00 AM.
+        """
+
+        let output = engine.formatIfNeeded(text, renderMode: .multiline)
+        XCTAssertEqual(
+            output,
+            "I'm going out of town next week and I need to buy a few things from Walmart:\n\n1. Socks\n2. Razor blades\n3. Soda\n\nAnd remind me to buy an extra bottle of shampoo for my suitcase before I leave on my flight tomorrow at 10:00 AM."
+        )
+    }
+
     func testPreservesTerminalPunctuationOnlyForLongerListItems() {
         let engine = ListFormattingEngine()
         let text = """

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListFormattingEngineTests.swift
@@ -66,6 +66,17 @@ final class ListFormattingEngineTests: XCTestCase {
         )
     }
 
+    func testFormatsSpokenListBeforeTimePhraseTrailingSentence() {
+        let engine = ListFormattingEngine()
+        let text = "Please help me pick up a couple of things from the party store. One, party hats, two, kazoos, three, gift bags, and bring them to my house by about 5:00 PM tomorrow."
+
+        let output = engine.formatIfNeeded(text, renderMode: .multiline)
+        XCTAssertEqual(
+            output,
+            "Please help me pick up a couple of things from the party store:\n\n1. Party hats\n2. Kazoos\n3. Gift bags\n\nAnd bring them to my house by about 5:00 PM tomorrow."
+        )
+    }
+
     func testPreservesTerminalPunctuationOnlyForLongerListItems() {
         let engine = ListFormattingEngine()
         let text = """

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
@@ -59,6 +59,27 @@ final class ListPatternDetectorTests: XCTestCase {
         XCTAssertEqual(detected?.trailingText, "and honestly I don't think you're going to pick wrong")
     }
 
+    func testSplitsSingleWordLastItemFromSentenceStyleCommentaryAfterExplicitListMarker() {
+        let detector = ListPatternDetector()
+        let text = """
+        I'm going out of town next week and I need to buy a few things from Walmart:
+
+        1. Socks
+        2. Razor blades
+        3. Soda. And remind me to buy an extra bottle of shampoo for my suitcase before I leave on my flight tomorrow at 10:00 AM.
+        """
+
+        let detected = detector.detectList(in: text)
+
+        XCTAssertNotNil(detected)
+        XCTAssertEqual(detected?.items.map(\.spokenIndex), [1, 2, 3])
+        XCTAssertEqual(detected?.items.map(\.content), ["Socks", "Razor blades", "Soda"])
+        XCTAssertEqual(
+            detected?.trailingText,
+            "And remind me to buy an extra bottle of shampoo for my suitcase before I leave on my flight tomorrow at 10:00 AM."
+        )
+    }
+
     func testPreservesCausalTransitionWhenSplittingLastItem() {
         let detector = ListPatternDetector()
         let text = "Today one get dog food two charge phone three call mom because we leave early"


### PR DESCRIPTION
## Summary

This branch fixes two list-formatting regressions in `KeyVoxCore` where valid lists were being dropped or over-merged by time phrases and trailing sentence-style commentary.

## What Changed

- stop treating simple spoken or numeric hour tokens followed by `AM` or `PM` as list markers in `ListPatternMarkerParser`
- prevent trailing time phrases like `five PM` from poisoning otherwise valid spoken lists
- update `ListPatternTrailingSplitter` so sentence-boundary splits can still fire when the final list item is a short nominal item and the following text clearly reads as commentary
- preserve explicit list formatting for cases like `3. Soda. And remind me...` instead of folding the reminder into the last item

## Regression Coverage Added

- spoken list before a trailing time phrase:
  - `Please help me pick up a couple of things from the party store. One, party hats, two, kazoos, three, gift bags, and bring them to my house by about 5:00 PM tomorrow.`
- explicit list with a short final item plus trailing reminder:
  - `3. Soda. And remind me to buy an extra bottle of shampoo for my suitcase before I leave on my flight tomorrow at 10:00 AM.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed list parsing to prevent time expressions (e.g., "5:00 PM") from being misidentified as list markers.
  * Improved handling of list items followed by sentence-style commentary or continuation text.

* **Tests**
  * Added test coverage for list formatting with time phrases and trailing commentary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->