### PR TITLE
fix(keyboard): stabilize presentation lifecycle across swaps and host resume

### DIFF
--- a/iOS/Docs/CODEMAP.md
+++ b/iOS/Docs/CODEMAP.md
@@ -27,7 +27,7 @@ The current default runtime flow is:
 ## Architecture
 
 - **`KeyVox iOS/`**: app lifecycle, composition root, onboarding state, app haptics, URL routing, App Group storage, iCloud sync, model background downloads, audio capture, transcription/session management, Live Activity coordination, and the SwiftUI shell.
-- **`KeyVox Keyboard/`**: custom keyboard controller, toolbar modes, call-aware warning detection, key grid UI, full-access instructional surface, live indicator rendering, host-app launch handoff, haptics, cursor trackpad behavior, and final insertion heuristics.
+- **`KeyVox Keyboard/`**: custom keyboard controller, presentation-scoped keyboard view lifecycle, toolbar modes, call-aware warning detection, key grid UI, full-access instructional surface, live indicator rendering, host-app launch handoff, haptics, cursor trackpad behavior, and final insertion heuristics.
 - **`KeyVox Widget/`**: ActivityKit/WidgetKit surface for the lock screen and Dynamic Island, plus the stop-session App Intent.
 - **`../Packages/KeyVoxCore/`**: shared dictation pipeline, provider seams, dictionary store, post-processing order, silence heuristics, and list formatting behavior.
 - **`KeyVoxiOSTests/`**: deterministic tests for onboarding state, keyboard-tour routing, settings persistence, iCloud sync, weekly stats, model lifecycle, model download recovery, microphone permission handling, text input helpers, cursor-trackpad behavior, and transcription/session orchestration.
@@ -167,6 +167,8 @@ iOS/
 ├── KeyVox Keyboard/
 │   ├── App/
 │   │   ├── KeyboardContainingAppLauncher.swift
+│   │   ├── KeyboardViewController+Debug.swift
+│   │   ├── KeyboardViewController+PresentationLifecycle.swift
 │   │   └── KeyboardViewController.swift
 │   ├── Core/
 │   │   ├── AudioIndicatorDriver.swift
@@ -239,7 +241,8 @@ iOS/
 │   │   │   ├── KeyboardDictationControllerTests.swift
 │   │   │   ├── KeyboardInteractionHapticsTests.swift
 │   │   │   ├── KeyboardToolbarModeTests.swift
-│   │   │   └── KeyboardTextInputControllerTests.swift
+│   │   │   ├── KeyboardTextInputControllerTests.swift
+│   │   │   └── KeyboardViewControllerTests.swift
 │   │   └── Transcription/
 │   │       └── TranscriptionManagerTests.swift
 │   └── KeyVoxiOSTests.swift
@@ -392,6 +395,12 @@ Packages/
 - `KeyVox Keyboard/App/KeyboardViewController.swift`
   - Extension controller and top-level keyboard surface owner.
   - Owns toolbar mode switching, call-aware warning presentation, full-access instructions presentation, warm/cold app launch behavior, onboarding presentation reporting, Caps Lock, symbol page, trackpad mode, and insertion.
+- `KeyVox Keyboard/App/KeyboardViewController+PresentationLifecycle.swift`
+  - Presentation-tree creation, per-presentation binding, teardown, and extension-host lifecycle observation.
+  - Pauses the active presentation during host backgrounding, refreshes it on host foregrounding, and tears the tree down only for real dismissal and globe-key presentation swaps.
+  - Keeps the keyboard view hierarchy disposable across globe-key presentation swaps.
+- `KeyVox Keyboard/App/KeyboardViewController+Debug.swift`
+  - Debug-only presentation lifecycle counters and controller test hooks.
 - `KeyVox Keyboard/Core/KeyboardCallObserver.swift`
   - Tracks active phone-call state through `CallKit` so the keyboard can warn before dictation is attempted during a call.
 - `KeyVox Keyboard/Core/KeyboardDictationController.swift`
@@ -428,7 +437,7 @@ Packages/
 - `KeyVoxiOSTests/Core/Audio/`
   - Audio input preference resolution and stop-time capture processing.
 - `KeyVoxiOSTests/Core/Keyboard/`
-  - Keyboard dictation control, toolbar warning precedence, interaction haptics, text insertion behavior, and cursor-trackpad helpers.
+  - Keyboard dictation control, controller presentation lifecycle coverage, toolbar warning precedence, interaction haptics, text insertion behavior, and cursor-trackpad helpers.
 - `KeyVoxiOSTests/Core/Transcription/`
   - Transcription/session lifecycle and interrupted-capture recovery behavior.
 

