### PR TITLE
feat(ios-shortcuts): add an official KeyVox Speak app shortcut for copied-text playback

### DIFF
--- a/iOS/KeyVox iOS.xcodeproj/project.pbxproj
+++ b/iOS/KeyVox iOS.xcodeproj/project.pbxproj
@@ -54,6 +54,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		8E7DC73B2F827B11009E3576 /* Embed ExtensionKit Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(EXTENSIONS_FOLDER_PATH)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			name = "Embed ExtensionKit Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8E7EC0572F5C28B00080C762 /* Embed Foundation Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -420,6 +430,7 @@
 				8E9E384F2F5BF1F000EAFA72 /* Frameworks */,
 				8E9E38502F5BF1F000EAFA72 /* Resources */,
 				8E7EC0572F5C28B00080C762 /* Embed Foundation Extensions */,
+				8E7DC73B2F827B11009E3576 /* Embed ExtensionKit Extensions */,
 			);
 			buildRules = (
 			);

--- a/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
+++ b/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
@@ -76,12 +76,12 @@
          <EnvironmentVariable
             key = "KEYVOX_BYPASS_TTS_FREE_SPEAK_LIMIT"
             value = "1"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "KEYVOX_FORCE_KEYVOX_SPEAK_INTRO"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
+++ b/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
@@ -81,7 +81,7 @@
          <EnvironmentVariable
             key = "KEYVOX_FORCE_KEYVOX_SPEAK_INTRO"
             value = "1"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/iOS/KeyVox iOS/App/KeyVoxIPCBridge.swift
