### PR TITLE
feat(ios-tts-iap): add phase one unlock scaffolding for copied-text playback

### DIFF
--- a/iOS/Docs/CODEMAP.md
+++ b/iOS/Docs/CODEMAP.md
@@ -74,6 +74,7 @@ iOS/
 │   │   ├── KeyVoxURLRouter.swift
 │   │   ├── KeyVoxiOSApp.swift
 │   │   ├── SharedPaths.swift
+│   │   ├── TTSPurchaseController.swift
 │   │   ├── WeeklyWordStatsStore.swift
 │   │   ├── Onboarding/
 │   │   │   ├── OnboardingDownloadNetworkMonitor.swift
@@ -177,7 +178,8 @@ iOS/
 │   │   │   ├── OnboardingStepRow.swift
 │   │   │   ├── PlaybackVoicePickerMenu.swift
 │   │   │   ├── SettingsDeletionConfirmation.swift
-│   │   │   └── SettingsRow.swift
+│   │   │   ├── SettingsRow.swift
+│   │   │   └── TTSUnlockSheetView.swift
 │   │   ├── Dictionary/
 │   │   │   ├── AutoFocusTextField.swift
 │   │   │   ├── DictionaryEntryRowView.swift
@@ -288,6 +290,7 @@ iOS/
 │   │   ├── OnboardingSetupStateTests.swift
 │   │   ├── OnboardingStoreTests.swift
 │   │   ├── SharedPathsTests.swift
+│   │   ├── TTSPurchaseControllerTests.swift
 │   │   ├── WeeklyWordStatsCloudSyncTests.swift
 │   │   └── WeeklyWordStatsStoreTests.swift
 │   ├── Core/
@@ -362,8 +365,11 @@ Packages/
   - Small launch-scoped routing owner for early cold-start URL presentation and later route consumption.
 - `KeyVox iOS/App/AppServiceRegistry.swift`
   - Main composition root.
-  - Builds dictionary, onboarding, settings, weekly stats, app haptics, the shared app-tab router, Whisper, Parakeet, the active-provider router, post-processing, model, keyboard bridge, transcription, PocketTTS runtime services, iCloud sync, Live Activity, and URL-routing services.
+  - Builds dictionary, onboarding, settings, weekly stats, app haptics, the shared app-tab router, Whisper, Parakeet, the active-provider router, post-processing, model, keyboard bridge, transcription, PocketTTS runtime services, the TTS unlock gate, iCloud sync, Live Activity, and URL-routing services.
   - Normalizes the persisted active provider back to a ready model when install state changes.
+- `KeyVox iOS/App/TTSPurchaseController.swift`
+  - App-owned one-time unlock and daily-usage owner for copied-text playback.
+  - Loads the placeholder StoreKit non-consumable product, owns purchase and restore flows, caches last-known unlock state, tracks two free new speaks per local day, and exposes the shared unlock-sheet presentation state.
 - `KeyVox iOS/App/AppHaptics.swift`
   - App-owned UIKit haptic emitter injected through the SwiftUI environment.
 - `KeyVox iOS/App/AppHapticsDecisions.swift`
@@ -389,6 +395,9 @@ Packages/
   - Keeps the onboarding setup presentation consistent while the screen owns step-specific button state and copy.
 - `KeyVox iOS/Views/Components/ModelDownloadProgress.swift`
   - Reusable onboarding download progress bar with the app accent styling and an optional percent label.
+- `KeyVox iOS/Views/Components/TTSUnlockSheetView.swift`
+  - Intentionally plain placeholder unlock sheet for the copied-text playback monetization proof path.
+  - Surfaces the one-time unlock CTA, restore action, and the current remaining-free-speaks summary without trying to be a polished paywall yet.
 - `KeyVox iOS/Views/Onboarding/Tour/OnboardingKeyboardTourScreen.swift`
   - Full-screen post-Settings handoff screen that autofocuses a text field and keeps the input pinned above the keyboard.
   - Advances through three tour scenes (`a`, `b`, `c`) and only enables the final completion action after the KeyVox keyboard has been shown and a first non-empty transcription has completed.
@@ -408,6 +417,8 @@ Packages/
 
 - `KeyVox iOS/App/KeyVoxIPCBridge.swift`
   - Source of truth for App Group defaults keys, TTS playback state and request state, replay-related shared request storage, keyboard onboarding presentation/access timestamps, shared live-meter file transport, and Darwin notification names.
+- `KeyVox iOS/App/iCloud/UserDefaultsKeys.swift`
+  - Includes the app-owned cached TTS unlock state plus the local day token and free-speak usage count used by the phase-one copied-text playback gate.
 - `KeyVox iOS/App/KeyVoxKeyboardBridge.swift`
   - App-side IPC endpoint for start/stop/cancel/disable-session commands and extension-facing state publishing.
 - `KeyVox iOS/App/KeyVoxSessionLiveActivityCoordinator.swift`
@@ -452,13 +463,14 @@ Packages/
 - `KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/`
   - Split playback transport owner for deterministic startup runway, background-safe continuation, replay capture, pause and resume, metering, progress publishing, and playback scheduling.
 - `KeyVox iOS/Core/TTS/TTSManager/`
-  - Split high-level copied-text playback owner for request lifecycle, preparation progress, replay state, paused replay restoration, lifecycle observation, and App Group TTS state publishing.
+  - Split high-level copied-text playback owner for request lifecycle, preparation progress, replay state, paused replay restoration, lifecycle observation, App Group TTS state publishing, and the consume-on-success free-speak hook used by phase-one monetization.
 - `KeyVox iOS/Core/TTS/TTSReplayCache.swift`
   - Persistence layer for the last replayable rendered playback and paused replay sample offsets.
 - `KeyVox iOS/Core/TTS/TTSVoicePreviewPlayer.swift`
   - Bundled voice-preview playback owner used by the Voice Model settings section.
 - `KeyVox iOS/Core/TTS/AudioModeCoordinator.swift`
   - Single arbitration surface for dictation-versus-TTS transitions, including pause/resume/replay transport.
+  - Also enforces the copied-text playback entitlement gate for every new TTS start path before playback begins.
 - `KeyVox iOS/Views/PlaybackPreparationView.swift`
   - Cold-launch playback-preparation screen shown before returning to the host app.
 
@@ -494,8 +506,8 @@ Packages/
   - `HomeTabView.swift` owns the weekly stats card, last transcription card, Home-level state, and debug-only diagnostics.
   - `TTS/HomeTabView+TTS.swift` owns the main copied-text playback card layout.
   - `TTS/HomeTabView+TTSTranscript.swift` owns transcript toggle behavior, expanded transcript presentation, transcript copy affordance, and idle transcript dismissal.
-  - `TTS/HomeTabView+TTSTransport.swift` owns the live transport ring, replay transport button, replay scrubber gating, badge state, status copy, and playback error presentation.
-  - `TTS/HomeTabView+TTSPresentation.swift` owns preparation presentation state, button titles, shared installed-voice selection binding, the hidden Home voice-picker shortcut, and Home-scoped TTS actions.
+  - `TTS/HomeTabView+TTSTransport.swift` owns the live transport ring, replay transport button, replay scrubber gating, badge state, status copy, playback error presentation, and the idle monetization messaging for remaining free speaks or locked state.
+  - `TTS/HomeTabView+TTSPresentation.swift` owns preparation presentation state, button titles, shared installed-voice selection binding, the hidden Home voice-picker shortcut, the unlock-title fallback, and Home-scoped TTS actions.
   - `TTS/TTSReplayScrubber.swift` owns the replay timeline scrubber view.
 - `KeyVox iOS/App/CopyFeedbackController.swift`
   - Shared app-scoped copy interaction state for pasteboard writes, success haptics, copied-state timing, and reset behavior used by multiple UI surfaces without forcing them into one visual component.
@@ -503,6 +515,8 @@ Packages/
   - Latest transcription card plus its trailing copy action, backed by the shared copy-feedback interaction controller instead of view-local pasteboard logic.
 - `KeyVox iOS/Views/Components/PlaybackVoicePickerMenu.swift`
   - Reusable installed-voice picker menu used by both the Settings Voice Model section and the hidden Home copied-text playback shortcut.
+- `KeyVox iOS/Views/Components/TTSUnlockSheetView.swift`
+  - Placeholder copied-text playback unlock sheet used by Home and Settings when the user needs to purchase or restore the one-time TTS unlock.
 - `KeyVox iOS/Views/DictionaryTabView.swift`
   - Dictionary UI plus editor flow built around `AutoFocusTextField`, sort state, and `KeyboardObserver`.
 - `KeyVox iOS/Views/StyleTabView.swift`
@@ -512,7 +526,7 @@ Packages/
 - `KeyVox iOS/Views/SettingsTabView+Models.swift`
   - Release-facing `Text Model` section, provider selection, per-model install actions, and not-installed size labels.
 - `KeyVox iOS/Views/SettingsTabView+TTS.swift`
-  - Release-facing `Voice Model` section for PocketTTS runtime install state, per-voice install actions, voice previews, and playback voice selection, including the shared installed-voice picker menu.
+  - Release-facing `Voice Model` section for PocketTTS runtime install state, per-voice install actions, voice previews, playback voice selection, and the placeholder `TTS Access` unlock row, including the shared installed-voice picker menu.
 - `KeyVox iOS/Views/Components/SettingsDeletionConfirmation.swift`
   - Shared destructive-delete confirmation component used by the settings model sections.
 - `KeyVox iOS/Views/ReturnToHostView.swift`
@@ -566,6 +580,8 @@ Packages/
 
 - `KeyVoxiOSTests/App/`
   - Onboarding state, onboarding keyboard-tour state, keyboard access probing, app haptics decisions, settings persistence, shared paths, iCloud sync, weekly stats, Live Activity coordination, URL routing, and model manager behavior across rooted Whisper migration and Parakeet installs.
+- `KeyVoxiOSTests/App/TTSPurchaseControllerTests.swift`
+  - Deterministic copied-text playback monetization coverage for cached unlock state, two-free-speaks-per-day accounting, local day resets, and purchase or restore state transitions through the placeholder store abstraction.
 - `KeyVoxiOSTests/Core/Audio/`
   - Audio input preference resolution and stop-time capture processing.
 - `KeyVoxiOSTests/Core/Keyboard/`