--- a/iOS/Docs/ENGINEERING.md
+++ b/iOS/Docs/ENGINEERING.md
@@ -41,6 +41,7 @@ The containing app owns:
 The keyboard extension owns:
 
 - visible keyboard UI
+- presentation-scoped keyboard view-tree lifecycle
 - toolbar mode selection and warning presentation
 - warm/cold launch handoff into the containing app
 - text insertion into host apps
@@ -570,6 +571,7 @@ The extension is a transport and insertion surface, not the transcription owner.
 `KeyboardViewController` should own only:
 
 - UI event handling
+- presentation lifecycle coordination
 - toolbar mode switching
 - call-state observation for warning presentation
 - full-access instructions presentation
@@ -578,6 +580,27 @@ The extension is a transport and insertion surface, not the transcription owner.
 - cancel flow
 - host-text insertion
 - cursor movement and key-repeat interactions
+
+### Keyboard Presentation Lifecycle Rules
+
+The keyboard presentation tree is intentionally disposable.
+
+Rules:
+
+- `KeyboardViewController` may be preloaded before the keyboard is actually shown, so it must **not** build the presentation tree in `viewDidLoad`
+- the keyboard presentation tree is created only on the appearance path
+- teardown must run on real keyboard dismissal and presentation-swap boundaries while the extension host is active, including `viewWillDisappear`
+- extension-host resign-active notifications must pause the active presentation without destroying the current tree so host app background/foreground does not blank the keyboard
+- `deinit` is not a safe ownership boundary for keyboard cleanup
+- teardown must remove the presentation tree, popup overlay, full-access overlay, IPC observers, and indicator callbacks
+- host lifecycle observers are controller-scoped and remain installed until controller teardown
+- rebuild must preserve the same visuals, toolbar behavior, warning precedence, haptics, and insertion rules as a fresh keyboard presentation
+
+Implementation split:
+
+- `KeyboardViewController.swift` owns the controller-facing event and state surface
+- `KeyboardViewController+PresentationLifecycle.swift` owns presentation-tree creation, binding, teardown, and host-lifecycle observation
+- `KeyboardViewController+Debug.swift` owns debug-only lifecycle counters and testing hooks
 
 ### Toolbar and Layout Rules
 
@@ -718,6 +741,7 @@ Views may surface manager state, but runtime ownership stays in the managers and
 - stop-time capture processing
 - keyboard dictation controller behavior
 - keyboard interaction haptics
+- keyboard controller presentation teardown and rebuild behavior
 - keyboard text input helpers
 - keyboard cursor-trackpad support
 - transcription manager lifecycle and interruption handling

--- a/iOS/KeyVox Keyboard/App/KeyboardViewController+Debug.swift
+++ b/iOS/KeyVox Keyboard/App/KeyboardViewController+Debug.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+#if DEBUG
+extension KeyboardViewController {
+    var debugHasPresentationViewTree: Bool {
+        rootContainerView != nil && popupOverlayView != nil
+    }
+
+    var debugRootViewIdentifier: ObjectIdentifier? {
+        rootContainerView.map(ObjectIdentifier.init)
+    }
+
+    var debugFullAccessViewIdentifier: ObjectIdentifier? {
+        fullAccessView.map(ObjectIdentifier.init)
+    }
+
+    var debugHasHostLifecycleObservers: Bool {
+        hostWillResignActiveObserver != nil && hostDidBecomeActiveObserver != nil
+    }
+
+    var debugIPCObserverRegistrationActive: Bool {
+        ipcManager.debugIsRegistered
+    }
+
+    static func resetPresentationLifecycleDiagnostics() {
+        KeyboardPresentationLifecycleDiagnostics.reset()
+    }
+
+    static var debugCreatedPresentationViewTreeCount: Int {
+        KeyboardPresentationLifecycleDiagnostics.createdPresentationViewTreeCount
+    }
+
+    static var debugDestroyedPresentationViewTreeCount: Int {
+        KeyboardPresentationLifecycleDiagnostics.destroyedPresentationViewTreeCount
+    }
+
+    func debugPresentFullAccessInstructionsForTesting() {
+        setFullAccessInstructionsPresented(true)
+    }
+}
+#endif

