### PR TITLE
feat(ios-tts): prewarm PocketTTS after install and surface real TTS readiness on Home and Keyboard

### DIFF
--- a/Packages/KeyVoxTTS/Sources/KeyVoxTTS/KeyVoxPocketTTSRuntime/KeyVoxPocketTTSRuntime.swift
+++ b/Packages/KeyVoxTTS/Sources/KeyVoxTTS/KeyVoxPocketTTSRuntime/KeyVoxPocketTTSRuntime.swift
@@ -51,6 +51,22 @@ public actor KeyVoxPocketTTSRuntime {
         Self.log("Preferred compute mode set to \(mode.logName).")
     }
 
+    public func prepareVoiceIfNeeded(_ voice: KeyVoxTTSVoice) async throws {
+        try await prepareIfNeeded()
+
+        let voiceConditioning = try loadVoiceConditioning(voice)
+        let currentMode = await computeModeController.mode()
+        let prefillModel = currentMode == .backgroundSafe
+            ? try modelSet(backgroundModels, modeName: "background").condStepModel
+            : try modelSet(foregroundModels, modeName: "foreground").condStepModel
+
+        _ = try await loadVoiceKVSnapshot(
+            for: voice,
+            voiceConditioning: voiceConditioning,
+            model: prefillModel
+        )
+    }
+
     public func synthesizeStreaming(
         text: String,
         voice: KeyVoxTTSVoice,

--- a/iOS/Docs/CODEMAP.md
+++ b/iOS/Docs/CODEMAP.md
@@ -552,7 +552,7 @@ Packages/
 - `KeyVox iOS/Views/SettingsTabView+Models.swift`
   - Release-facing `Text Model` section, provider selection, per-model install actions, and not-installed size labels.
 - `KeyVox iOS/Views/SettingsTabView+TTS.swift`
-  - Release-facing `Voice Model` section for PocketTTS runtime install state, per-voice install actions, voice previews, playback voice selection, and the `KeyVox Speak Access` unlock row placed beneath the model section, including the shared installed-voice picker menu.
+  - Release-facing `Voice Model` section for PocketTTS runtime install state, per-voice install actions, voice previews, playback voice selection, and the `KeyVox Speak Unlimited` unlock row placed beneath the model section, including the shared installed-voice picker menu.
 - `KeyVox iOS/Views/Components/SettingsDeletionConfirmation.swift`
   - Shared destructive-delete confirmation component used by the settings model sections.
 - `KeyVox iOS/Views/ReturnToHostView.swift`

--- a/iOS/Docs/ENGINEERING.md
+++ b/iOS/Docs/ENGINEERING.md
@@ -938,7 +938,7 @@ Current app-owned surfaces:
 - `StyleTabView`: dictation style toggles
 - `SettingsTabView`: top-level settings composition, disclosure state, and destructive-confirmation coordination
 - `SettingsTabView+Models`: release-facing `Text Model` section for provider selection plus per-model install actions and uninstalled model size display
-- `SettingsTabView+TTS`: release-facing `Voice Model` section for PocketTTS runtime install state, per-voice install actions, previews, voice selection, and the `KeyVox Speak Access` unlock row placed beneath the model section
+- `SettingsTabView+TTS`: release-facing `Voice Model` section for PocketTTS runtime install state, per-voice install actions, previews, voice selection, and the `KeyVox Speak Unlimited` unlock row placed beneath the model section
 - `PlaybackPreparationView`: keyboard cold-launch playback-preparation surface shown before returning to the host app
 - `ReturnToHostView`: one-time host-return guidance after a cold keyboard launch
 - onboarding screens: welcome, setup, keyboard tour

--- a/iOS/KeyVox Keyboard/App/KeyboardViewController.swift
+++ b/iOS/KeyVox Keyboard/App/KeyboardViewController.swift
@@ -43,9 +43,13 @@ final class KeyboardViewController: UIInputViewController {
         clipboardTextProvider: {
             UIPasteboard.general.string
         },
-        selectedVoiceIDProvider: {
+        selectedVoiceIDProvider: { [fileManager = FileManager.default] in
             let defaults = UserDefaults(suiteName: KeyVoxIPCBridge.appGroupID)
-            return defaults?.string(forKey: UserDefaultsKeys.ttsVoice) ?? "azelma"
+            let preferredVoiceID = defaults?.string(forKey: UserDefaultsKeys.ttsVoice)
+            return KeyboardModelAvailability.resolvedTTSVoiceID(
+                preferredVoiceID: preferredVoiceID,
+                fileManager: fileManager
+            ) ?? "alba"
         },
         requestWriter: { request in
             KeyVoxIPCBridge.writeTTSRequest(request)
@@ -188,11 +192,15 @@ final class KeyboardViewController: UIInputViewController {
 
     func updateUI() {
         let toolbarMode = currentToolbarMode()
+        let preferredTTSVoiceID = UserDefaults(suiteName: KeyVoxIPCBridge.appGroupID)?
+            .string(forKey: UserDefaultsKeys.ttsVoice)
+        let isTTSReady = KeyboardModelAvailability.isTTSReady(preferredVoiceID: preferredTTSVoiceID)
         rootContainerView?.apply(
             state: keyboardState,
             symbolPage: symbolPage,
             isCapsLockEnabled: isCapsLockEnabled,
             toolbarMode: toolbarMode,
+            isTTSReady: isTTSReady,
             isTrackpadModeActive: isTrackpadModeActive
         )
         if toolbarMode != .fullAccessWarning {

--- a/iOS/KeyVox Keyboard/Core/KeyboardModelAvailability.swift
+++ b/iOS/KeyVox Keyboard/Core/KeyboardModelAvailability.swift
@@ -1,6 +1,33 @@
 import Foundation
 
 enum KeyboardModelAvailability {
+    private static let supportedTTSVoiceIDs = [
+        "alba",
+        "azelma",
+        "cosette",
+        "eponine",
+        "fantine",
+        "javert",
+        "jean",
+        "marius",
+    ]
+
+    private static func modelsDirectoryURL(fileManager: FileManager) -> URL? {
+        fileManager.containerURL(forSecurityApplicationGroupIdentifier: KeyVoxIPCBridge.appGroupID)?
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+
+    private static func pocketTTSRootDirectoryURL(fileManager: FileManager) -> URL? {
+        modelsDirectoryURL(fileManager: fileManager)?
+            .appendingPathComponent("tts", isDirectory: true)
+            .appendingPathComponent("pockettts", isDirectory: true)
+    }
+
+    private static func pocketTTSVoiceDirectoryURL(fileManager: FileManager) -> URL? {
+        pocketTTSRootDirectoryURL(fileManager: fileManager)?
+            .appendingPathComponent("Voices", isDirectory: true)
+    }
+
     static func isInstalled(fileManager: FileManager = .default) -> Bool {
         guard let containerURL = fileManager.containerURL(
             forSecurityApplicationGroupIdentifier: KeyVoxIPCBridge.appGroupID
@@ -11,6 +38,95 @@ enum KeyboardModelAvailability {
         let modelsDirectory = containerURL.appendingPathComponent("Models", isDirectory: true)
         return whisperIsInstalled(in: modelsDirectory, fileManager: fileManager)
             || parakeetIsInstalled(in: modelsDirectory, fileManager: fileManager)
+    }
+
+    static func isTTSReady(
+        preferredVoiceID: String?,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard isPocketTTSSharedModelInstalled(fileManager: fileManager),
+              resolvedTTSVoiceID(preferredVoiceID: preferredVoiceID, fileManager: fileManager) != nil else {
+            return false
+        }
+
+        return true
+    }
+
+    static func resolvedTTSVoiceID(
+        preferredVoiceID: String?,
+        fileManager: FileManager = .default
+    ) -> String? {
+        let installedVoiceIDs = installedTTSVoiceIDs(fileManager: fileManager)
+        guard installedVoiceIDs.isEmpty == false else {
+            return nil
+        }
+
+        if let preferredVoiceID,
+           installedVoiceIDs.contains(preferredVoiceID) {
+            return preferredVoiceID
+        }
+
+        for voiceID in supportedTTSVoiceIDs where installedVoiceIDs.contains(voiceID) {
+            return voiceID
+        }
+
+        return installedVoiceIDs.sorted().first
+    }
+
+    private static func installedTTSVoiceIDs(fileManager: FileManager) -> Set<String> {
+        guard let voicesDirectoryURL = pocketTTSVoiceDirectoryURL(fileManager: fileManager),
+              let candidateURLs = try? fileManager.contentsOfDirectory(
+                at: voicesDirectoryURL,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+              ) else {
+            return []
+        }
+
+        return Set(
+            candidateURLs
+                .filter { $0.hasDirectoryPath }
+                .map { $0.lastPathComponent }
+                .filter { isTTSVoiceInstalled($0, fileManager: fileManager) }
+        )
+    }
+
+    private static func isPocketTTSSharedModelInstalled(fileManager: FileManager) -> Bool {
+        guard let rootDirectoryURL = pocketTTSRootDirectoryURL(fileManager: fileManager) else {
+            return false
+        }
+
+        let requiredPaths = [
+            "install-manifest.json",
+            "Model/cond_step.mlmodelc",
+            "Model/flowlm_step.mlmodelc",
+            "Model/flow_decoder.mlmodelc",
+            "Model/mimi_decoder_v2.mlmodelc",
+            "Model/constants_bin/bos_emb.bin",
+            "Model/constants_bin/text_embed_table.bin",
+            "Model/constants_bin/tokenizer.model",
+            "Model/constants_bin/manifest.json",
+            "Model/constants_bin/mimi_init_state",
+        ]
+
+        return requiredPaths.allSatisfy { relativePath in
+            fileManager.fileExists(atPath: rootDirectoryURL.appendingPathComponent(relativePath).path)
+        }
+    }
+
+    private static func isTTSVoiceInstalled(_ voiceID: String, fileManager: FileManager) -> Bool {
+        guard let rootDirectoryURL = pocketTTSRootDirectoryURL(fileManager: fileManager) else {
+            return false
+        }
+
+        let requiredPaths = [
+            "Voices/\(voiceID)/install-manifest.json",
+            "Voices/\(voiceID)/audio_prompt.bin",
+        ]
+
+        return requiredPaths.allSatisfy { relativePath in
+            fileManager.fileExists(atPath: rootDirectoryURL.appendingPathComponent(relativePath).path)
+        }
     }
 
     private static func whisperIsInstalled(in modelsDirectory: URL, fileManager: FileManager) -> Bool {

--- a/iOS/KeyVox Keyboard/Views/KeyboardRootView.swift
+++ b/iOS/KeyVox Keyboard/Views/KeyboardRootView.swift
@@ -94,13 +94,14 @@ final class KeyboardRootView: UIView {
         symbolPage: KeyboardSymbolPage,
         isCapsLockEnabled: Bool,
         toolbarMode: KeyboardToolbarMode,
+        isTTSReady: Bool,
         isTrackpadModeActive: Bool
     ) {
         let showsBrandedToolbar = toolbarMode == .branded
         let warningText = toolbarMode.warningText
         let showsToolbarWarning = warningText != nil
         let shouldShowCancel = showsBrandedToolbar && state.showsCancelButton
-        let shouldShowSpeak = showsBrandedToolbar && !state.showsCancelButton
+        let shouldShowSpeak = showsBrandedToolbar && isTTSReady && !state.showsCancelButton
 
         if shouldShowCancel != cancelButtonVisibilityTarget {
             cancelButtonVisibilityTarget = shouldShowCancel

--- a/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
+++ b/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
@@ -76,7 +76,7 @@
          <EnvironmentVariable
             key = "KEYVOX_BYPASS_TTS_FREE_SPEAK_LIMIT"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "KEYVOX_FORCE_KEYVOX_SPEAK_INTRO"

--- a/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
+++ b/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
@@ -66,7 +66,7 @@
          <EnvironmentVariable
             key = "KVX_DEBUG_LOG_RAW_TEXT"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "KEYVOX_FORCE_ONBOARDING"
@@ -81,7 +81,7 @@
          <EnvironmentVariable
             key = "KEYVOX_FORCE_KEYVOX_SPEAK_INTRO"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/iOS/KeyVox iOS/App/AppServiceRegistry.swift
+++ b/iOS/KeyVox iOS/App/AppServiceRegistry.swift
@@ -30,7 +30,10 @@ final class AppServiceRegistry {
     let weeklyWordStatsCloudSync: WeeklyWordStatsCloudSync
     let sessionLiveActivityCoordinator: KeyVoxSessionLiveActivityCoordinator
     let urlRouter: KeyVoxURLRouter
+    private let ttsEngine: PocketTTSEngine
     private var cancellables = Set<AnyCancellable>()
+    private var ttsWarmupTask: Task<Void, Never>?
+    private var warmedTTSVoiceID: String?
 
     private init(fileManager: FileManager = .default) {
         let dictionaryBaseDirectory = SharedPaths.dictionaryBaseDirectoryURL(fileManager: fileManager)
@@ -240,6 +243,7 @@ final class AppServiceRegistry {
         self.iCloudSyncCoordinator = iCloudSyncCoordinator
         self.weeklyWordStatsCloudSync = weeklyWordStatsCloudSync
         self.sessionLiveActivityCoordinator = sessionLiveActivityCoordinator
+        self.ttsEngine = ttsEngine
         self.urlRouter = KeyVoxURLRouter(
             transcriptionManager: transcriptionManager,
             ttsManager: ttsManager,
@@ -262,18 +266,28 @@ final class AppServiceRegistry {
         pocketTTSModelManager.$voiceInstallStates
             .sink { [weak self] _ in
                 self?.normalizeTTSVoiceSelection()
+                self?.warmPocketTTSIfReady()
             }
             .store(in: &cancellables)
 
         pocketTTSModelManager.$sharedModelInstallState
             .sink { [weak self] _ in
                 self?.normalizeTTSVoiceSelection()
+                self?.warmPocketTTSIfReady()
+            }
+            .store(in: &cancellables)
+
+        settingsStore.$ttsVoice
+            .removeDuplicates()
+            .sink { [weak self] _ in
+                self?.warmPocketTTSIfReady()
             }
             .store(in: &cancellables)
 
         normalizeActiveProviderSelection()
         normalizeTTSVoiceSelection()
         applyActiveProviderSelection(settingsStore.activeDictationProvider)
+        warmPocketTTSIfReady()
     }
 
     private func applyActiveProviderSelection(_ provider: AppSettingsStore.ActiveDictationProvider) {
@@ -329,5 +343,36 @@ final class AppServiceRegistry {
         }
 
         return pocketTTSModelManager.installedVoices().first ?? selectedVoice
+    }
+
+    private func warmPocketTTSIfReady() {
+        let resolvedVoice = Self.resolvedTTSVoiceSelection(
+            selectedVoice: settingsStore.ttsVoice,
+            pocketTTSModelManager: pocketTTSModelManager
+        )
+
+        guard pocketTTSModelManager.isReady(for: resolvedVoice) else {
+            ttsWarmupTask?.cancel()
+            ttsWarmupTask = nil
+            warmedTTSVoiceID = nil
+            return
+        }
+
+        guard warmedTTSVoiceID != resolvedVoice.rawValue else { return }
+
+        ttsWarmupTask?.cancel()
+        warmedTTSVoiceID = resolvedVoice.rawValue
+        let voiceID = resolvedVoice.rawValue
+        let ttsEngine = self.ttsEngine
+
+        ttsWarmupTask = Task {
+            do {
+                try await ttsEngine.prewarmVoiceIfNeeded(voiceID: voiceID)
+            } catch {
+                #if DEBUG
+                NSLog("[AppServiceRegistry] Failed to prewarm PocketTTS voice %@: %@", voiceID, error.localizedDescription)
+                #endif
+            }
+        }
     }
 }

--- a/iOS/KeyVox iOS/App/KeyVoxSpeakIntroController.swift
+++ b/iOS/KeyVox iOS/App/KeyVoxSpeakIntroController.swift
@@ -7,6 +7,7 @@ final class KeyVoxSpeakIntroController: ObservableObject {
 
     private let defaults: UserDefaults
     private let forcePresentation: Bool
+    private var hasCountedEligibleOpenThisLaunch = false
 
     init(
         defaults: UserDefaults,
@@ -27,11 +28,13 @@ final class KeyVoxSpeakIntroController: ObservableObject {
         guard onboardingStore.hasCompletedOnboardingThisLaunch == false else { return }
         guard hasSeenIntro == false else { return }
         guard hasUsedKeyVoxSpeak == false else { return }
+        guard hasCountedEligibleOpenThisLaunch == false else { return }
 
         let eligibleOpenCount = defaults.integer(forKey: UserDefaultsKeys.App.keyVoxSpeakEligibleOpenCount) + 1
         defaults.set(eligibleOpenCount, forKey: UserDefaultsKeys.App.keyVoxSpeakEligibleOpenCount)
+        hasCountedEligibleOpenThisLaunch = true
 
-        if eligibleOpenCount >= 2 {
+        if eligibleOpenCount >= 3 {
             isPresented = true
         }
     }

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSEngine.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSEngine.swift
@@ -21,6 +21,17 @@ final class PocketTTSEngine: TTSEngine {
         Self.log("PocketTTS runtime prepared.")
     }
 
+    func prewarmVoiceIfNeeded(voiceID: String) async throws {
+        let runtime = try runtimeForInstalledAssets()
+        guard let voice = KeyVoxTTSVoice(rawValue: voiceID) else {
+            throw KeyVoxTTSError.invalidVoice("PocketTTS voice \(voiceID) is not supported.")
+        }
+
+        Self.log("Prewarming PocketTTS voice \(voiceID).")
+        try await runtime.prepareVoiceIfNeeded(voice)
+        Self.log("Prewarmed PocketTTS voice \(voiceID).")
+    }
+
     func prepareForForegroundSynthesis() async {
         do {
             let runtime = try runtimeForInstalledAssets()

--- a/iOS/KeyVox iOS/Core/TTS/TTSEngine.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSEngine.swift
@@ -3,6 +3,7 @@ import KeyVoxTTS
 
 protocol TTSEngine {
     func prepareIfNeeded() async throws
+    func prewarmVoiceIfNeeded(voiceID: String) async throws
     func prepareForForegroundSynthesis() async
     func prepareForBackgroundContinuation() async
     func makeAudioStream(

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTS.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTS.swift
@@ -86,6 +86,15 @@ extension HomeTabView {
                     }
                 }
 
+                if let activeTTSInstallState {
+                    switch activeTTSInstallState {
+                    case .downloading(let progress), .installing(let progress):
+                        ModelDownloadProgress(progress: progress, showLabel: false)
+                    case .notInstalled, .ready, .failed:
+                        EmptyView()
+                    }
+                }
+
                 if showsTTSPreparationSlot {
                     VStack(alignment: .leading, spacing: 8) {
                         ProgressView(value: ttsManager.playbackPreparationProgress)

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
@@ -95,6 +95,29 @@ extension HomeTabView {
         showsTTSPreparationProgress ? ttsPreparationProgressLabel : nil
     }
 
+    var activeTTSInstallState: PocketTTSInstallState? {
+        if pocketTTSModelManager.isSharedModelReady() == false {
+            switch pocketTTSModelManager.sharedModelInstallState {
+            case .downloading, .installing:
+                return pocketTTSModelManager.sharedModelInstallState
+            case .notInstalled, .failed, .ready:
+                break
+            }
+        }
+
+        let voiceState = pocketTTSModelManager.installState(for: effectiveTTSVoice)
+        switch voiceState {
+        case .downloading, .installing:
+            return voiceState
+        case .notInstalled, .failed, .ready:
+            return nil
+        }
+    }
+
+    var showsTTSInstallProgressBar: Bool {
+        activeTTSInstallState != nil
+    }
+
     func syncTTSPreparationPresentation() {
         showsTTSPreparationSlot = showsTTSPreparationProgress
         isTTSPreparationVisible = showsTTSPreparationProgress

--- a/iOS/KeyVox iOS/Views/SettingsTabView+TTS.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView+TTS.swift
@@ -145,7 +145,7 @@ extension SettingsTabView {
     private var ttsUnlockRow: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center, spacing: 12) {
-                Text("KeyVox Speak Access")
+                Text("KeyVox Speak Unlimited")
                     .font(.appFont(17))
                     .foregroundStyle(.white)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
+++ b/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
@@ -254,6 +254,8 @@ private final class StubDictationService: DictationProvider {
 private struct StubTTSEngine: TTSEngine {
     func prepareIfNeeded() async throws {}
 
+    func prewarmVoiceIfNeeded(voiceID: String) async throws {}
+
     func prepareForForegroundSynthesis() async {}
 
     func prepareForBackgroundContinuation() async {}


### PR DESCRIPTION
This branch improves the iOS PocketTTS first-run experience by prewarming the installed voice after model setup, surfacing install progress on the Home Speak card, tightening the delayed KeyVox Speak intro timing, and making the keyboard Speak key appear only when PocketTTS is truly ready.

## What This Branch Changes

This branch adds a real PocketTTS voice prewarm path so that once the shared PocketTTS model and the resolved voice are both ready, the app proactively prepares the runtime and loads the selected voice conditioning snapshot instead of waiting for the first actual Speak request.

It updates the app service registry to observe PocketTTS shared-model state, voice install state, and selected voice changes, then trigger prewarm work only when a usable voice is actually ready.

It adds Home Speak card install progress so users can see PocketTTS download or install progress directly on the copied-text TTS surface instead of only in the KeyVox Speak setup flow.

It tightens the KeyVox Speak intro timing so the informational sheet is shown only after a true third eligible cold start, with the eligible-open counter incrementing at most once per app launch.

It updates the keyboard Speak button gating so the button is hidden until PocketTTS is actually usable, based on the real shared model layout and an actually installed voice rather than only the saved voice preference.

It also updates the keyboard-side TTS voice resolution so the keyboard request uses a truly installed voice if the saved preference is stale, with Alba as the final fallback if no resolved installed voice is found.

## Key Files

`Packages/KeyVoxTTS/Sources/KeyVoxTTS/KeyVoxPocketTTSRuntime/KeyVoxPocketTTSRuntime.swift`
Adds PocketTTS voice prewarm support on the runtime itself.

`iOS/KeyVox iOS/Core/TTS/TTSEngine.swift`
`iOS/KeyVox iOS/Core/TTS/PocketTTSEngine.swift`
Extend the iOS TTS engine abstraction and PocketTTS engine to support explicit voice prewarming.

`iOS/KeyVox iOS/App/AppServiceRegistry.swift`
Wires automatic PocketTTS warmup when the shared model and resolved voice become ready.

`iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift`
`iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTS.swift`
Add Home-card install progress presentation for PocketTTS shared-model and voice installs.

`iOS/KeyVox iOS/App/KeyVoxSpeakIntroController.swift`
Changes the intro eligibility behavior so it counts true eligible cold starts and waits until the third one.

`iOS/KeyVox Keyboard/Core/KeyboardModelAvailability.swift`
Adds real PocketTTS shared-model and voice-availability checks rooted in the app-group container.

`iOS/KeyVox Keyboard/App/KeyboardViewController.swift`
Uses the resolved installed TTS voice for keyboard requests and threads TTS readiness into the keyboard UI state.

`iOS/KeyVox Keyboard/Views/KeyboardRootView.swift`
Only shows the Speak key when the branded keyboard toolbar is active and PocketTTS is actually ready.

`iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift`
Updates the TTS engine stub for the new prewarm requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TTS voice prewarming to improve speak responsiveness.
  * UI now shows TTS model download/install progress where relevant.

* **Bug Fixes**
  * Speak button properly gated by TTS readiness.
  * Voice selection uses stored preferences with smarter fallbacks.

* **Improvements**
  * Better TTS availability and installed-voice discovery.

* **Documentation**
  * Renamed release-facing unlock row to "KeyVox Speak Unlimited" and updated docs.

* **Chores**
  * Disabled certain debug speak-related launch flags in debug scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->