--- a/iOS/Docs/ENGINEERING.md
+++ b/iOS/Docs/ENGINEERING.md
@@ -174,11 +174,12 @@ Current root behavior:
 - `isIgnoringPersistedPendingKeyboardTourThisLaunch`
 - `hasCompletedOnboardingThisLaunch`
 
-### Force-Onboarding Runtime Flag
+### Runtime Flags
 
-The only supported runtime flag is:
+The supported runtime flags are:
 
 - `KEYVOX_FORCE_ONBOARDING`
+- `KEYVOX_BYPASS_TTS_FREE_SPEAK_LIMIT`
 
 Accepted truthy values:
 
@@ -192,6 +193,21 @@ Behavior:
 - the flag must still allow in-launch progression through the flow
 - persisted onboarding completion must not block the forced flow
 - stale persisted keyboard-tour handoff state must not skip setup during a forced run
+
+### TTS Free-Speak Bypass Runtime Flag
+
+Accepted truthy values:
+
+- `1`
+- `true`
+- `yes`
+
+Behavior:
+
+- the flag bypasses the phase-one limit of two free new copied-text playback generations per local calendar day
+- the flag is for development and testing only and must not change production monetization policy
+- the flag only applies to new PocketTTS generation gating and does not change replay behavior
+- `TTSManager` still consumes a free speak only after a new PocketTTS generation has actually started, but no use is consumed while the bypass flag is enabled
 
 ### Onboarding Screen Order
 
@@ -599,6 +615,7 @@ Primary owners:
 - keyboard-initiated playback stages the request in shared storage and uses the containing app as the synthesis owner
 - share-extension initiated playback also stages the request in shared storage and uses the containing app as the synthesis owner
 - phase-one monetization allows two free new copied-text playback generations per local calendar day before the one-time unlock is required
+- `KEYVOX_BYPASS_TTS_FREE_SPEAK_LIMIT` bypasses that daily-generation gate for development and testing only
 - replay remains free for already generated playback and must not consume daily free uses
 - only new copied-text playback generations are gated; replay, pause, resume, scrubbing, replay restore, and transcript viewing remain outside the monetization gate
 - playback-preparation progress is deterministic and gates the return-to-host path before audio starts
@@ -607,6 +624,7 @@ Primary owners:
 - paused replay state, including sample offset, is durable across app relaunches
 - replay transport uses a dedicated scrubber while cached replay is active
 - `TTSManager` consumes a free daily speak only after the new PocketTTS generation has successfully begun, not on button tap alone
+- no free speak is consumed while the TTS free-speak bypass runtime flag is enabled
 - `AudioModeCoordinator` must remain the transition owner for:
   - start dictation
   - start copied-text playback

--- a/iOS/Docs/ENGINEERING.md
+++ b/iOS/Docs/ENGINEERING.md
@@ -131,6 +131,7 @@ It builds and wires:
 - `TTSVoicePreviewPlayer`
 - `PocketTTSEngine`
 - `PocketTTSModelManager`
+- `TTSPurchaseController`
 - `TTSPlaybackCoordinator`
 - `TTSManager`
 - `AudioModeCoordinator`
@@ -289,6 +290,9 @@ Keyboard onboarding detection is deliberately split across three signals:
 - `KeyVox.App.HasCompletedOnboardingWelcome`
 - `KeyVox.App.HasPendingKeyboardTour`
 - `KeyVox.App.ActiveDictationProvider`
+- `KeyVox.App.IsTTSUnlocked`
+- `KeyVox.App.TTSFreeSpeakUsageDayStart`
+- `KeyVox.App.TTSFreeSpeakUsageCount`
 
 ### App Group File Transport
 
@@ -559,9 +563,10 @@ Primary owners:
 - `PocketTTSModelManager` owns shared PocketTTS Core ML runtime install state plus per-voice install state.
 - `PocketTTSModelCatalog` owns shared-runtime artifact metadata plus approximate per-voice download size metadata used by settings.
 - `PocketTTSEngine` owns PocketTTS runtime access and streaming synthesis.
+- `TTSPurchaseController` owns the one-time copied-text playback unlock, cached entitlement state, the two-free-speaks-per-day local usage policy, and the placeholder unlock-sheet presentation state.
 - `TTSPlaybackCoordinator` owns audio-engine playback, deterministic runway gating, background-safe continuation, playback metering, replayable-audio capture, replay seeking, and pause/resume.
-- `TTSManager` owns request lifecycle, playback-preparation progress, home-card replay state, replay cache persistence, paused replay restoration, and App Group TTS state publishing.
-- `AudioModeCoordinator` is the only owner allowed to arbitrate dictation-versus-TTS transitions.
+- `TTSManager` owns request lifecycle, playback-preparation progress, home-card replay state, replay cache persistence, paused replay restoration, App Group TTS state publishing, and the free-speak consumption point once a new generation has actually started.
+- `AudioModeCoordinator` is the only owner allowed to arbitrate dictation-versus-TTS transitions and to enforce the copied-text playback gate before new TTS starts.
 
 ### PocketTTS Install Rules
 
@@ -593,11 +598,15 @@ Primary owners:
 - copied-text playback requests are serialized through `KeyVoxTTSRequest`
 - keyboard-initiated playback stages the request in shared storage and uses the containing app as the synthesis owner
 - share-extension initiated playback also stages the request in shared storage and uses the containing app as the synthesis owner
+- phase-one monetization allows two free new copied-text playback generations per local calendar day before the one-time unlock is required
+- replay remains free for already generated playback and must not consume daily free uses
+- only new copied-text playback generations are gated; replay, pause, resume, scrubbing, replay restore, and transcript viewing remain outside the monetization gate
 - playback-preparation progress is deterministic and gates the return-to-host path before audio starts
 - the success haptic for playback preparation completion must fire before the intentional pre-playback delay begins
 - the last completed rendered playback is cached independently of the clipboard and may be replayed later from the Home tab
 - paused replay state, including sample offset, is durable across app relaunches
 - replay transport uses a dedicated scrubber while cached replay is active
+- `TTSManager` consumes a free daily speak only after the new PocketTTS generation has successfully begun, not on button tap alone
 - `AudioModeCoordinator` must remain the transition owner for:
   - start dictation
   - start copied-text playback
@@ -614,6 +623,7 @@ Primary owners:
 
 - TTS starts coming from the keyboard or URL routes must move the containing app back to the Home tab before the copied-text playback UI becomes active
 - `AppTabRouter` is the shared tab-selection source of truth for that behavior
+- the same coordinator path must enforce the copied-text playback gate for Home, keyboard, URL, and share-driven TTS starts so shortcuts cannot bypass the daily limit
 
 ### Background Download Rules
 
@@ -882,11 +892,12 @@ Current app-owned surfaces:
 - `HomeTabView`: filesystem-grouped Home feature with `HomeTabView.swift` for the main Home composition and a dedicated `HomeTabView/TTS/` split for copied-text playback layout, transport presentation, transcript behavior, and replay scrubber UI
 - `CopyFeedbackController`: shared app-scoped interaction helper for pasteboard writes, success haptics, copied-state timing, and reset behavior used by multiple UI surfaces without forcing a shared button component
 - `PlaybackVoicePickerMenu`: reusable installed-voice menu surface shared between the release-facing Settings Voice Model section and the hidden Home copied-text playback shortcut
+- `TTSUnlockSheetView`: intentionally plain placeholder unlock sheet for the phase-one copied-text playback monetization proof path
 - `DictionaryTabView`: dictionary browsing/editing
 - `StyleTabView`: dictation style toggles
 - `SettingsTabView`: top-level settings composition, disclosure state, and destructive-confirmation coordination
 - `SettingsTabView+Models`: release-facing `Text Model` section for provider selection plus per-model install actions and uninstalled model size display
-- `SettingsTabView+TTS`: release-facing `Voice Model` section for PocketTTS runtime install state, per-voice install actions, previews, and voice selection
+- `SettingsTabView+TTS`: release-facing `Voice Model` section for PocketTTS runtime install state, per-voice install actions, previews, voice selection, and the placeholder `TTS Access` unlock row
 - `PlaybackPreparationView`: keyboard cold-launch playback-preparation surface shown before returning to the host app
 - `ReturnToHostView`: one-time host-return guidance after a cold keyboard launch
 - onboarding screens: welcome, setup, keyboard tour

--- a/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
+++ b/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
@@ -76,7 +76,7 @@
          <EnvironmentVariable
             key = "KEYVOX_BYPASS_TTS_FREE_SPEAK_LIMIT"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
+++ b/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
@@ -73,6 +73,11 @@
             value = "1"
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "KEYVOX_BYPASS_TTS_FREE_SPEAK_LIMIT"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction

--- a/iOS/KeyVox iOS/App/AppServiceRegistry.swift
+++ b/iOS/KeyVox iOS/App/AppServiceRegistry.swift
@@ -13,6 +13,7 @@ final class AppServiceRegistry {
     let weeklyWordStatsStore: WeeklyWordStatsStore
     let appTabRouter: AppTabRouter
     let appHaptics: AppHaptics
+    let ttsPurchaseController: TTSPurchaseController
     let ttsVoicePreviewPlayer: TTSVoicePreviewPlayer
     let whisperService: WhisperService
     let parakeetService: ParakeetService
@@ -62,6 +63,10 @@ final class AppServiceRegistry {
         let weeklyWordStatsStore = WeeklyWordStatsStore(defaults: settingsDefaults)
         let appTabRouter = AppTabRouter()
         let appHaptics = AppHaptics()
+        let ttsPurchaseController = TTSPurchaseController(
+            defaults: settingsDefaults,
+            bypassFreeSpeakLimit: runtimeFlags.bypassTTSFreeSpeakLimit
+        )
         let ttsVoicePreviewPlayer = TTSVoicePreviewPlayer(appHaptics: appHaptics)
         let whisperService = WhisperService(modelPathResolver: modelLocator.resolvedWhisperModelPath)
         let parakeetService = ParakeetService(modelURLResolver: modelLocator.resolvedParakeetModelDirectoryURL)
@@ -139,6 +144,7 @@ final class AppServiceRegistry {
             keyboardBridge: keyboardBridge,
             engine: ttsEngine,
             playbackCoordinator: ttsPlaybackCoordinator,
+            purchaseGate: ttsPurchaseController,
             effectiveVoiceProvider: { [weak settingsStore, weak pocketTTSModelManager] in
                 guard let settingsStore else { return .azelma }
                 guard let pocketTTSModelManager else { return settingsStore.ttsVoice }
@@ -151,7 +157,8 @@ final class AppServiceRegistry {
         let audioModeCoordinator = AudioModeCoordinator(
             transcriptionManager: transcriptionManager,
             ttsManager: ttsManager,
-            appTabRouter: appTabRouter
+            appTabRouter: appTabRouter,
+            ttsPurchaseGate: ttsPurchaseController
         )
         let iCloudSyncCoordinator = CloudSyncCoordinator(
             settingsStore: settingsStore,
@@ -209,6 +216,7 @@ final class AppServiceRegistry {
         self.weeklyWordStatsStore = weeklyWordStatsStore
         self.appTabRouter = appTabRouter
         self.appHaptics = appHaptics
+        self.ttsPurchaseController = ttsPurchaseController
         self.ttsVoicePreviewPlayer = ttsVoicePreviewPlayer
         self.whisperService = whisperService
         self.parakeetService = parakeetService

--- a/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
+++ b/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
@@ -10,6 +10,7 @@ struct KeyVoxApp: App {
     @StateObject private var audioModeCoordinator: AudioModeCoordinator
     @StateObject private var transcriptionManager: TranscriptionManager
     @StateObject private var ttsManager: TTSManager
+    @StateObject private var ttsPurchaseController: TTSPurchaseController
     @StateObject private var ttsVoicePreviewPlayer: TTSVoicePreviewPlayer
     @StateObject private var pocketTTSModelManager: PocketTTSModelManager
     @StateObject private var modelManager: ModelManager
@@ -27,6 +28,7 @@ struct KeyVoxApp: App {
         _audioModeCoordinator = StateObject(wrappedValue: services.audioModeCoordinator)
         _transcriptionManager = StateObject(wrappedValue: services.transcriptionManager)
         _ttsManager = StateObject(wrappedValue: services.ttsManager)
+        _ttsPurchaseController = StateObject(wrappedValue: services.ttsPurchaseController)
         _ttsVoicePreviewPlayer = StateObject(wrappedValue: services.ttsVoicePreviewPlayer)
         _pocketTTSModelManager = StateObject(wrappedValue: services.pocketTTSModelManager)
         _modelManager = StateObject(wrappedValue: services.modelManager)
@@ -65,6 +67,7 @@ struct KeyVoxApp: App {
                 .environmentObject(audioModeCoordinator)
                 .environmentObject(transcriptionManager)
                 .environmentObject(ttsManager)
+                .environmentObject(ttsPurchaseController)
                 .environmentObject(ttsVoicePreviewPlayer)
                 .environmentObject(pocketTTSModelManager)
                 .environmentObject(modelManager)

--- a/iOS/KeyVox iOS/App/Onboarding/RuntimeFlags.swift
+++ b/iOS/KeyVox iOS/App/Onboarding/RuntimeFlags.swift
@@ -2,15 +2,26 @@ import Foundation
 
 struct RuntimeFlags {
     static let forceOnboardingEnvironmentKey = "KEYVOX_FORCE_ONBOARDING"
+    static let bypassTTSFreeSpeakLimitEnvironmentKey = "KEYVOX_BYPASS_TTS_FREE_SPEAK_LIMIT"
 
     let forceOnboarding: Bool
+    let bypassTTSFreeSpeakLimit: Bool
 
     init(environment: [String: String] = ProcessInfo.processInfo.environment) {
-        let normalizedValue = environment[Self.forceOnboardingEnvironmentKey]?
+        forceOnboarding = Self.isEnabled(
+            environmentValue: environment[Self.forceOnboardingEnvironmentKey]
+        )
+        bypassTTSFreeSpeakLimit = Self.isEnabled(
+            environmentValue: environment[Self.bypassTTSFreeSpeakLimitEnvironmentKey]
+        )
+    }
+
+    private static func isEnabled(environmentValue: String?) -> Bool {
+        let normalizedValue = environmentValue?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
 
-        forceOnboarding = normalizedValue == "1"
+        return normalizedValue == "1"
             || normalizedValue == "true"
             || normalizedValue == "yes"
     }

--- a/iOS/KeyVox iOS/App/TTSPurchaseController.swift
+++ b/iOS/KeyVox iOS/App/TTSPurchaseController.swift
@@ -96,6 +96,7 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
     private let now: () -> Date
     private let calendar: Calendar
     private let bypassFreeSpeakLimit: Bool
+    private var storeRefreshGeneration: UInt64 = 0
 
     init(
         defaults: UserDefaults,
@@ -154,12 +155,21 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
 
     func refreshStoreState() async {
         refreshUsageIfNeeded()
+        guard isStoreActionInFlight == false else { return }
+        let refreshGeneration = beginStoreRefresh()
+
+        let unlocked = await currentEntitlementIsUnlocked(productID: Self.unlockProductID)
+        guard canApplyStoreRefresh(generation: refreshGeneration) else { return }
+        applyUnlockState(unlocked)
+
         do {
-            unlockProduct = try await store.loadUnlockProduct(productID: Self.unlockProductID)
-            let unlocked = try await store.isUnlocked(productID: Self.unlockProductID)
-            applyUnlockState(unlocked)
+            let product = try await store.loadUnlockProduct(productID: Self.unlockProductID)
+            guard canApplyStoreRefresh(generation: refreshGeneration) else { return }
+            unlockProduct = product
             storeMessage = nil
         } catch {
+            guard canApplyStoreRefresh(generation: refreshGeneration) else { return }
+            unlockProduct = nil
             storeMessage = error.localizedDescription
         }
     }
@@ -167,6 +177,7 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
     func purchaseTTSUnlock() async {
         guard isStoreActionInFlight == false else { return }
         refreshUsageIfNeeded()
+        invalidateStoreRefreshes()
         isStoreActionInFlight = true
         defer { isStoreActionInFlight = false }
 
@@ -185,6 +196,7 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
     func restorePurchases() async {
         guard isStoreActionInFlight == false else { return }
         refreshUsageIfNeeded()
+        invalidateStoreRefreshes()
         isStoreActionInFlight = true
         defer { isStoreActionInFlight = false }
 
@@ -249,5 +261,29 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
         isTTSUnlocked = unlocked
         defaults.set(unlocked, forKey: UserDefaultsKeys.App.isTTSUnlocked)
         refreshUsageState()
+    }
+
+    private func currentEntitlementIsUnlocked(productID: String) async -> Bool {
+        for await verificationResult in Transaction.currentEntitlements {
+            guard case .verified(let transaction) = verificationResult else { continue }
+            guard transaction.productID == productID else { continue }
+            guard transaction.revocationDate == nil else { continue }
+            return true
+        }
+
+        return false
+    }
+
+    private func beginStoreRefresh() -> UInt64 {
+        storeRefreshGeneration &+= 1
+        return storeRefreshGeneration
+    }
+
+    private func invalidateStoreRefreshes() {
+        storeRefreshGeneration &+= 1
+    }
+
+    private func canApplyStoreRefresh(generation: UInt64) -> Bool {
+        isStoreActionInFlight == false && storeRefreshGeneration == generation
     }
 }

--- a/iOS/KeyVox iOS/App/TTSPurchaseController.swift
+++ b/iOS/KeyVox iOS/App/TTSPurchaseController.swift
@@ -73,6 +73,7 @@ protocol TTSPurchaseGating {
     var isTTSUnlocked: Bool { get }
     var remainingFreeTTSSpeaksToday: Int { get }
     var canStartNewTTSSpeak: Bool { get }
+    func refreshUsageIfNeeded()
     func presentUnlockSheet()
     func dismissUnlockSheet()
     func consumeFreeTTSSpeakIfNeeded()
@@ -132,13 +133,19 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
     }
 
     var canStartNewTTSSpeak: Bool {
+        refreshUsageIfNeeded()
         if bypassFreeSpeakLimit {
             return true
         }
         return isTTSUnlocked || remainingFreeTTSSpeaksToday > 0
     }
 
+    func refreshUsageIfNeeded() {
+        refreshUsageState()
+    }
+
     func presentUnlockSheet() {
+        refreshUsageIfNeeded()
         isUnlockSheetPresented = true
     }
 
@@ -147,6 +154,7 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
     }
 
     func refreshStoreState() async {
+        refreshUsageIfNeeded()
         do {
             unlockProduct = try await store.loadUnlockProduct(productID: Self.unlockProductID)
             let unlocked = try await store.isUnlocked(productID: Self.unlockProductID)
@@ -159,6 +167,7 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
 
     func purchaseTTSUnlock() async {
         guard isStoreActionInFlight == false else { return }
+        refreshUsageIfNeeded()
         isStoreActionInFlight = true
         defer { isStoreActionInFlight = false }
 
@@ -176,6 +185,7 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
 
     func restorePurchases() async {
         guard isStoreActionInFlight == false else { return }
+        refreshUsageIfNeeded()
         isStoreActionInFlight = true
         defer { isStoreActionInFlight = false }
 

--- a/iOS/KeyVox iOS/App/TTSPurchaseController.swift
+++ b/iOS/KeyVox iOS/App/TTSPurchaseController.swift
@@ -80,8 +80,8 @@ protocol TTSPurchaseGating {
 
 @MainActor
 final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
-    static let unlockProductID = "com.cueit.keyvox.tts.unlock"
-    static let dailyFreeSpeakLimit = 2
+    nonisolated static let unlockProductID = "com.cueit.keyvox.tts.unlock"
+    nonisolated static let dailyFreeSpeakLimit = 2
 
     @Published private(set) var isTTSUnlocked: Bool
     @Published private(set) var remainingFreeTTSSpeaksToday: Int = TTSPurchaseController.dailyFreeSpeakLimit

--- a/iOS/KeyVox iOS/App/TTSPurchaseController.swift
+++ b/iOS/KeyVox iOS/App/TTSPurchaseController.swift
@@ -133,11 +133,10 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
     }
 
     var canStartNewTTSSpeak: Bool {
-        refreshUsageIfNeeded()
         if bypassFreeSpeakLimit {
             return true
         }
-        return isTTSUnlocked || remainingFreeTTSSpeaksToday > 0
+        return isTTSUnlocked || currentRemainingFreeSpeakCount > 0
     }
 
     func refreshUsageIfNeeded() {
@@ -224,18 +223,26 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
         defaults.integer(forKey: UserDefaultsKeys.App.ttsFreeSpeakUsageCount)
     }
 
+    private var currentRemainingFreeSpeakCount: Int {
+        if bypassFreeSpeakLimit {
+            return Self.dailyFreeSpeakLimit
+        }
+
+        if isTTSUnlocked {
+            return Self.dailyFreeSpeakLimit
+        }
+
+        let usedCount = storedUsageDayStart == currentUsageDayStart ? usedFreeSpeaksToday : 0
+        return max(0, Self.dailyFreeSpeakLimit - usedCount)
+    }
+
     private func refreshUsageState() {
         if storedUsageDayStart != currentUsageDayStart {
             defaults.set(currentUsageDayStart, forKey: UserDefaultsKeys.App.ttsFreeSpeakUsageDayStart)
             defaults.set(0, forKey: UserDefaultsKeys.App.ttsFreeSpeakUsageCount)
         }
 
-        let usedCount = defaults.integer(forKey: UserDefaultsKeys.App.ttsFreeSpeakUsageCount)
-        if bypassFreeSpeakLimit {
-            remainingFreeTTSSpeaksToday = Self.dailyFreeSpeakLimit
-        } else {
-            remainingFreeTTSSpeaksToday = isTTSUnlocked ? Self.dailyFreeSpeakLimit : max(0, Self.dailyFreeSpeakLimit - usedCount)
-        }
+        remainingFreeTTSSpeaksToday = currentRemainingFreeSpeakCount
     }
 
     private func applyUnlockState(_ unlocked: Bool) {

--- a/iOS/KeyVox iOS/App/TTSPurchaseController.swift
+++ b/iOS/KeyVox iOS/App/TTSPurchaseController.swift
@@ -158,7 +158,7 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
         guard isStoreActionInFlight == false else { return }
         let refreshGeneration = beginStoreRefresh()
 
-        let unlocked = await currentEntitlementIsUnlocked(productID: Self.unlockProductID)
+        let unlocked = await refreshedUnlockState(productID: Self.unlockProductID)
         guard canApplyStoreRefresh(generation: refreshGeneration) else { return }
         applyUnlockState(unlocked)
 
@@ -272,6 +272,18 @@ final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
         }
 
         return false
+    }
+
+    private func refreshedUnlockState(productID: String) async -> Bool {
+        if store is AppStoreTTSUnlockStore {
+            return await currentEntitlementIsUnlocked(productID: productID)
+        }
+
+        do {
+            return try await store.isUnlocked(productID: productID)
+        } catch {
+            return isTTSUnlocked
+        }
     }
 
     private func beginStoreRefresh() -> UInt64 {

--- a/iOS/KeyVox iOS/App/TTSPurchaseController.swift
+++ b/iOS/KeyVox iOS/App/TTSPurchaseController.swift
@@ -1,0 +1,236 @@
+import Combine
+import Foundation
+import StoreKit
+
+struct TTSUnlockStoreProduct: Equatable {
+    let id: String
+    let displayName: String
+    let displayPrice: String
+}
+
+protocol TTSUnlockStore {
+    func loadUnlockProduct(productID: String) async throws -> TTSUnlockStoreProduct?
+    func isUnlocked(productID: String) async throws -> Bool
+    func purchase(productID: String) async throws -> Bool
+    func restore(productID: String) async throws -> Bool
+}
+
+struct AppStoreTTSUnlockStore: TTSUnlockStore {
+    func loadUnlockProduct(productID: String) async throws -> TTSUnlockStoreProduct? {
+        let products = try await Product.products(for: [productID])
+        guard let product = products.first(where: { $0.id == productID }) else {
+            return nil
+        }
+
+        return TTSUnlockStoreProduct(
+            id: product.id,
+            displayName: product.displayName,
+            displayPrice: product.displayPrice
+        )
+    }
+
+    func isUnlocked(productID: String) async throws -> Bool {
+        for await verificationResult in Transaction.currentEntitlements {
+            guard case .verified(let transaction) = verificationResult else { continue }
+            guard transaction.productID == productID else { continue }
+            guard transaction.revocationDate == nil else { continue }
+            return true
+        }
+
+        return false
+    }
+
+    func purchase(productID: String) async throws -> Bool {
+        let products = try await Product.products(for: [productID])
+        guard let product = products.first(where: { $0.id == productID }) else {
+            return false
+        }
+
+        let result = try await product.purchase()
+
+        switch result {
+        case .success(let verificationResult):
+            guard case .verified(let transaction) = verificationResult else {
+                return false
+            }
+            await transaction.finish()
+            return true
+        case .userCancelled, .pending:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    func restore(productID: String) async throws -> Bool {
+        try await AppStore.sync()
+        return try await isUnlocked(productID: productID)
+    }
+}
+
+@MainActor
+protocol TTSPurchaseGating {
+    var isTTSUnlocked: Bool { get }
+    var remainingFreeTTSSpeaksToday: Int { get }
+    var canStartNewTTSSpeak: Bool { get }
+    func presentUnlockSheet()
+    func dismissUnlockSheet()
+    func consumeFreeTTSSpeakIfNeeded()
+}
+
+@MainActor
+final class TTSPurchaseController: ObservableObject, TTSPurchaseGating {
+    static let unlockProductID = "com.cueit.keyvox.tts.unlock"
+    static let dailyFreeSpeakLimit = 2
+
+    @Published private(set) var isTTSUnlocked: Bool
+    @Published private(set) var remainingFreeTTSSpeaksToday: Int = TTSPurchaseController.dailyFreeSpeakLimit
+    @Published private(set) var unlockProduct: TTSUnlockStoreProduct?
+    @Published private(set) var isStoreActionInFlight = false
+    @Published var isUnlockSheetPresented = false
+    @Published var storeMessage: String?
+
+    private let defaults: UserDefaults
+    private let store: any TTSUnlockStore
+    private let now: () -> Date
+    private let calendar: Calendar
+    private let bypassFreeSpeakLimit: Bool
+
+    init(
+        defaults: UserDefaults,
+        store: any TTSUnlockStore,
+        now: @escaping () -> Date = Date.init,
+        calendar: Calendar = .current,
+        bypassFreeSpeakLimit: Bool = false
+    ) {
+        self.defaults = defaults
+        self.store = store
+        self.now = now
+        self.calendar = calendar
+        self.bypassFreeSpeakLimit = bypassFreeSpeakLimit
+        self.isTTSUnlocked = defaults.bool(forKey: UserDefaultsKeys.App.isTTSUnlocked)
+        refreshUsageState()
+
+        Task { @MainActor [weak self] in
+            await self?.refreshStoreState()
+        }
+    }
+
+    convenience init(
+        defaults: UserDefaults,
+        now: @escaping () -> Date = Date.init,
+        calendar: Calendar = .current,
+        bypassFreeSpeakLimit: Bool = false
+    ) {
+        self.init(
+            defaults: defaults,
+            store: AppStoreTTSUnlockStore(),
+            now: now,
+            calendar: calendar,
+            bypassFreeSpeakLimit: bypassFreeSpeakLimit
+        )
+    }
+
+    var canStartNewTTSSpeak: Bool {
+        if bypassFreeSpeakLimit {
+            return true
+        }
+        return isTTSUnlocked || remainingFreeTTSSpeaksToday > 0
+    }
+
+    func presentUnlockSheet() {
+        isUnlockSheetPresented = true
+    }
+
+    func dismissUnlockSheet() {
+        isUnlockSheetPresented = false
+    }
+
+    func refreshStoreState() async {
+        do {
+            unlockProduct = try await store.loadUnlockProduct(productID: Self.unlockProductID)
+            let unlocked = try await store.isUnlocked(productID: Self.unlockProductID)
+            applyUnlockState(unlocked)
+            storeMessage = nil
+        } catch {
+            storeMessage = error.localizedDescription
+        }
+    }
+
+    func purchaseTTSUnlock() async {
+        guard isStoreActionInFlight == false else { return }
+        isStoreActionInFlight = true
+        defer { isStoreActionInFlight = false }
+
+        do {
+            let unlocked = try await store.purchase(productID: Self.unlockProductID)
+            if unlocked {
+                applyUnlockState(true)
+                isUnlockSheetPresented = false
+                storeMessage = nil
+            }
+        } catch {
+            storeMessage = error.localizedDescription
+        }
+    }
+
+    func restorePurchases() async {
+        guard isStoreActionInFlight == false else { return }
+        isStoreActionInFlight = true
+        defer { isStoreActionInFlight = false }
+
+        do {
+            let unlocked = try await store.restore(productID: Self.unlockProductID)
+            applyUnlockState(unlocked)
+            if unlocked {
+                isUnlockSheetPresented = false
+                storeMessage = nil
+            }
+        } catch {
+            storeMessage = error.localizedDescription
+        }
+    }
+
+    func consumeFreeTTSSpeakIfNeeded() {
+        guard bypassFreeSpeakLimit == false else { return }
+        refreshUsageState()
+        guard isTTSUnlocked == false else { return }
+        guard remainingFreeTTSSpeaksToday > 0 else { return }
+
+        let newCount = usedFreeSpeaksToday + 1
+        defaults.set(newCount, forKey: UserDefaultsKeys.App.ttsFreeSpeakUsageCount)
+        refreshUsageState()
+    }
+
+    private var currentUsageDayStart: TimeInterval {
+        calendar.startOfDay(for: now()).timeIntervalSince1970
+    }
+
+    private var storedUsageDayStart: TimeInterval {
+        defaults.double(forKey: UserDefaultsKeys.App.ttsFreeSpeakUsageDayStart)
+    }
+
+    private var usedFreeSpeaksToday: Int {
+        defaults.integer(forKey: UserDefaultsKeys.App.ttsFreeSpeakUsageCount)
+    }
+
+    private func refreshUsageState() {
+        if storedUsageDayStart != currentUsageDayStart {
+            defaults.set(currentUsageDayStart, forKey: UserDefaultsKeys.App.ttsFreeSpeakUsageDayStart)
+            defaults.set(0, forKey: UserDefaultsKeys.App.ttsFreeSpeakUsageCount)
+        }
+
+        let usedCount = defaults.integer(forKey: UserDefaultsKeys.App.ttsFreeSpeakUsageCount)
+        if bypassFreeSpeakLimit {
+            remainingFreeTTSSpeaksToday = Self.dailyFreeSpeakLimit
+        } else {
+            remainingFreeTTSSpeaksToday = isTTSUnlocked ? Self.dailyFreeSpeakLimit : max(0, Self.dailyFreeSpeakLimit - usedCount)
+        }
+    }
+
+    private func applyUnlockState(_ unlocked: Bool) {
+        isTTSUnlocked = unlocked
+        defaults.set(unlocked, forKey: UserDefaultsKeys.App.isTTSUnlocked)
+        refreshUsageState()
+    }
+}

--- a/iOS/KeyVox iOS/App/iCloud/UserDefaultsKeys.swift
+++ b/iOS/KeyVox iOS/App/iCloud/UserDefaultsKeys.swift
@@ -15,6 +15,9 @@ nonisolated enum UserDefaultsKeys {
     enum App {
         static let activeDictationProvider = "KeyVox.App.ActiveDictationProvider"
         static let isTTSTranscriptExpanded = "KeyVox.App.IsTTSTranscriptExpanded"
+        static let isTTSUnlocked = "KeyVox.App.IsTTSUnlocked"
+        static let ttsFreeSpeakUsageDayStart = "KeyVox.App.TTSFreeSpeakUsageDayStart"
+        static let ttsFreeSpeakUsageCount = "KeyVox.App.TTSFreeSpeakUsageCount"
         static let weeklyWordStatsPayload = "KeyVox.App.WeeklyWordStatsPayload"
         static let weeklyWordStatsInstallationID = "KeyVox.App.WeeklyWordStatsInstallationID"
         static let hasCompletedOnboarding = "KeyVox.App.HasCompletedOnboarding"

--- a/iOS/KeyVox iOS/Core/TTS/AudioModeCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/TTS/AudioModeCoordinator.swift
@@ -6,17 +6,20 @@ final class AudioModeCoordinator: ObservableObject {
     private let transcriptionManager: TranscriptionManager
     private let ttsManager: TTSManager
     private let appTabRouter: AppTabRouter
+    private let ttsPurchaseGate: any TTSPurchaseGating
     private var isTransitioning = false
     private var shouldRepairMonitoringAfterTTS = false
 
     init(
         transcriptionManager: TranscriptionManager,
         ttsManager: TTSManager,
-        appTabRouter: AppTabRouter
+        appTabRouter: AppTabRouter,
+        ttsPurchaseGate: any TTSPurchaseGating
     ) {
         self.transcriptionManager = transcriptionManager
         self.ttsManager = ttsManager
         self.appTabRouter = appTabRouter
+        self.ttsPurchaseGate = ttsPurchaseGate
         self.ttsManager.onWillTeardownPlayback = { [weak self] in
             await self?.repairMonitoringAfterTTSIfNeeded()
         }
@@ -56,6 +59,11 @@ final class AudioModeCoordinator: ObservableObject {
                 String(describing: transcriptionManager.state),
                 String(transcriptionManager.isSessionActive)
             )
+            guard ttsPurchaseGate.canStartNewTTSSpeak else {
+                ttsManager.isPlaybackPreparationViewPresented = false
+                ttsPurchaseGate.presentUnlockSheet()
+                return
+            }
             appTabRouter.selectedTab = .home
             shouldRepairMonitoringAfterTTS = transcriptionManager.isSessionActive
             ttsManager.setPlaybackAudioSessionMode(
@@ -88,6 +96,11 @@ final class AudioModeCoordinator: ObservableObject {
 
             if ttsManager.isActive {
                 await ttsManager.stopPlayback()
+                return
+            }
+
+            guard ttsPurchaseGate.canStartNewTTSSpeak else {
+                ttsPurchaseGate.presentUnlockSheet()
                 return
             }
 

--- a/iOS/KeyVox iOS/Core/TTS/AudioModeCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/TTS/AudioModeCoordinator.swift
@@ -92,7 +92,6 @@ final class AudioModeCoordinator: ObservableObject {
                 String(transcriptionManager.isSessionActive),
                 String(ttsManager.isActive)
             )
-            appTabRouter.selectedTab = .home
 
             if ttsManager.isActive {
                 await ttsManager.stopPlayback()
@@ -104,6 +103,7 @@ final class AudioModeCoordinator: ObservableObject {
                 return
             }
 
+            appTabRouter.selectedTab = .home
             shouldRepairMonitoringAfterTTS = transcriptionManager.isSessionActive
             ttsManager.setPlaybackAudioSessionMode(
                 transcriptionManager.isSessionActive

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
@@ -89,6 +89,7 @@ extension TTSManager {
                 voiceID: request.voiceID,
                 fastModeEnabled: settingsStore.fastPlaybackModeEnabled
             )
+            purchaseGate.consumeFreeTTSSpeakIfNeeded()
             playbackCoordinator.play(stream, fastModeEnabled: settingsStore.fastPlaybackModeEnabled)
         } catch {
             handleError(error.localizedDescription)

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
@@ -64,6 +64,7 @@ extension TTSManager {
         activeRequest = request
         hasStartedPlaybackForActiveRequest = false
         didEmitPreparationCompletionForActiveRequest = false
+        shouldConsumeFreeSpeakOnPlaybackStart = true
         isPlaybackPaused = false
         lastErrorMessage = nil
         resetPlaybackPreparationState()
@@ -89,9 +90,9 @@ extension TTSManager {
                 voiceID: request.voiceID,
                 fastModeEnabled: settingsStore.fastPlaybackModeEnabled
             )
-            purchaseGate.consumeFreeTTSSpeakIfNeeded()
             playbackCoordinator.play(stream, fastModeEnabled: settingsStore.fastPlaybackModeEnabled)
         } catch {
+            shouldConsumeFreeSpeakOnPlaybackStart = false
             handleError(error.localizedDescription)
         }
     }
@@ -112,6 +113,7 @@ extension TTSManager {
             activeRequest = lastReplayableRequest
             hasStartedPlaybackForActiveRequest = true
             didEmitPreparationCompletionForActiveRequest = true
+            shouldConsumeFreeSpeakOnPlaybackStart = false
             isPlaybackPaused = false
             lastErrorMessage = nil
             resetPlaybackPreparationState()
@@ -132,6 +134,7 @@ extension TTSManager {
         }
         hasStartedPlaybackForActiveRequest = false
         didEmitPreparationCompletionForActiveRequest = true
+        shouldConsumeFreeSpeakOnPlaybackStart = false
         isPlaybackPaused = false
         pausedReplaySampleOffset = nil
         lastErrorMessage = nil
@@ -153,6 +156,7 @@ extension TTSManager {
         }
         hasStartedPlaybackForActiveRequest = true
         didEmitPreparationCompletionForActiveRequest = true
+        shouldConsumeFreeSpeakOnPlaybackStart = false
         lastErrorMessage = nil
         resetPlaybackPreparationState()
         isPlaybackPreparationViewPresented = false

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
@@ -70,6 +70,7 @@ extension TTSManager {
         activeRequest = nil
         hasStartedPlaybackForActiveRequest = false
         didEmitPreparationCompletionForActiveRequest = false
+        shouldConsumeFreeSpeakOnPlaybackStart = false
         isPlaybackPaused = false
         isReplayingCachedPlayback = false
         pausedReplaySampleOffset = nil
@@ -93,6 +94,10 @@ extension TTSManager {
     func handlePlaybackStarted() {
         if let activeRequest {
             Self.log("Playback started for id=\(activeRequest.id.uuidString) voice=\(activeRequest.voiceID)")
+        }
+        if shouldConsumeFreeSpeakOnPlaybackStart {
+            purchaseGate.consumeFreeTTSSpeakIfNeeded()
+            shouldConsumeFreeSpeakOnPlaybackStart = false
         }
         hasStartedPlaybackForActiveRequest = true
         isPlaybackPaused = false

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
@@ -27,6 +27,7 @@ final class TTSManager: ObservableObject {
     let keyboardBridge: KeyVoxKeyboardBridge
     let engine: any TTSEngine
     let playbackCoordinator: TTSPlaybackCoordinator
+    let purchaseGate: any TTSPurchaseGating
     let replayCache: TTSReplayCache
     let effectiveVoiceProvider: @MainActor () -> AppSettingsStore.TTSVoice
     var activeRequest: KeyVoxTTSRequest?
@@ -77,6 +78,7 @@ final class TTSManager: ObservableObject {
         keyboardBridge: KeyVoxKeyboardBridge,
         engine: any TTSEngine,
         playbackCoordinator: TTSPlaybackCoordinator,
+        purchaseGate: any TTSPurchaseGating,
         replayCache: TTSReplayCache? = nil,
         effectiveVoiceProvider: (@MainActor () -> AppSettingsStore.TTSVoice)? = nil
     ) {
@@ -85,6 +87,7 @@ final class TTSManager: ObservableObject {
         self.keyboardBridge = keyboardBridge
         self.engine = engine
         self.playbackCoordinator = playbackCoordinator
+        self.purchaseGate = purchaseGate
         self.replayCache = replayCache ?? TTSReplayCache()
         self.effectiveVoiceProvider = effectiveVoiceProvider ?? { settingsStore.ttsVoice }
 

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
@@ -35,6 +35,7 @@ final class TTSManager: ObservableObject {
     var pausedReplaySampleOffset: Int?
     var hasStartedPlaybackForActiveRequest = false
     var didEmitPreparationCompletionForActiveRequest = false
+    var shouldConsumeFreeSpeakOnPlaybackStart = false
     var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
     var backgroundTaskReleaseTask: Task<Void, Never>?
     var onWillTeardownPlayback: (() async -> Void)?

--- a/iOS/KeyVox iOS/Views/AppRootView.swift
+++ b/iOS/KeyVox iOS/Views/AppRootView.swift
@@ -121,6 +121,7 @@ struct AppRootView: View {
         .environmentObject(AppServiceRegistry.shared.appTabRouter)
         .environmentObject(AppServiceRegistry.shared.transcriptionManager)
         .environmentObject(AppServiceRegistry.shared.ttsManager)
+        .environmentObject(AppServiceRegistry.shared.ttsPurchaseController)
         .environmentObject(AppServiceRegistry.shared.modelManager)
         .environmentObject(AppServiceRegistry.shared.settingsStore)
         .environmentObject(AppServiceRegistry.shared.onboardingStore)

--- a/iOS/KeyVox iOS/Views/Components/TTSUnlockSheetView.swift
+++ b/iOS/KeyVox iOS/Views/Components/TTSUnlockSheetView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+struct TTSUnlockSheetView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.appHaptics) private var appHaptics
+    @EnvironmentObject private var ttsPurchaseController: TTSPurchaseController
+
+    var body: some View {
+        NavigationStack {
+            AppScrollScreen {
+                AppCard {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("Unlock TTS")
+                            .font(.appFont(20))
+                            .foregroundStyle(.white)
+
+                        Text("Keep copied text playback available without the daily free limit.")
+                            .font(.appFont(15, variant: .light))
+                            .foregroundStyle(.white.opacity(0.78))
+
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text("Two free speaks per day")
+                            Text("Replay stays free for anything already generated")
+                            Text(ttsPurchaseSummaryText)
+                        }
+                        .font(.appFont(14, variant: .light))
+                        .foregroundStyle(.white.opacity(0.7))
+
+                        HStack(spacing: 10) {
+                            AppActionButton(
+                                title: purchaseButtonTitle,
+                                style: .primary,
+                                fillsWidth: true,
+                                size: .compact,
+                                fontSize: 15,
+                                isEnabled: ttsPurchaseController.isStoreActionInFlight == false,
+                                action: purchaseUnlock
+                            )
+
+                            AppActionButton(
+                                title: "Restore",
+                                style: .secondary,
+                                fillsWidth: true,
+                                size: .compact,
+                                fontSize: 15,
+                                isEnabled: ttsPurchaseController.isStoreActionInFlight == false,
+                                action: restorePurchases
+                            )
+                        }
+
+                        if let storeMessage = ttsPurchaseController.storeMessage {
+                            Text(storeMessage)
+                                .font(.appFont(12))
+                                .foregroundStyle(.red)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        dismissSheet()
+                    }
+                    .foregroundStyle(.yellow)
+                }
+            }
+        }
+    }
+
+    private var purchaseButtonTitle: String {
+        if ttsPurchaseController.isTTSUnlocked {
+            return "Unlocked"
+        }
+
+        if let unlockProduct = ttsPurchaseController.unlockProduct {
+            return "Unlock \(unlockProduct.displayPrice)"
+        }
+
+        return "Unlock"
+    }
+
+    private var ttsPurchaseSummaryText: String {
+        if ttsPurchaseController.isTTSUnlocked {
+            return "TTS is unlocked on this Apple account."
+        }
+
+        return "\(ttsPurchaseController.remainingFreeTTSSpeaksToday) free speaks left today"
+    }
+
+    private func purchaseUnlock() {
+        guard ttsPurchaseController.isTTSUnlocked == false else {
+            dismissSheet()
+            return
+        }
+
+        appHaptics.light()
+        Task {
+            await ttsPurchaseController.purchaseTTSUnlock()
+        }
+    }
+
+    private func restorePurchases() {
+        appHaptics.light()
+        Task {
+            await ttsPurchaseController.restorePurchases()
+        }
+    }
+
+    private func dismissSheet() {
+        ttsPurchaseController.dismissUnlockSheet()
+        dismiss()
+    }
+}

--- a/iOS/KeyVox iOS/Views/Components/TTSUnlockSheetView.swift
+++ b/iOS/KeyVox iOS/Views/Components/TTSUnlockSheetView.swift
@@ -81,6 +81,7 @@ struct TTSUnlockSheetView: View {
     }
 
     private var ttsPurchaseSummaryText: String {
+        ttsPurchaseController.refreshUsageIfNeeded()
         if ttsPurchaseController.isTTSUnlocked {
             return "TTS is unlocked on this Apple account."
         }

--- a/iOS/KeyVox iOS/Views/Components/TTSUnlockSheetView.swift
+++ b/iOS/KeyVox iOS/Views/Components/TTSUnlockSheetView.swift
@@ -85,7 +85,9 @@ struct TTSUnlockSheetView: View {
             return "TTS is unlocked on this Apple account."
         }
 
-        return "\(ttsPurchaseController.remainingFreeTTSSpeaksToday) free speaks left today"
+        let remainingFreeSpeaks = ttsPurchaseController.remainingFreeTTSSpeaksToday
+        let noun = remainingFreeSpeaks == 1 ? "speak" : "speaks"
+        return "\(remainingFreeSpeaks) free \(noun) left today"
     }
 
     private func purchaseUnlock() {

--- a/iOS/KeyVox iOS/Views/Components/TTSUnlockSheetView.swift
+++ b/iOS/KeyVox iOS/Views/Components/TTSUnlockSheetView.swift
@@ -81,7 +81,6 @@ struct TTSUnlockSheetView: View {
     }
 
     private var ttsPurchaseSummaryText: String {
-        ttsPurchaseController.refreshUsageIfNeeded()
         if ttsPurchaseController.isTTSUnlocked {
             return "TTS is unlocked on this Apple account."
         }

--- a/iOS/KeyVox iOS/Views/HomeTabView/HomeTabView.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/HomeTabView.swift
@@ -6,6 +6,7 @@ struct HomeTabView: View {
     @EnvironmentObject private var transcriptionManager: TranscriptionManager
     @EnvironmentObject var ttsManager: TTSManager
     @EnvironmentObject var pocketTTSModelManager: PocketTTSModelManager
+    @EnvironmentObject var ttsPurchaseController: TTSPurchaseController
     @EnvironmentObject var settingsStore: AppSettingsStore
     @EnvironmentObject private var weeklyWordStatsStore: WeeklyWordStatsStore
     @State var showsTTSPreparationSlot = false
@@ -115,6 +116,7 @@ struct HomeTabView: View {
         .environmentObject(AppServiceRegistry.shared.transcriptionManager)
         .environmentObject(AppServiceRegistry.shared.ttsManager)
         .environmentObject(AppServiceRegistry.shared.pocketTTSModelManager)
+        .environmentObject(AppServiceRegistry.shared.ttsPurchaseController)
         .environmentObject(AppServiceRegistry.shared.settingsStore)
         .environmentObject(AppServiceRegistry.shared.weeklyWordStatsStore)
 }

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
@@ -71,6 +71,9 @@ extension HomeTabView {
         case .failed:
             return "Repair"
         case .ready:
+            if ttsManager.isActive == false && ttsPurchaseController.canStartNewTTSSpeak == false {
+                return "Unlock"
+            }
             return ttsManager.isActive ? "Stop" : "Speak"
         }
     }

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTransport.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTransport.swift
@@ -131,11 +131,15 @@ extension HomeTabView {
 
         switch ttsManager.state {
         case .idle:
-            if ttsPurchaseController.isTTSUnlocked == false {
+            ttsPurchaseController.refreshUsageIfNeeded()
+
+            if ttsPurchaseController.canStartNewTTSSpeak == false {
                 if ttsPurchaseController.remainingFreeTTSSpeaksToday == 0 {
                     return "Unlock TTS to keep speaking copied text."
                 }
+            }
 
+            if ttsPurchaseController.isTTSUnlocked == false {
                 let remainingFreeSpeaks = ttsPurchaseController.remainingFreeTTSSpeaksToday
                 let noun = remainingFreeSpeaks == 1 ? "speak" : "speaks"
                 return "\(remainingFreeSpeaks) free \(noun) left today."

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTransport.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTransport.swift
@@ -131,6 +131,15 @@ extension HomeTabView {
 
         switch ttsManager.state {
         case .idle:
+            if ttsPurchaseController.isTTSUnlocked == false {
+                if ttsPurchaseController.remainingFreeTTSSpeaksToday == 0 {
+                    return "Unlock TTS to keep speaking copied text."
+                }
+
+                let remainingFreeSpeaks = ttsPurchaseController.remainingFreeTTSSpeaksToday
+                let noun = remainingFreeSpeaks == 1 ? "speak" : "speaks"
+                return "\(remainingFreeSpeaks) free \(noun) left today."
+            }
             return "Read copied text aloud using your selected voice."
         case .preparing:
             return "Getting ready..."

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTransport.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTransport.swift
@@ -131,8 +131,6 @@ extension HomeTabView {
 
         switch ttsManager.state {
         case .idle:
-            ttsPurchaseController.refreshUsageIfNeeded()
-
             if ttsPurchaseController.canStartNewTTSSpeak == false {
                 if ttsPurchaseController.remainingFreeTTSSpeaksToday == 0 {
                     return "Unlock TTS to keep speaking copied text."

--- a/iOS/KeyVox iOS/Views/MainTabView.swift
+++ b/iOS/KeyVox iOS/Views/MainTabView.swift
@@ -15,6 +15,7 @@ struct MainTabView: View {
     @Environment(\.appHaptics) private var appHaptics
     @EnvironmentObject var modelManager: ModelManager
     @EnvironmentObject var pocketTTSModelManager: PocketTTSModelManager
+    @EnvironmentObject private var ttsPurchaseController: TTSPurchaseController
     @EnvironmentObject private var appTabRouter: AppTabRouter
     @State private var pendingDeletionConfirmation: SettingsPendingDeletionConfirmation?
 
@@ -37,6 +38,19 @@ struct MainTabView: View {
             }
         }
         .settingsDeletionConfirmation($pendingDeletionConfirmation, onConfirm: performDeletionConfirmation)
+        .sheet(
+            isPresented: Binding(
+                get: { ttsPurchaseController.isUnlockSheetPresented },
+                set: { isPresented in
+                    if isPresented == false {
+                        ttsPurchaseController.dismissUnlockSheet()
+                    }
+                }
+            )
+        ) {
+            TTSUnlockSheetView()
+                .environmentObject(ttsPurchaseController)
+        }
         .onChange(of: selectedTab, initial: false) { oldTab, newTab in
             if let event = MainTabHapticsDecision.eventForSelectionChange(previous: oldTab, current: newTab) {
                 appHaptics.emit(event)
@@ -143,4 +157,5 @@ struct MainTabView: View {
         .environmentObject(AppServiceRegistry.shared.dictionaryStore)
         .environmentObject(AppServiceRegistry.shared.audioModeCoordinator)
         .environmentObject(AppServiceRegistry.shared.ttsManager)
+        .environmentObject(AppServiceRegistry.shared.ttsPurchaseController)
 }

--- a/iOS/KeyVox iOS/Views/SettingsTabView+TTS.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView+TTS.swift
@@ -458,7 +458,6 @@ extension SettingsTabView {
     }
 
     var ttsUnlockStatusText: String {
-        ttsPurchaseController.refreshUsageIfNeeded()
         if ttsPurchaseController.isTTSUnlocked {
             return "Unlimited copied-text playback is enabled on this Apple account."
         }

--- a/iOS/KeyVox iOS/Views/SettingsTabView+TTS.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView+TTS.swift
@@ -50,6 +50,11 @@ extension SettingsTabView {
                 Divider()
                     .background(.white.opacity(0.22))
 
+                ttsUnlockRow
+
+                Divider()
+                    .background(.white.opacity(0.22))
+
                 HStack(alignment: .center, spacing: 12) {
                     Text(playbackVoiceDescriptionText)
                         .font(.appFont(15, variant: .light))
@@ -122,6 +127,55 @@ extension SettingsTabView {
         .animation(.easeOut(duration: 0.18), value: isTTSExpandedContentVisible)
         .animation(.spring(response: 0.42, dampingFraction: 0.84), value: shouldShowExpandedTTSContent)
         .animation(.spring(response: 0.42, dampingFraction: 0.84), value: ttsExpandedContentHeight)
+    }
+
+    @ViewBuilder
+    private var ttsUnlockRow: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 12) {
+                Text("TTS Access")
+                    .font(.appFont(17))
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if ttsPurchaseController.isTTSUnlocked {
+                    Text("Unlocked")
+                        .font(.appFont(15))
+                        .foregroundStyle(.yellow)
+                } else {
+                    AppActionButton(
+                        title: "Unlock",
+                        style: .primary,
+                        size: .compact,
+                        fontSize: 15,
+                        action: {
+                            appHaptics.light()
+                            ttsPurchaseController.presentUnlockSheet()
+                        }
+                    )
+                }
+            }
+
+            Text(ttsUnlockStatusText)
+                .font(.appFont(14, variant: .light))
+                .foregroundStyle(.white.opacity(0.7))
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            if ttsPurchaseController.isTTSUnlocked == false {
+                AppActionButton(
+                    title: "Restore Purchases",
+                    style: .secondary,
+                    size: .compact,
+                    fontSize: 14,
+                    action: {
+                        appHaptics.light()
+                        Task {
+                            await ttsPurchaseController.restorePurchases()
+                        }
+                    }
+                )
+            }
+        }
     }
 
     @ViewBuilder
@@ -400,6 +454,16 @@ extension SettingsTabView {
             return "Download a playback voice to let KeyVox read copied text aloud."
         }
         return "Choose which installed PocketTTS voice KeyVox uses when speaking copied text."
+    }
+
+    var ttsUnlockStatusText: String {
+        if ttsPurchaseController.isTTSUnlocked {
+            return "Unlimited copied-text playback is enabled on this Apple account."
+        }
+
+        let remainingFreeSpeaks = ttsPurchaseController.remainingFreeTTSSpeaksToday
+        let noun = remainingFreeSpeaks == 1 ? "speak" : "speaks"
+        return "\(remainingFreeSpeaks) free \(noun) left today. Replay stays free for anything already generated."
     }
 
     var supportsTTSExpansion: Bool {

--- a/iOS/KeyVox iOS/Views/SettingsTabView+TTS.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView+TTS.swift
@@ -167,6 +167,7 @@ extension SettingsTabView {
                     style: .secondary,
                     size: .compact,
                     fontSize: 14,
+                    isEnabled: ttsPurchaseController.isStoreActionInFlight == false,
                     action: {
                         appHaptics.light()
                         Task {
@@ -457,6 +458,7 @@ extension SettingsTabView {
     }
 
     var ttsUnlockStatusText: String {
+        ttsPurchaseController.refreshUsageIfNeeded()
         if ttsPurchaseController.isTTSUnlocked {
             return "Unlimited copied-text playback is enabled on this Apple account."
         }

--- a/iOS/KeyVox iOS/Views/SettingsTabView.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView.swift
@@ -5,6 +5,7 @@ struct SettingsTabView: View {
     @Environment(\.appHaptics) var appHaptics
     @EnvironmentObject var modelManager: ModelManager
     @EnvironmentObject var pocketTTSModelManager: PocketTTSModelManager
+    @EnvironmentObject var ttsPurchaseController: TTSPurchaseController
     @EnvironmentObject var ttsVoicePreviewPlayer: TTSVoicePreviewPlayer
     @EnvironmentObject var settingsStore: AppSettingsStore
     @Binding var pendingDeletionConfirmation: SettingsPendingDeletionConfirmation?
@@ -275,6 +276,7 @@ struct SettingsTabView: View {
     SettingsTabView(pendingDeletionConfirmation: .constant(nil))
         .environmentObject(AppServiceRegistry.shared.modelManager)
         .environmentObject(AppServiceRegistry.shared.pocketTTSModelManager)
+        .environmentObject(AppServiceRegistry.shared.ttsPurchaseController)
         .environmentObject(AppServiceRegistry.shared.ttsVoicePreviewPlayer)
         .environmentObject(AppServiceRegistry.shared.settingsStore)
 }

--- a/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
+++ b/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import KeyVoxCore
 import KeyVoxTTS
 import Testing
@@ -40,7 +41,29 @@ struct KeyVoxURLRouterTests {
         #expect(harness.manager.state == .recording)
     }
 
-    private func makeHarness() throws -> Harness {
+    @Test func startTTSRoutePresentsUnlockWhenDailyLimitIsExhausted() async throws {
+        let harness = try makeHarness(isTTSUnlocked: false, remainingFreeTTSSpeaksToday: 0)
+        defer { harness.cleanup() }
+
+        UIPasteboard.general.string = "Test clipboard speech"
+
+        let router = KeyVoxURLRouter(
+            transcriptionManager: harness.manager,
+            ttsManager: harness.ttsManager,
+            audioModeCoordinator: harness.audioModeCoordinator
+        )
+
+        router.handle(route: .startTTS, shouldPresentReturnToHost: false)
+        await settleAsyncWork()
+
+        #expect(harness.purchaseGate.presentUnlockSheetCallCount == 1)
+        #expect(harness.ttsManager.state == .idle)
+    }
+
+    private func makeHarness(
+        isTTSUnlocked: Bool = false,
+        remainingFreeTTSSpeaksToday: Int = TTSPurchaseController.dailyFreeSpeakLimit
+    ) throws -> Harness {
         let tempRootURL = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("KeyVoxURLRouterTests.\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempRootURL, withIntermediateDirectories: true)
@@ -79,23 +102,30 @@ struct KeyVoxURLRouterTests {
             ),
             modelPathProvider: { modelURL.path }
         )
+        let purchaseGate = StubTTSPurchaseGate(
+            isTTSUnlocked: isTTSUnlocked,
+            remainingFreeTTSSpeaksToday: remainingFreeTTSSpeaksToday
+        )
         let ttsManager = TTSManager(
             settingsStore: settingsStore,
             appHaptics: AppHaptics(),
             keyboardBridge: KeyVoxKeyboardBridge(),
             engine: StubTTSEngine(),
-            playbackCoordinator: TTSPlaybackCoordinator()
+            playbackCoordinator: TTSPlaybackCoordinator(),
+            purchaseGate: purchaseGate
         )
         let audioModeCoordinator = AudioModeCoordinator(
             transcriptionManager: manager,
             ttsManager: ttsManager,
-            appTabRouter: AppTabRouter()
+            appTabRouter: AppTabRouter(),
+            ttsPurchaseGate: purchaseGate
         )
 
         return Harness(
             manager: manager,
             ttsManager: ttsManager,
             audioModeCoordinator: audioModeCoordinator,
+            purchaseGate: purchaseGate,
             tempRootURL: tempRootURL,
             defaultsSuiteName: defaultsSuiteName
         )
@@ -113,6 +143,7 @@ private final class Harness {
     let manager: TranscriptionManager
     let ttsManager: TTSManager
     let audioModeCoordinator: AudioModeCoordinator
+    let purchaseGate: StubTTSPurchaseGate
     private let tempRootURL: URL
     private let defaultsSuiteName: String
 
@@ -120,12 +151,14 @@ private final class Harness {
         manager: TranscriptionManager,
         ttsManager: TTSManager,
         audioModeCoordinator: AudioModeCoordinator,
+        purchaseGate: StubTTSPurchaseGate,
         tempRootURL: URL,
         defaultsSuiteName: String
     ) {
         self.manager = manager
         self.ttsManager = ttsManager
         self.audioModeCoordinator = audioModeCoordinator
+        self.purchaseGate = purchaseGate
         self.tempRootURL = tempRootURL
         self.defaultsSuiteName = defaultsSuiteName
     }
@@ -230,4 +263,28 @@ private struct StubTTSEngine: TTSEngine {
             continuation.finish()
         }
     }
+}
+
+@MainActor
+private final class StubTTSPurchaseGate: TTSPurchaseGating {
+    let isTTSUnlocked: Bool
+    let remainingFreeTTSSpeaksToday: Int
+    private(set) var presentUnlockSheetCallCount = 0
+
+    init(isTTSUnlocked: Bool, remainingFreeTTSSpeaksToday: Int) {
+        self.isTTSUnlocked = isTTSUnlocked
+        self.remainingFreeTTSSpeaksToday = remainingFreeTTSSpeaksToday
+    }
+
+    var canStartNewTTSSpeak: Bool {
+        isTTSUnlocked || remainingFreeTTSSpeaksToday > 0
+    }
+
+    func presentUnlockSheet() {
+        presentUnlockSheetCallCount += 1
+    }
+
+    func dismissUnlockSheet() {}
+
+    func consumeFreeTTSSpeakIfNeeded() {}
 }

--- a/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
+++ b/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
@@ -43,7 +43,11 @@ struct KeyVoxURLRouterTests {
 
     @Test func startTTSRoutePresentsUnlockWhenDailyLimitIsExhausted() async throws {
         let harness = try makeHarness(isTTSUnlocked: false, remainingFreeTTSSpeaksToday: 0)
-        defer { harness.cleanup() }
+        let originalPasteboardString = UIPasteboard.general.string
+        defer {
+            UIPasteboard.general.string = originalPasteboardString
+            harness.cleanup()
+        }
 
         UIPasteboard.general.string = "Test clipboard speech"
 
@@ -279,6 +283,8 @@ private final class StubTTSPurchaseGate: TTSPurchaseGating {
     var canStartNewTTSSpeak: Bool {
         isTTSUnlocked || remainingFreeTTSSpeaksToday > 0
     }
+
+    func refreshUsageIfNeeded() {}
 
     func presentUnlockSheet() {
         presentUnlockSheetCallCount += 1

--- a/iOS/KeyVoxiOSTests/App/TTSPurchaseControllerTests.swift
+++ b/iOS/KeyVoxiOSTests/App/TTSPurchaseControllerTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import Testing
+@testable import KeyVox_iOS
+
+@MainActor
+struct TTSPurchaseControllerTests {
+    @Test func lockedUsersStartWithTwoFreeSpeaksPerDay() async throws {
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+
+        let controller = TTSPurchaseController(
+            defaults: harness.defaults,
+            store: harness.store,
+            now: { harness.now }
+        )
+        await settleAsyncWork()
+
+        #expect(controller.isTTSUnlocked == false)
+        #expect(controller.remainingFreeTTSSpeaksToday == 2)
+        #expect(controller.canStartNewTTSSpeak == true)
+    }
+
+    @Test func consumingFreeSpeaksStopsAtZero() async throws {
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+
+        let controller = TTSPurchaseController(
+            defaults: harness.defaults,
+            store: harness.store,
+            now: { harness.now }
+        )
+        await settleAsyncWork()
+
+        controller.consumeFreeTTSSpeakIfNeeded()
+        #expect(controller.remainingFreeTTSSpeaksToday == 1)
+
+        controller.consumeFreeTTSSpeakIfNeeded()
+        #expect(controller.remainingFreeTTSSpeaksToday == 0)
+        #expect(controller.canStartNewTTSSpeak == false)
+
+        controller.consumeFreeTTSSpeakIfNeeded()
+        #expect(controller.remainingFreeTTSSpeaksToday == 0)
+    }
+
+    @Test func unlockedUsersDoNotConsumeDailySpeaks() async throws {
+        let harness = makeHarness(isUnlocked: true)
+        defer { harness.cleanup() }
+
+        let controller = TTSPurchaseController(
+            defaults: harness.defaults,
+            store: harness.store,
+            now: { harness.now }
+        )
+        await settleAsyncWork()
+
+        controller.consumeFreeTTSSpeakIfNeeded()
+        #expect(controller.isTTSUnlocked == true)
+        #expect(controller.remainingFreeTTSSpeaksToday == TTSPurchaseController.dailyFreeSpeakLimit)
+    }
+
+    @Test func dailyUsageResetsWhenTheLocalDayChanges() async throws {
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+
+        let controller = TTSPurchaseController(
+            defaults: harness.defaults,
+            store: harness.store,
+            now: { harness.now }
+        )
+        await settleAsyncWork()
+
+        controller.consumeFreeTTSSpeakIfNeeded()
+        controller.consumeFreeTTSSpeakIfNeeded()
+        #expect(controller.remainingFreeTTSSpeaksToday == 0)
+
+        harness.now = Calendar.current.date(byAdding: .day, value: 1, to: harness.now)!
+        await controller.refreshStoreState()
+
+        #expect(controller.remainingFreeTTSSpeaksToday == 2)
+        #expect(controller.canStartNewTTSSpeak == true)
+    }
+
+    @Test func purchaseAndRestoreFlipUnlockState() async throws {
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+
+        let controller = TTSPurchaseController(
+            defaults: harness.defaults,
+            store: harness.store,
+            now: { harness.now }
+        )
+        await settleAsyncWork()
+
+        await controller.purchaseTTSUnlock()
+        #expect(controller.isTTSUnlocked == true)
+
+        harness.store.isUnlocked = false
+        harness.defaults.set(false, forKey: UserDefaultsKeys.App.isTTSUnlocked)
+        let secondController = TTSPurchaseController(
+            defaults: harness.defaults,
+            store: harness.store,
+            now: { harness.now }
+        )
+        await settleAsyncWork()
+        #expect(secondController.isTTSUnlocked == false)
+
+        harness.store.restoreWillUnlock = true
+        await secondController.restorePurchases()
+        #expect(secondController.isTTSUnlocked == true)
+    }
+
+    private func makeHarness(isUnlocked: Bool = false) -> TTSPurchaseHarness {
+        let suiteName = "TTSPurchaseControllerTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let store = StubTTSUnlockStore(isUnlocked: isUnlocked)
+        return TTSPurchaseHarness(
+            defaults: defaults,
+            store: store,
+            now: Date(timeIntervalSince1970: 0),
+            suiteName: suiteName
+        )
+    }
+
+    private func settleAsyncWork() async {
+        for _ in 0..<5 {
+            await Task.yield()
+        }
+    }
+}
+
+@MainActor
+private final class TTSPurchaseHarness {
+    let defaults: UserDefaults
+    let store: StubTTSUnlockStore
+    var now: Date
+    private let suiteName: String
+
+    init(defaults: UserDefaults, store: StubTTSUnlockStore, now: Date, suiteName: String) {
+        self.defaults = defaults
+        self.store = store
+        self.now = now
+        self.suiteName = suiteName
+    }
+
+    func cleanup() {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+}
+
+private final class StubTTSUnlockStore: TTSUnlockStore {
+    var isUnlocked: Bool
+    var restoreWillUnlock: Bool
+
+    init(isUnlocked: Bool) {
+        self.isUnlocked = isUnlocked
+        self.restoreWillUnlock = isUnlocked
+    }
+
+    func loadUnlockProduct(productID: String) async throws -> TTSUnlockStoreProduct? {
+        TTSUnlockStoreProduct(id: productID, displayName: "Unlock TTS", displayPrice: "$9.99")
+    }
+
+    func isUnlocked(productID: String) async throws -> Bool {
+        isUnlocked
+    }
+
+    func purchase(productID: String) async throws -> Bool {
+        isUnlocked = true
+        return true
+    }
+
+    func restore(productID: String) async throws -> Bool {
+        isUnlocked = restoreWillUnlock
+        return isUnlocked
+    }
+}

--- a/iOS/KeyVoxiOSTests/App/TTSPurchaseControllerTests.swift
+++ b/iOS/KeyVoxiOSTests/App/TTSPurchaseControllerTests.swift
@@ -74,7 +74,7 @@ struct TTSPurchaseControllerTests {
         #expect(controller.remainingFreeTTSSpeaksToday == 0)
 
         harness.now = Calendar.current.date(byAdding: .day, value: 1, to: harness.now)!
-        await controller.refreshStoreState()
+        controller.refreshUsageIfNeeded()
 
         #expect(controller.remainingFreeTTSSpeaksToday == 2)
         #expect(controller.canStartNewTTSSpeak == true)


### PR DESCRIPTION
## Summary

This branch adds the first phase of the TTS monetization system. It introduces the app-scoped purchase and usage owner, daily free-speak accounting, centralized gating for all new copied-text playback starts, a placeholder unlock sheet, and minimal Home and Settings UI so the entitlement flow can be exercised end to end before any polished paywall work.

## What This Branch Adds

This branch adds `TTSPurchaseController` as the single app-owned source of truth for the one-time TTS unlock, cached entitlement state, StoreKit product loading, purchase flow, restore flow, and local daily free-speak counting.

It adds the phase one copied-text playback policy of two free new speaks per local calendar day while keeping replay free for already generated audio.

It adds centralized gating for new TTS starts through `AudioModeCoordinator` so Home, keyboard-driven playback, URL-driven playback, and share-driven request consumption all respect the same limit instead of relying on view-only checks.

It adds the consumption hook in `TTSManager` so a free daily speak is only consumed after a new TTS generation has actually begun rather than on button tap.

It adds a placeholder unlock sheet that surfaces the one-time unlock action, restore action, and the remaining free-speak count without trying to design the final paywall yet.

It adds minimal Home and Settings UI changes so the locked state, remaining free speaks, and unlock entry points are visible while the entitlement system is being proven.

It adds a maintainer-facing runtime flag to bypass the free-speak cap during development with `KEYVOX_BYPASS_TTS_FREE_SPEAK_LIMIT`.

## Key Implementation Areas

`iOS/KeyVox iOS/App/TTSPurchaseController.swift`
This file now owns the phase one TTS unlock and daily-usage policy.

`iOS/KeyVox iOS/Core/TTS/AudioModeCoordinator.swift`
This file now enforces the copied-text playback gate for all new TTS starts.

`iOS/KeyVox iOS/Core/TTS/TTSManager/`
This area now consumes a free daily speak only after playback generation successfully starts.

`iOS/KeyVox iOS/Views/Components/TTSUnlockSheetView.swift`
This file provides the placeholder unlock sheet for the current proof path.

`iOS/KeyVox iOS/Views/HomeTabView/TTS/`
This area now reflects the locked state and remaining free-speak messaging on the Home copied-text playback card.

`iOS/KeyVox iOS/Views/SettingsTabView+TTS.swift`
This file now exposes a basic `TTS Access` row with unlock and restore entry points.

## Tests

This branch adds deterministic iOS-side coverage for:
- daily free-speak accounting
- day rollover reset behavior
- unlocked users not consuming daily uses
- purchase and restore state transitions through the placeholder store abstraction
- blocked `startTTS` routing when the daily free-speak limit is exhausted

## Notes

This is intentionally the scaffolding phase only. The goal of this branch is to prove the entitlement model, usage tracking, centralized gate enforcement, and placeholder unlock flow before polishing the final in-app purchase presentation.

Every commit on this branch also ran through GitHub Actions CI, so the branch was under continuous automated validation while the entitlement layer was being built out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-time TTS unlock for copied-text playback with two free speaks/day fallback, an unlock/restore sheet, and gating across all TTS entry points; Home shows remaining-free-speaks messaging and Settings adds a “TTS Access” row.

* **Documentation**
  * Engine docs cover a runtime flag to bypass the free-speak limit (dev/testing) and updated TTS control/ownership and monetization flow notes.

* **Tests**
  * New tests for purchase/restore, free-speak consumption, day-boundary reset, and route gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->