--- a/iOS/KeyVox Keyboard/App/KeyboardViewController+PresentationLifecycle.swift
+++ b/iOS/KeyVox Keyboard/App/KeyboardViewController+PresentationLifecycle.swift
@@ -1,0 +1,189 @@
+import Foundation
+import UIKit
+
+#if DEBUG
+enum KeyboardPresentationLifecycleDiagnostics {
+    static var createdPresentationViewTreeCount = 0
+    static var destroyedPresentationViewTreeCount = 0
+
+    static func reset() {
+        createdPresentationViewTreeCount = 0
+        destroyedPresentationViewTreeCount = 0
+    }
+}
+#endif
+
+extension KeyboardViewController {
+    func preparePresentationIfNeeded() {
+        ensurePresentationViews()
+        activatePresentationBindingsIfNeeded()
+    }
+
+    func ensurePresentationViews() {
+        guard rootContainerView == nil || popupOverlayView == nil else { return }
+
+        if rootContainerView != nil || popupOverlayView != nil {
+            tearDownPresentation()
+        }
+
+        let rootView = KeyboardRootView()
+        rootView.translatesAutoresizingMaskIntoConstraints = false
+
+        let popupOverlayView = UIView()
+        popupOverlayView.translatesAutoresizingMaskIntoConstraints = false
+        popupOverlayView.backgroundColor = .clear
+        popupOverlayView.isUserInteractionEnabled = false
+        popupOverlayView.clipsToBounds = false
+
+        view.addSubview(rootView)
+        view.addSubview(popupOverlayView)
+
+        NSLayoutConstraint.activate([
+            rootView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            rootView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            rootView.topAnchor.constraint(equalTo: view.topAnchor),
+            rootView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            popupOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            popupOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            popupOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
+            popupOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        self.rootContainerView = rootView
+        self.popupOverlayView = popupOverlayView
+
+#if DEBUG
+        KeyboardPresentationLifecycleDiagnostics.createdPresentationViewTreeCount += 1
+#endif
+    }
+
+    func activatePresentationBindingsIfNeeded() {
+        guard isPresentationBound == false,
+              let rootContainerView,
+              let popupOverlayView else { return }
+
+        rootContainerView.cancelButton.addTarget(self, action: #selector(handleCancelTap), for: .touchUpInside)
+        rootContainerView.capsLockButton.addTarget(self, action: #selector(handleCapsLockTap), for: .touchUpInside)
+        rootContainerView.logoBarView.addTarget(self, action: #selector(handleMicTap), for: .touchUpInside)
+        rootContainerView.fullAccessInfoButton.addTarget(self, action: #selector(handleFullAccessInfoTap), for: .touchUpInside)
+        rootContainerView.keyGridView.onKeyActivated = { [weak self] kind in
+            self?.handleKeyActivation(kind) ?? false
+        }
+        rootContainerView.keyGridView.onSpaceTrackpadEvent = { [weak self] event in
+            self?.handleSpaceTrackpadEvent(event)
+        }
+        rootContainerView.keyGridView.setPopupContainerView(popupOverlayView)
+
+        indicatorDriver.sampleProvider = { [weak self] in
+            self?.ipcManager.currentAudioIndicatorSample()
+        }
+        indicatorDriver.onUpdate = { [weak self] timelineState in
+            self?.rootContainerView?.logoBarView.applyTimelineState(timelineState)
+        }
+
+        dictationController.registerObservers()
+        isPresentationBound = true
+    }
+
+    func deactivatePresentationBindings() {
+        guard isPresentationBound else { return }
+
+        indicatorDriver.stop()
+        indicatorDriver.sampleProvider = nil
+        indicatorDriver.onUpdate = nil
+        dictationController.unregisterObservers()
+
+        if let rootContainerView {
+            rootContainerView.cancelButton.removeTarget(self, action: #selector(handleCancelTap), for: .touchUpInside)
+            rootContainerView.capsLockButton.removeTarget(self, action: #selector(handleCapsLockTap), for: .touchUpInside)
+            rootContainerView.logoBarView.removeTarget(self, action: #selector(handleMicTap), for: .touchUpInside)
+            rootContainerView.fullAccessInfoButton.removeTarget(self, action: #selector(handleFullAccessInfoTap), for: .touchUpInside)
+            rootContainerView.keyGridView.onKeyActivated = nil
+            rootContainerView.keyGridView.onSpaceTrackpadEvent = nil
+            rootContainerView.keyGridView.setPopupContainerView(nil)
+            rootContainerView.keyGridView.resetInteractionState()
+        }
+
+        fullAccessView?.onBack = nil
+        primaryHeightConstraint?.isActive = false
+        primaryHeightConstraint = nil
+        isPresentationBound = false
+    }
+
+    func destroyPresentationViews() {
+        let hadPresentationViews = fullAccessView != nil || popupOverlayView != nil || rootContainerView != nil
+
+        if let fullAccessView {
+            fullAccessView.removeFromSuperview()
+            self.fullAccessView = nil
+        }
+
+        if let popupOverlayView {
+            popupOverlayView.subviews.forEach { $0.removeFromSuperview() }
+            popupOverlayView.removeFromSuperview()
+            self.popupOverlayView = nil
+        }
+
+        if let rootContainerView {
+            rootContainerView.removeFromSuperview()
+            self.rootContainerView = nil
+        }
+
+#if DEBUG
+        if hadPresentationViews {
+            KeyboardPresentationLifecycleDiagnostics.destroyedPresentationViewTreeCount += 1
+        }
+#endif
+    }
+
+    func tearDownPresentation() {
+        deactivatePresentationBindings()
+        destroyPresentationViews()
+    }
+
+    func configureHostLifecycleObservers() {
+        guard hostWillResignActiveObserver == nil, hostDidBecomeActiveObserver == nil else { return }
+
+        hostWillResignActiveObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name.NSExtensionHostWillResignActive,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.extensionHostIsActive = false
+            self?.rootContainerView?.keyGridView.resetInteractionState()
+            self?.indicatorDriver.stop()
+        }
+
+        hostDidBecomeActiveObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name.NSExtensionHostDidBecomeActive,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.extensionHostIsActive = true
+            guard let self else { return }
+            self.preparePresentationIfNeeded()
+            self.configurePrimaryViewHeight()
+            self.syncCapsLockState()
+            self.callObserver.refreshState()
+            self.rootContainerView?.keyGridView.resetInteractionState()
+            self.dictationController.syncStateFromSharedState()
+            self.indicatorDriver.start()
+            KeyVoxIPCBridge.reportKeyboardOnboardingState(hasFullAccess: self.hasFullAccess)
+            KeyVoxIPCBridge.reportKeyboardOnboardingPresentation()
+            self.updateUI()
+        }
+    }
+
+    func removeHostLifecycleObservers() {
+        if let hostWillResignActiveObserver {
+            NotificationCenter.default.removeObserver(hostWillResignActiveObserver)
+            self.hostWillResignActiveObserver = nil
+        }
+
+        if let hostDidBecomeActiveObserver {
+            NotificationCenter.default.removeObserver(hostDidBecomeActiveObserver)
+            self.hostDidBecomeActiveObserver = nil
+        }
+    }
+}

--- a/iOS/KeyVox Keyboard/App/KeyboardViewController.swift
+++ b/iOS/KeyVox Keyboard/App/KeyboardViewController.swift
@@ -2,18 +2,18 @@ import AVFoundation
 import UIKit
 
 final class KeyboardViewController: UIInputViewController {
-    private let ipcManager = KeyboardIPCManager()
-    private let capsLockStateStore = KeyboardCapsLockStateStore()
-    private let keypressHaptics = KeyboardKeypressHaptics()
-    private let interactionHaptics = KeyboardInteractionHaptics()
-    private let indicatorDriver = AudioIndicatorDriver()
-    private let startRecordingURL = URL(string: "keyvoxios://record/start")
-    private let dictionaryCasingStore = KeyboardDictionaryCasingStore()
-    private let callObserver =  KeyboardCallObserver()
-    private lazy var containingAppLauncher = KeyboardContainingAppLauncher(responderProvider: { [weak self] in
+    let ipcManager = KeyboardIPCManager()
+    let capsLockStateStore = KeyboardCapsLockStateStore()
+    let keypressHaptics = KeyboardKeypressHaptics()
+    let interactionHaptics = KeyboardInteractionHaptics()
+    let indicatorDriver = AudioIndicatorDriver()
+    let startRecordingURL = URL(string: "keyvoxios://record/start")
+    let dictionaryCasingStore = KeyboardDictionaryCasingStore()
+    let callObserver =  KeyboardCallObserver()
+    lazy var containingAppLauncher = KeyboardContainingAppLauncher(responderProvider: { [weak self] in
         self
     })
-    private lazy var textInputController = KeyboardTextInputController(
+    lazy var textInputController = KeyboardTextInputController(
         documentProxy: KeyboardTextDocumentProxyAdapter(proxyProvider: { [weak self] in
             self?.textDocumentProxy
         }),
@@ -24,7 +24,7 @@ final class KeyboardViewController: UIInputViewController {
             self?.dictionaryCasingStore.shouldPreserveLeadingCapitalization(in: text) ?? false
         }
     )
-    private lazy var dictationController = KeyboardDictationController(
+    lazy var dictationController = KeyboardDictationController(
         ipcManager: ipcManager,
         scheduleAction: keyboardMainQueueScheduler,
         openContainingApp: { [weak self] url in
@@ -32,31 +32,33 @@ final class KeyboardViewController: UIInputViewController {
         },
         startRecordingURL: startRecordingURL
     )
-    private var primaryHeightConstraint: NSLayoutConstraint?
-    private var keyboardState: KeyboardState = .idle {
+    var primaryHeightConstraint: NSLayoutConstraint?
+    var keyboardState: KeyboardState = .idle {
         didSet {
             updateUI()
         }
     }
-    private var symbolPage: KeyboardSymbolPage = .primary {
+    var symbolPage: KeyboardSymbolPage = .primary {
         didSet {
             updateUI()
         }
     }
-    private var isCapsLockEnabled = false {
+    var isCapsLockEnabled = false {
         didSet {
             updateUI()
         }
     }
 
-    private var rootContainerView: KeyboardRootView!
-    private let popupOverlayView = UIView()
-    private var fullAccessView: FullAccessView?
-    private var cursorTrackpadInteractor = KeyboardCursorTrackpadInteractor()
-    private var isTrackpadModeActive = false
-    private var extensionHostIsActive = true
-    private var hostWillResignActiveObserver: NSObjectProtocol?
-    private var hostDidBecomeActiveObserver: NSObjectProtocol?
+    var rootContainerView: KeyboardRootView?
+    var popupOverlayView: UIView?
+    var fullAccessView: FullAccessView?
+    var cursorTrackpadInteractor = KeyboardCursorTrackpadInteractor()
+    var isTrackpadModeActive = false
+    var extensionHostIsActive = true
+    var hostWillResignActiveObserver: NSObjectProtocol?
+    var hostDidBecomeActiveObserver: NSObjectProtocol?
+    var hasConfiguredControllerBindings = false
+    var isPresentationBound = false
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -70,15 +72,12 @@ final class KeyboardViewController: UIInputViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        KeyVoxIPCBridge.reportKeyboardOnboardingState(hasFullAccess: hasFullAccess)
         view.backgroundColor = .clear
         view.clipsToBounds = true
-        configureRootView()
         configureTraitChangeObservation()
-        configureIndicatorDriver()
-        configureDictationController()
         configureHostLifecycleObservers()
-        configureCallObserver()
+        configureControllerBindingsIfNeeded()
+        KeyVoxIPCBridge.reportKeyboardOnboardingState(hasFullAccess: hasFullAccess)
         syncCapsLockState()
         dictationController.syncStateFromSharedState()
         updateUI()
@@ -86,6 +85,8 @@ final class KeyboardViewController: UIInputViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        extensionHostIsActive = true
+        preparePresentationIfNeeded()
         KeyVoxIPCBridge.reportKeyboardOnboardingState(hasFullAccess: hasFullAccess)
         configureDictationBehavior()
         callObserver.refreshState()
@@ -102,83 +103,31 @@ final class KeyboardViewController: UIInputViewController {
         KeyVoxIPCBridge.reportKeyboardOnboardingPresentation()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        guard extensionHostIsActive else { return }
+        tearDownPresentation()
+    }
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         rootContainerView?.keyGridView.resetInteractionState()
-        indicatorDriver.stop()
         if extensionHostIsActive {
             resetCapsLockStateIfNeeded()
+            tearDownPresentation()
         }
     }
 
     deinit {
-        indicatorDriver.stop()
-        if let hostWillResignActiveObserver {
-            NotificationCenter.default.removeObserver(hostWillResignActiveObserver)
-        }
-        if let hostDidBecomeActiveObserver {
-            NotificationCenter.default.removeObserver(hostDidBecomeActiveObserver)
-        }
-        dictationController.unregisterObservers()
+        tearDownPresentation()
+        removeHostLifecycleObservers()
     }
 
     private func configureDictationBehavior() {
         hasDictationKey = true
     }
 
-    private func configureRootView() {
-        if rootContainerView == nil {
-            view.backgroundColor = .clear
-            view.clipsToBounds = true
-
-            let rootView = KeyboardRootView()
-            rootView.translatesAutoresizingMaskIntoConstraints = false
-            rootContainerView = rootView
-
-            popupOverlayView.translatesAutoresizingMaskIntoConstraints = false
-            popupOverlayView.backgroundColor = .clear
-            popupOverlayView.isUserInteractionEnabled = false
-            popupOverlayView.clipsToBounds = false
-
-            view.addSubview(rootView)
-            view.addSubview(popupOverlayView)
-
-            NSLayoutConstraint.activate([
-                rootView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                rootView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                rootView.topAnchor.constraint(equalTo: view.topAnchor),
-                rootView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-
-                popupOverlayView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                popupOverlayView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                popupOverlayView.topAnchor.constraint(equalTo: view.topAnchor),
-                popupOverlayView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            ])
-        }
-
-        rootContainerView.cancelButton.addTarget(self, action: #selector(handleCancelTap), for: .touchUpInside)
-        rootContainerView.capsLockButton.addTarget(self, action: #selector(handleCapsLockTap), for: .touchUpInside)
-        rootContainerView.logoBarView.addTarget(self, action: #selector(handleMicTap), for: .touchUpInside)
-        rootContainerView.fullAccessInfoButton.addTarget(self, action: #selector(handleFullAccessInfoTap), for: .touchUpInside)
-        rootContainerView.keyGridView.onKeyActivated = { [weak self] kind in
-            self?.handleKeyActivation(kind) ?? false
-        }
-        rootContainerView.keyGridView.onSpaceTrackpadEvent = { [weak self] event in
-            self?.handleSpaceTrackpadEvent(event)
-        }
-        rootContainerView.keyGridView.setPopupContainerView(popupOverlayView)
-    }
-
-    private func configureIndicatorDriver() {
-        indicatorDriver.sampleProvider = { [weak self] in
-            self?.ipcManager.currentAudioIndicatorSample()
-        }
-        indicatorDriver.onUpdate = { [weak self] timelineState in
-            self?.rootContainerView?.logoBarView.applyTimelineState(timelineState)
-        }
-    }
-
-    private func configurePrimaryViewHeight() {
+    func configurePrimaryViewHeight() {
         primaryHeightConstraint?.isActive = false
         primaryHeightConstraint = nil
 
@@ -198,47 +147,22 @@ final class KeyboardViewController: UIInputViewController {
         }
     }
 
-    private func configureDictationController() {
+    private func configureControllerBindingsIfNeeded() {
+        guard hasConfiguredControllerBindings == false else { return }
+        hasConfiguredControllerBindings = true
+
         dictationController.onStateChange = { [weak self] state in
             self?.keyboardState = state
         }
         dictationController.onTranscriptionReady = { [weak self] text in
             self?.handleTranscriptionReady(text)
         }
-        dictationController.registerObservers()
-    }
-
-    private func configureCallObserver() {
         callObserver.onCallStateChange = { [weak self] in
             self?.updateUI()
         }
     }
 
-    private func configureHostLifecycleObservers() {
-        guard hostWillResignActiveObserver == nil, hostDidBecomeActiveObserver == nil else { return }
-
-        hostWillResignActiveObserver = NotificationCenter.default.addObserver(
-            forName: NSNotification.Name.NSExtensionHostWillResignActive,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.extensionHostIsActive = false
-        }
-
-        hostDidBecomeActiveObserver = NotificationCenter.default.addObserver(
-            forName: NSNotification.Name.NSExtensionHostDidBecomeActive,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.extensionHostIsActive = true
-            guard let self else { return }
-            KeyVoxIPCBridge.reportKeyboardOnboardingState(hasFullAccess: self.hasFullAccess)
-            KeyVoxIPCBridge.reportKeyboardOnboardingPresentation()
-            self.updateUI()
-        }
-    }
-
-    private func updateUI() {
+    func updateUI() {
         let toolbarMode = currentToolbarMode()
         rootContainerView?.apply(
             state: keyboardState,
@@ -262,7 +186,7 @@ final class KeyboardViewController: UIInputViewController {
         )
     }
 
-    private func ensureFullAccessView() -> FullAccessView {
+    func ensureFullAccessView() -> FullAccessView {
         if let fullAccessView {
             return fullAccessView
         }
@@ -297,41 +221,41 @@ final class KeyboardViewController: UIInputViewController {
         }
     }
 
-    private func setFullAccessInstructionsPresented(_ isPresented: Bool) {
+    func setFullAccessInstructionsPresented(_ isPresented: Bool) {
         if isPresented {
             ensureFullAccessView().isHidden = false
         } else {
             fullAccessView?.isHidden = true
         }
         rootContainerView?.isHidden = isPresented
-        popupOverlayView.isHidden = isPresented
+        popupOverlayView?.isHidden = isPresented
     }
 
     @objc
-    private func handleCancelTap() {
+    func handleCancelTap() {
         interactionHaptics.emitWarningIfEnabled()
         dictationController.handleCancelTap()
     }
 
     @objc
-    private func handleCapsLockTap() {
+    func handleCapsLockTap() {
         isCapsLockEnabled = capsLockStateStore.toggle()
         interactionHaptics.emitLightIfEnabled()
     }
 
     @objc
-    private func handleMicTap() {
+    func handleMicTap() {
         interactionHaptics.emitMediumIfEnabled()
         dictationController.handleMicTap()
     }
 
     @objc
-    private func handleFullAccessInfoTap() {
+    func handleFullAccessInfoTap() {
         setFullAccessInstructionsPresented(true)
     }
 
     @discardableResult
-    private func handleKeyActivation(_ kind: KeyboardKeyKind) -> Bool {
+    func handleKeyActivation(_ kind: KeyboardKeyKind) -> Bool {
         textInputController.handleKeyActivation(
             kind,
             symbolPage: &symbolPage,
@@ -344,7 +268,7 @@ final class KeyboardViewController: UIInputViewController {
         )
     }
 
-    private func handleSpaceTrackpadEvent(_ event: KeyboardSpaceTrackpadEvent) {
+    func handleSpaceTrackpadEvent(_ event: KeyboardSpaceTrackpadEvent) {
         switch event {
         case .began:
             isTrackpadModeActive = true
@@ -364,7 +288,7 @@ final class KeyboardViewController: UIInputViewController {
         }
     }
 
-    private func syncCapsLockState() {
+    func syncCapsLockState() {
         isCapsLockEnabled = capsLockStateStore.isEnabled
     }
 

--- a/iOS/KeyVox Keyboard/Core/KeyboardIPCManager.swift
+++ b/iOS/KeyVox Keyboard/Core/KeyboardIPCManager.swift
@@ -17,6 +17,12 @@ final class KeyboardIPCManager {
 
     private var isRegistered = false
 
+#if DEBUG
+    var debugIsRegistered: Bool {
+        isRegistered
+    }
+#endif
+
     func registerObservers() {
         guard !isRegistered else { return }
         isRegistered = true

--- a/iOS/KeyVox Keyboard/Views/Components/KeyboardKeyGridView.swift
+++ b/iOS/KeyVox Keyboard/Views/Components/KeyboardKeyGridView.swift
@@ -59,7 +59,7 @@ final class KeyboardKeyGridView: UIView {
         }
     }
 
-    func setPopupContainerView(_ view: UIView) {
+    func setPopupContainerView(_ view: UIView?) {
         popupContainerView = view
     }
 

--- a/iOS/KeyVox iOS.xcodeproj/project.pbxproj
+++ b/iOS/KeyVox iOS.xcodeproj/project.pbxproj
@@ -287,6 +287,8 @@
 			membershipExceptions = (
 				App/KeyboardContainingAppLauncher.swift,
 				App/KeyboardViewController.swift,
+				"App/KeyboardViewController+Debug.swift",
+				"App/KeyboardViewController+PresentationLifecycle.swift",
 				Core/AudioIndicatorDriver.swift,
 				Core/KeyboardCallObserver.swift,
 				Core/KeyboardCapsLockStateStore.swift,

--- a/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardViewControllerTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardViewControllerTests.swift
@@ -1,0 +1,80 @@
+import UIKit
+import Testing
+@testable import KeyVox_iOS
+
+@MainActor
+struct KeyboardViewControllerTests {
+    @Test func viewDisappearanceTearsDownPresentationTreeButKeepsHostLifecycleObservers() {
+        KeyboardViewController.resetPresentationLifecycleDiagnostics()
+        let controller = KeyboardViewController(nibName: nil, bundle: nil)
+
+        controller.loadViewIfNeeded()
+        controller.viewWillAppear(false)
+
+        #expect(controller.debugHasPresentationViewTree)
+        #expect(controller.debugIPCObserverRegistrationActive)
+        #expect(controller.debugHasHostLifecycleObservers)
+        #expect(KeyboardViewController.debugCreatedPresentationViewTreeCount == 1)
+
+        controller.viewDidDisappear(false)
+
+        #expect(controller.debugHasPresentationViewTree == false)
+        #expect(controller.debugIPCObserverRegistrationActive == false)
+        #expect(controller.debugHasHostLifecycleObservers)
+        #expect(KeyboardViewController.debugDestroyedPresentationViewTreeCount == 1)
+    }
+
+    @Test func reappearingRebuildsExactlyOneFreshPresentationTree() {
+        KeyboardViewController.resetPresentationLifecycleDiagnostics()
+        let controller = KeyboardViewController(nibName: nil, bundle: nil)
+
+        controller.loadViewIfNeeded()
+        controller.viewWillAppear(false)
+        let firstRootViewIdentifier = controller.debugRootViewIdentifier
+
+        controller.viewDidDisappear(false)
+        controller.viewWillAppear(false)
+
+        #expect(controller.debugHasPresentationViewTree)
+        #expect(controller.debugRootViewIdentifier != nil)
+        #expect(controller.debugRootViewIdentifier != firstRootViewIdentifier)
+        #expect(KeyboardViewController.debugCreatedPresentationViewTreeCount == 2)
+        #expect(KeyboardViewController.debugDestroyedPresentationViewTreeCount == 1)
+    }
+
+    @Test func fullAccessInstructionsDoNotPersistAcrossPresentationTeardown() {
+        KeyboardViewController.resetPresentationLifecycleDiagnostics()
+        let controller = KeyboardViewController(nibName: nil, bundle: nil)
+
+        controller.loadViewIfNeeded()
+        controller.viewWillAppear(false)
+        controller.debugPresentFullAccessInstructionsForTesting()
+
+        #expect(controller.debugFullAccessViewIdentifier != nil)
+
+        controller.viewDidDisappear(false)
+        controller.viewWillAppear(false)
+
+        #expect(controller.debugFullAccessViewIdentifier == nil)
+    }
+
+    @Test func hostBackgroundingDoesNotTearDownActivePresentationTree() {
+        KeyboardViewController.resetPresentationLifecycleDiagnostics()
+        let controller = KeyboardViewController(nibName: nil, bundle: nil)
+
+        controller.loadViewIfNeeded()
+        controller.viewWillAppear(false)
+        let firstRootViewIdentifier = controller.debugRootViewIdentifier
+
+        NotificationCenter.default.post(name: NSNotification.Name.NSExtensionHostWillResignActive, object: nil)
+        controller.viewWillDisappear(false)
+        controller.viewDidDisappear(false)
+        NotificationCenter.default.post(name: NSNotification.Name.NSExtensionHostDidBecomeActive, object: nil)
+
+        #expect(controller.debugHasPresentationViewTree)
+        #expect(controller.debugRootViewIdentifier == firstRootViewIdentifier)
+        #expect(controller.debugHasHostLifecycleObservers)
+        #expect(KeyboardViewController.debugCreatedPresentationViewTreeCount == 1)
+        #expect(KeyboardViewController.debugDestroyedPresentationViewTreeCount == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Stabilize the iOS keyboard presentation lifecycle so globe-key swaps no longer retain full keyboard trees, while preserving the active keyboard across host app background/foreground transitions.

## What Changed

- move keyboard presentation-tree creation, binding, teardown, and host lifecycle handling into `KeyboardViewController+PresentationLifecycle.swift`
- keep the keyboard view hierarchy disposable across real dismissal and globe-key swaps without relying on `deinit`
- stop building the presentation tree in `viewDidLoad` so preloaded controllers do not eagerly allocate keyboard UI
- preserve the active presentation during host resign-active and refresh it on host foreground so the keyboard no longer returns blank after app backgrounding
- add debug-only lifecycle counters and controller test hooks in `KeyboardViewController+Debug.swift`
- add controller lifecycle coverage for teardown, rebuild, full-access reset, and host background/foreground behavior
- allow `KeyboardKeyGridView` to clear its popup container during teardown
- expose a debug observer-registration seam in `KeyboardIPCManager`
- update the iOS engineering docs and codemap to reflect the final presentation-scoped lifecycle rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Tests**
  * Added comprehensive keyboard controller presentation lifecycle test coverage.

* **Chores**
  * Improved keyboard presentation lifecycle management and app switching stability through internal architecture refinements.
  * Updated documentation to formalize keyboard presentation rules and lifecycle constraints.
  * Enhanced debug diagnostics and testing hooks for keyboard state inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->