+++ b/iOS/KeyVox iOS/App/KeyVoxIPCBridge.swift
@@ -66,6 +66,7 @@ enum KeyVoxIPCBridge {
         static let keyboardOnboardingPresentationTimestamp = "keyboardOnboardingPresentation_timestamp"
         static let keyboardOnboardingAccessTimestamp = "keyboardOnboardingAccess_timestamp"
         static let keyboardOnboardingHasFullAccess = "keyboardOnboardingHasFullAccess"
+        static let pendingURLRoute = "pendingURLRoute"
     }
 
     private enum LiveMeterPacket {
@@ -200,6 +201,19 @@ enum KeyVoxIPCBridge {
     static func clearTTSRequest(fileManager: FileManager = .default) {
         guard let requestURL = ttsRequestURL(fileManager: fileManager) else { return }
         try? fileManager.removeItem(at: requestURL)
+    }
+
+    static func writePendingURLRoute(_ urlString: String) {
+        defaults?.set(urlString, forKey: Key.pendingURLRoute)
+    }
+
+    static func consumePendingURLRoute() -> URL? {
+        guard let urlString = defaults?.string(forKey: Key.pendingURLRoute) else {
+            return nil
+        }
+
+        defaults?.removeObject(forKey: Key.pendingURLRoute)
+        return URL(string: urlString)
     }
 
     static func writeLiveMeter(level: Float, signalState: KeyVoxIPCLiveMeterSignalState) {

--- a/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
+++ b/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
@@ -86,6 +86,10 @@ struct KeyVoxApp: App {
                         if let initialRoute = appLaunchRouteStore.consumeInitialURLRoute() {
                             handle(route: initialRoute, shouldPresentReturnToHost: true)
                         }
+                        if let pendingShortcutURL = KeyVoxIPCBridge.consumePendingURLRoute(),
+                           let pendingShortcutRoute = KeyVoxURLRoute(url: pendingShortcutURL) {
+                            handle(route: pendingShortcutRoute, shouldPresentReturnToHost: true)
+                        }
                         transcriptionManager.handleAppDidBecomeActive()
                         ttsManager.handleAppDidBecomeActive()
                         pocketTTSModelManager.handleAppDidBecomeActive()

--- a/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
+++ b/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
@@ -83,12 +83,10 @@ struct KeyVoxApp: App {
                     NSLog("[KeyVoxApp] scenePhase=%@", String(describing: newPhase))
                     switch newPhase {
                     case .active:
-                        if let initialRoute = appLaunchRouteStore.consumeInitialURLRoute() {
-                            handle(route: initialRoute, shouldPresentReturnToHost: true)
-                        }
-                        if let pendingShortcutURL = KeyVoxIPCBridge.consumePendingURLRoute(),
-                           let pendingShortcutRoute = KeyVoxURLRoute(url: pendingShortcutURL) {
-                            handle(route: pendingShortcutRoute, shouldPresentReturnToHost: true)
+                        let initialRoute = appLaunchRouteStore.consumeInitialURLRoute()
+                        let pendingShortcutRoute = KeyVoxIPCBridge.consumePendingURLRoute().flatMap(KeyVoxURLRoute.init(url:))
+                        if let selectedRoute = pendingShortcutRoute ?? initialRoute {
+                            handle(route: selectedRoute, shouldPresentReturnToHost: true)
                         }
                         transcriptionManager.handleAppDidBecomeActive()
                         ttsManager.handleAppDidBecomeActive()

--- a/iOS/KeyVox iOS/App/Shortcuts/KeyVoxSpeakShortcutIntent.swift
+++ b/iOS/KeyVox iOS/App/Shortcuts/KeyVoxSpeakShortcutIntent.swift
@@ -1,0 +1,27 @@
+import AppIntents
+import Foundation
+
+struct KeyVoxSpeakShortcutIntent: AppIntent {
+    static let launchURL = URL(string: "keyvoxios://tts/start")!
+
+    static var title: LocalizedStringResource { "Speak Copied Text" }
+    static var description = IntentDescription("Starts the KeyVox copied-text speech route.")
+    static var openAppWhenRun: Bool { true }
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "Speak Copied Text",
+            subtitle: "Start KeyVox Speak",
+            image: .init(
+                named: "keyvox-circle",
+                isTemplate: false,
+                displayStyle: .circular
+            )
+        )
+    }
+
+    func perform() async throws -> some IntentResult {
+        KeyVoxIPCBridge.writePendingURLRoute(Self.launchURL.absoluteString)
+        return .result()
+    }
+}

--- a/iOS/KeyVox iOS/App/Shortcuts/KeyVoxSpeakShortcutIntent.swift
+++ b/iOS/KeyVox iOS/App/Shortcuts/KeyVoxSpeakShortcutIntent.swift
@@ -21,7 +21,9 @@ struct KeyVoxSpeakShortcutIntent: AppIntent {
     }
 
     func perform() async throws -> some IntentResult {
-        KeyVoxIPCBridge.writePendingURLRoute(Self.launchURL.absoluteString)
+        await MainActor.run {
+            KeyVoxIPCBridge.writePendingURLRoute(Self.launchURL.absoluteString)
+        }
         return .result()
     }
 }

--- a/iOS/KeyVox iOS/App/Shortcuts/KeyVoxSpeakShortcutsProvider.swift
+++ b/iOS/KeyVox iOS/App/Shortcuts/KeyVoxSpeakShortcutsProvider.swift
@@ -1,0 +1,16 @@
+import AppIntents
+
+struct KeyVoxSpeakShortcutsProvider: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: KeyVoxSpeakShortcutIntent(),
+            phrases: [
+                "Speak copied text in \(.applicationName)",
+                "Start KeyVox Speak in \(.applicationName)",
+                "Use KeyVox Speak in \(.applicationName)"
+            ],
+            shortTitle: "KeyVox Speak",
+            systemImageName: "speaker.wave.2.fill"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

This branch adds an official App Shortcut for KeyVox Speak on iOS and wires it into the existing copied-text TTS route instead of introducing a separate shortcut-only playback path.

## What This Branch Adds

This branch adds a new app-owned `Speak Copied Text` App Intent in the main iOS target.

It adds a matching `AppShortcutsProvider` so KeyVox Speak can be surfaced in the Shortcuts system with official phrases instead of relying only on a manually constructed custom shortcut.

It keeps the shortcut behavior intentionally simple by reusing the existing `keyvoxios://tts/start` route rather than inventing a second TTS start mechanism.

It adds a small shared-app-group handoff for a pending URL route so the shortcut can signal intent and then let the app consume that route on activation through the existing routing layer.

It uses the shared `keyvox-circle` asset in the intent display representation for the shortcut-facing KeyVox Speak identity.

## Key Implementation Areas

`iOS/KeyVox iOS/App/Shortcuts/KeyVoxSpeakShortcutIntent.swift`
Defines the app-owned KeyVox Speak App Intent and writes the pending copied-text TTS route.

`iOS/KeyVox iOS/App/Shortcuts/KeyVoxSpeakShortcutsProvider.swift`
Registers the official KeyVox Speak App Shortcut phrases.

`iOS/KeyVox iOS/App/KeyVoxIPCBridge.swift`
Adds one-shot shared-state storage for a pending URL route handoff.

`iOS/KeyVox iOS/App/KeyVoxiOSApp.swift`
Consumes any pending shortcut route on activation and routes it through the existing URL handling flow.

## Notes

This branch keeps the shortcut implementation intentionally thin. The shortcut layer only signals the existing copied-text TTS route, while the app shell and existing coordinator stack continue to own actual routing and playback behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "KeyVox Speak" Siri Shortcut to trigger copied-text speech and automatically open the app.
* **Improvements**
  * App now accepts a pending shortcut route written by the shortcut and consumes it once on activation to resume the requested flow.
* **Shortcuts**
  * Exposed the shortcut via the app's shortcuts provider with localized phrases and an icon for easy setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->