### PR TITLE
fix(ios-tts): make shortcut startup deterministic and keep TTS alive across route and session changes

### DIFF
--- a/iOS/CHANGELOG.md
+++ b/iOS/CHANGELOG.md
@@ -6,7 +6,7 @@ The format loosely follows Keep a Changelog and the project uses semantic versio
 
 ---
 
-## [1.1.0] Build 1 - Test Flight - 2026-04-05
+## [1.0.0] Build 14 - Test Flight - 2026-04-05
 
 Introduces KeyVox Speak to the iOS beta with local copied-text playback, PocketTTS model management, official shortcut routing, and the first pass of the new unlock and feature-discovery flow.
 

--- a/iOS/KeyVox iOS.xcodeproj/project.pbxproj
+++ b/iOS/KeyVox iOS.xcodeproj/project.pbxproj
@@ -642,7 +642,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Share/KeyVoxShare.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Share/Info.plist";
@@ -677,7 +677,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Share/KeyVoxShare.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Share/Info.plist";
@@ -711,7 +711,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Keyboard/KeyVoxKeyboard.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Keyboard/Info.plist";
@@ -745,7 +745,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Keyboard/KeyVoxKeyboard.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Keyboard/Info.plist";
@@ -782,7 +782,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Widget/KeyVox Widget.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Widget/Info.plist";
@@ -819,7 +819,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Widget/KeyVox Widget.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Widget/Info.plist";
@@ -979,7 +979,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox iOS/KeyVoxiOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1024,7 +1024,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox iOS/KeyVoxiOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/iOS/KeyVox iOS/App/AppLaunchRouteStore.swift
+++ b/iOS/KeyVox iOS/App/AppLaunchRouteStore.swift
@@ -44,14 +44,11 @@ final class AppLaunchRouteStore: ObservableObject {
     }
 
     private func stage(route: KeyVoxURLRoute?) {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            pendingURLRoute = route
-            initialURLRoute = route
-            hasResolvedInitialLaunchContext = true
-            if route != nil {
-                routeEventSequence &+= 1
-            }
+        pendingURLRoute = route
+        initialURLRoute = route
+        hasResolvedInitialLaunchContext = true
+        if route != nil {
+            routeEventSequence &+= 1
         }
     }
 

--- a/iOS/KeyVox iOS/App/AppLaunchRouteStore.swift
+++ b/iOS/KeyVox iOS/App/AppLaunchRouteStore.swift
@@ -1,4 +1,5 @@
 import Combine
+import CoreFoundation
 import Foundation
 
 @MainActor
@@ -7,17 +8,21 @@ final class AppLaunchRouteStore: ObservableObject {
 
     @Published private(set) var initialURLRoute: KeyVoxURLRoute?
     @Published private(set) var hasResolvedInitialLaunchContext = false
+    @Published private(set) var routeEventSequence: UInt64 = 0
     private var pendingURLRoute: KeyVoxURLRoute?
+
+    init() {
+        registerPendingRouteObserver()
+    }
+
+    deinit {
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterRemoveEveryObserver(center, Unmanaged.passUnretained(self).toOpaque())
+    }
 
     func resolveInitialLaunchURL(_ url: URL?) {
         let route = url.flatMap(KeyVoxURLRoute.init(url:))
-
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            pendingURLRoute = route
-            initialURLRoute = route
-            hasResolvedInitialLaunchContext = true
-        }
+        stage(route: route)
     }
 
     func consumeInitialURLRoute() -> KeyVoxURLRoute? {
@@ -26,9 +31,51 @@ final class AppLaunchRouteStore: ObservableObject {
         return route
     }
 
+    func consumePendingShortcutRouteIfNeeded() {
+        let route = KeyVoxIPCBridge.consumePendingURLRoute().flatMap(KeyVoxURLRoute.init(url:))
+        guard let route else { return }
+        stage(route: route)
+    }
+
     func clearInitialPresentationRoute() {
         Task { @MainActor [weak self] in
             self?.initialURLRoute = nil
+        }
+    }
+
+    private func stage(route: KeyVoxURLRoute?) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            pendingURLRoute = route
+            initialURLRoute = route
+            hasResolvedInitialLaunchContext = true
+            if route != nil {
+                routeEventSequence &+= 1
+            }
+        }
+    }
+
+    private func registerPendingRouteObserver() {
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterAddObserver(
+            center,
+            Unmanaged.passUnretained(self).toOpaque(),
+            Self.notificationCallback,
+            KeyVoxIPCBridge.Notification.pendingURLRouteReady as CFString,
+            nil,
+            .deliverImmediately
+        )
+    }
+
+    private func handlePendingRouteNotification() {
+        consumePendingShortcutRouteIfNeeded()
+    }
+
+    nonisolated private static let notificationCallback: CFNotificationCallback = { _, observer, _, _, _ in
+        guard let observer else { return }
+        let store = Unmanaged<AppLaunchRouteStore>.fromOpaque(observer).takeUnretainedValue()
+        Task { @MainActor in
+            store.handlePendingRouteNotification()
         }
     }
 }

--- a/iOS/KeyVox iOS/App/AppServiceRegistry.swift
+++ b/iOS/KeyVox iOS/App/AppServiceRegistry.swift
@@ -95,6 +95,7 @@ final class AppServiceRegistry {
         )
         let postProcessor = TranscriptionPostProcessor()
         let keyboardBridge = KeyVoxKeyboardBridge()
+        var ttsManagerRef: TTSManager?
         let recorder = AudioRecorder(
             preferBuiltInMicrophoneProvider: { [weak settingsStore] in
                 settingsStore?.preferBuiltInMicrophone ?? true
@@ -140,6 +141,9 @@ final class AppServiceRegistry {
             sessionDisableTimingProvider: { [weak settingsStore] in
                 settingsStore?.sessionDisableTiming ?? .fiveMinutes
             },
+            isTTSPlaybackActiveProvider: {
+                ttsManagerRef?.isActive ?? false
+            },
             sessionDisableTimingPublisher: settingsStore.$sessionDisableTiming.eraseToAnyPublisher(),
             sessionPolicy: .default
         )
@@ -171,6 +175,7 @@ final class AppServiceRegistry {
             appTabRouter: appTabRouter,
             ttsPurchaseGate: ttsPurchaseController
         )
+        ttsManagerRef = ttsManager
         let iCloudSyncCoordinator = CloudSyncCoordinator(
             settingsStore: settingsStore,
             dictionaryStore: dictionaryStore,

--- a/iOS/KeyVox iOS/App/KeyVoxIPCBridge.swift
+++ b/iOS/KeyVox iOS/App/KeyVoxIPCBridge.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import Foundation
 
 enum KeyVoxIPCLiveMeterSignalState: UInt8, Equatable {
@@ -92,6 +93,7 @@ enum KeyVoxIPCBridge {
         static let ttsFinished = "com.cueit.keyvox.ttsFinished"
         static let ttsStopped = "com.cueit.keyvox.ttsStopped"
         static let ttsFailed = "com.cueit.keyvox.ttsFailed"
+        static let pendingURLRouteReady = "com.cueit.keyvox.pendingURLRouteReady"
     }
     
     static let heartbeatFreshnessWindow: TimeInterval = 5 // 5 seconds (active heartbeat is 1Hz)
@@ -168,6 +170,11 @@ enum KeyVoxIPCBridge {
         #endif
     }
 
+    private static func postDarwinNotification(named name: String) {
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterPostNotification(center, CFNotificationName(name as CFString), nil, nil, true)
+    }
+
     static func clearTTSState() {
         defaults?.removeObject(forKey: Key.ttsState)
         defaults?.removeObject(forKey: Key.ttsStateTimestamp)
@@ -211,6 +218,7 @@ enum KeyVoxIPCBridge {
 
     static func writePendingURLRoute(_ urlString: String) {
         defaults?.set(urlString, forKey: Key.pendingURLRoute)
+        postDarwinNotification(named: Notification.pendingURLRouteReady)
     }
 
     static func consumePendingURLRoute() -> URL? {

--- a/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
+++ b/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
@@ -83,10 +83,10 @@ struct KeyVoxApp: App {
                     Self.log("scenePhase=\(String(describing: newPhase))")
                     switch newPhase {
                     case .active:
+                        appLaunchRouteStore.consumePendingShortcutRouteIfNeeded()
                         let initialRoute = appLaunchRouteStore.consumeInitialURLRoute()
-                        let pendingShortcutRoute = KeyVoxIPCBridge.consumePendingURLRoute().flatMap(KeyVoxURLRoute.init(url:))
-                        if let selectedRoute = pendingShortcutRoute ?? initialRoute {
-                            handle(route: selectedRoute, shouldPresentReturnToHost: true)
+                        if let initialRoute {
+                            handle(route: initialRoute, shouldPresentReturnToHost: true)
                         }
                         transcriptionManager.handleAppDidBecomeActive()
                         ttsManager.handleAppDidBecomeActive()
@@ -120,6 +120,13 @@ struct KeyVoxApp: App {
                     } else {
                         urlRouter.handle(url: url)
                     }
+                }
+                .onChange(of: appLaunchRouteStore.routeEventSequence, initial: false) { _, _ in
+                    guard scenePhase == .active,
+                          let stagedRoute = appLaunchRouteStore.consumeInitialURLRoute() else {
+                        return
+                    }
+                    handle(route: stagedRoute, shouldPresentReturnToHost: false)
                 }
         }
     }

--- a/iOS/KeyVox iOS/Core/Audio/AudioRecorder+Session.swift
+++ b/iOS/KeyVox iOS/Core/Audio/AudioRecorder+Session.swift
@@ -244,7 +244,7 @@ extension AudioRecorder {
         KeyVoxIPCBridge.setSessionActive()
     }
 
-    func stopMonitoring() throws {
+    func stopMonitoring(keepAudioSessionActive: Bool = false) throws {
         guard isMonitoring else { return }
         guard !isRecording else {
             throw AudioRecorderError.monitoringShutdownWhileRecording
@@ -252,10 +252,12 @@ extension AudioRecorder {
 
         invalidateAudioEngine(clearSessionActive: false)
 
-        do {
-            try audioSession.setActive(false)
-        } catch {
-            throw AudioRecorderError.engineStopFailed(underlying: error)
+        if keepAudioSessionActive == false {
+            do {
+                try audioSession.setActive(false)
+            } catch {
+                throw AudioRecorderError.engineStopFailed(underlying: error)
+            }
         }
 
         isMonitoring = false

--- a/iOS/KeyVox iOS/Core/Audio/AudioRecorder.swift
+++ b/iOS/KeyVox iOS/Core/Audio/AudioRecorder.swift
@@ -22,7 +22,7 @@ protocol AudioRecording: AnyObject {
     func startRecording() async throws
     func stopRecording() async -> StoppedCapture
     func ensureEngineRunning() throws
-    func stopMonitoring() throws
+    func stopMonitoring(keepAudioSessionActive: Bool) throws
     func cancelCurrentUtterance()
 }
 

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
@@ -1,10 +1,9 @@
 import AVFoundation
 import Foundation
-import UIKit
 
 extension TTSManager {
     func startPlaybackFromClipboard() async {
-        guard let text = UIPasteboard.general.string?.trimmingCharacters(in: .whitespacesAndNewlines),
+        guard let text = clipboardTextProvider()?.trimmingCharacters(in: .whitespacesAndNewlines),
               text.isEmpty == false else {
             return
         }

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
@@ -29,6 +29,7 @@ final class TTSManager: ObservableObject {
     let playbackCoordinator: TTSPlaybackCoordinator
     let purchaseGate: any TTSPurchaseGating
     let replayCache: TTSReplayCache
+    let clipboardTextProvider: @MainActor () -> String?
     let effectiveVoiceProvider: @MainActor () -> AppSettingsStore.TTSVoice
     let onNewGenerationPlaybackStarted: @MainActor () -> Void
     var activeRequest: KeyVoxTTSRequest?
@@ -82,6 +83,7 @@ final class TTSManager: ObservableObject {
         playbackCoordinator: TTSPlaybackCoordinator,
         purchaseGate: any TTSPurchaseGating,
         replayCache: TTSReplayCache? = nil,
+        clipboardTextProvider: (@MainActor () -> String?)? = nil,
         effectiveVoiceProvider: (@MainActor () -> AppSettingsStore.TTSVoice)? = nil,
         onNewGenerationPlaybackStarted: (@MainActor () -> Void)? = nil
     ) {
@@ -92,6 +94,7 @@ final class TTSManager: ObservableObject {
         self.playbackCoordinator = playbackCoordinator
         self.purchaseGate = purchaseGate
         self.replayCache = replayCache ?? TTSReplayCache()
+        self.clipboardTextProvider = clipboardTextProvider ?? { UIPasteboard.general.string }
         self.effectiveVoiceProvider = effectiveVoiceProvider ?? { settingsStore.ttsVoice }
         self.onNewGenerationPlaybackStarted = onNewGenerationPlaybackStarted ?? {}
 

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Lifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Lifecycle.swift
@@ -161,6 +161,13 @@ extension TTSPlaybackCoordinator {
             return
         }
 
+        do {
+            try ensureAudioEngineReadyForPlayback(context: "resume")
+        } catch {
+            handleFailure(error)
+            return
+        }
+
         playerNode.play()
         isPaused = false
         isWaitingForResumeBuffer = false
@@ -312,6 +319,14 @@ extension TTSPlaybackCoordinator {
             try? session.overrideOutputAudioPort(isUsingBuiltInReceiver ? .speaker : .none)
         }
         try session.setActive(true)
+    }
+
+    func ensureAudioEngineReadyForPlayback(context: String) throws {
+        if audioEngine.isRunning { return }
+
+        Self.log("Audio engine was stopped before playback context=\(context); reconfiguring session and restarting engine.")
+        try configureAudioSession()
+        try audioEngine.start()
     }
 
     func finishIfPossible() {

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Progress.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Progress.swift
@@ -59,6 +59,13 @@ extension TTSPlaybackCoordinator {
         )
         guard queuedSampleCount >= requiredSamples || (isFinishing && queuedSampleCount > 0) else { return }
 
+        do {
+            try ensureAudioEngineReadyForPlayback(context: "resumeIfBufferedEnough")
+        } catch {
+            handleFailure(error)
+            return
+        }
+
         playerNode.play()
         isPaused = false
         isWaitingForResumeBuffer = false

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Scheduling.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Scheduling.swift
@@ -197,6 +197,12 @@ extension TTSPlaybackCoordinator {
 
         let startPlayback = { [weak self] in
             guard let self else { return }
+            do {
+                try self.ensureAudioEngineReadyForPlayback(context: "startupBuffer")
+            } catch {
+                self.handleFailure(error)
+                return
+            }
             self.playerNode.play()
             self.startPlaybackProgressTimer()
             self.onPreparationProgress?(self.activeSilentStartSampleCount, self.activeSilentStartSampleCount, true)

--- a/iOS/KeyVox iOS/Core/Transcription/TranscriptionManager+SessionLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/Transcription/TranscriptionManager+SessionLifecycle.swift
@@ -112,7 +112,7 @@ extension TranscriptionManager {
         cancelUtteranceSafetyWatchdog()
 
         do {
-            try recorder.stopMonitoring()
+            try recorder.stopMonitoring(keepAudioSessionActive: isTTSPlaybackActiveProvider())
             isSessionActive = false
             sessionDisablePending = false
             sessionExpirationDate = nil

--- a/iOS/KeyVox iOS/Core/Transcription/TranscriptionManager.swift
+++ b/iOS/KeyVox iOS/Core/Transcription/TranscriptionManager.swift
@@ -36,6 +36,7 @@ final class TranscriptionManager: ObservableObject {
     private let listFormattingEnabledProvider: () -> Bool
     private let capsLockEnabledProvider: () -> Bool
     private let sessionDisableTimingProvider: (() -> SessionDisableTiming)?
+    let isTTSPlaybackActiveProvider: () -> Bool
     let sessionPolicy: SessionPolicy
 
     private var cancellables = Set<AnyCancellable>()
@@ -83,6 +84,7 @@ final class TranscriptionManager: ObservableObject {
         listFormattingEnabledProvider: @escaping () -> Bool = { true },
         capsLockEnabledProvider: @escaping () -> Bool = { false },
         sessionDisableTimingProvider: (() -> SessionDisableTiming)? = nil,
+        isTTSPlaybackActiveProvider: @escaping () -> Bool = { false },
         sessionDisableTimingPublisher: AnyPublisher<SessionDisableTiming, Never> = Empty().eraseToAnyPublisher(),
         sessionPolicy: SessionPolicy = .default
     ) {
@@ -109,6 +111,7 @@ final class TranscriptionManager: ObservableObject {
         self.listFormattingEnabledProvider = listFormattingEnabledProvider
         self.capsLockEnabledProvider = capsLockEnabledProvider
         self.sessionDisableTimingProvider = sessionDisableTimingProvider
+        self.isTTSPlaybackActiveProvider = isTTSPlaybackActiveProvider
         self.sessionPolicy = sessionPolicy
 
         bindDictionaryState()

--- a/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
+++ b/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIKit
 import KeyVoxCore
 import KeyVoxTTS
 import Testing
@@ -43,13 +42,7 @@ struct KeyVoxURLRouterTests {
 
     @Test func startTTSRoutePresentsUnlockWhenDailyLimitIsExhausted() async throws {
         let harness = try makeHarness(isTTSUnlocked: false, remainingFreeTTSSpeaksToday: 0)
-        let originalPasteboardString = UIPasteboard.general.string
-        defer {
-            UIPasteboard.general.string = originalPasteboardString
-            harness.cleanup()
-        }
-
-        UIPasteboard.general.string = "Test clipboard speech"
+        defer { harness.cleanup() }
 
         let router = KeyVoxURLRouter(
             transcriptionManager: harness.manager,
@@ -116,7 +109,8 @@ struct KeyVoxURLRouterTests {
             keyboardBridge: KeyVoxKeyboardBridge(),
             engine: StubTTSEngine(),
             playbackCoordinator: TTSPlaybackCoordinator(),
-            purchaseGate: purchaseGate
+            purchaseGate: purchaseGate,
+            clipboardTextProvider: { "Test clipboard speech" }
         )
         let audioModeCoordinator = AudioModeCoordinator(
             transcriptionManager: manager,

--- a/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
+++ b/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
@@ -219,7 +219,7 @@ private final class StubAudioRecorder: AudioRecording {
         isMonitoring = true
     }
 
-    func stopMonitoring() throws {
+    func stopMonitoring(keepAudioSessionActive: Bool) throws {
         isMonitoring = false
     }
 

--- a/iOS/KeyVoxiOSTests/Core/Transcription/TranscriptionManagerTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/Transcription/TranscriptionManagerTests.swift
@@ -50,6 +50,7 @@ struct TranscriptionManagerTests {
         #expect(harness.manager.isSessionActive == false)
         #expect(harness.manager.sessionDisablePending == false)
         #expect(harness.recorder.stopMonitoringCallCount == 1)
+        #expect(harness.recorder.lastStopMonitoringKeepAudioSessionActive == false)
         #expect(harness.manager.sessionExpirationDate == nil)
     }
 
@@ -71,6 +72,7 @@ struct TranscriptionManagerTests {
         #expect(harness.recorder.cancelCurrentUtteranceCallCount == 1)
         #expect(harness.transcriptionService.transcribeCallCount == 0)
         #expect(harness.recorder.stopMonitoringCallCount == 1)
+        #expect(harness.recorder.lastStopMonitoringKeepAudioSessionActive == false)
     }
 
     @Test func disableSessionWhileTranscribingCancelsImmediatelyAndDisables() async throws {
@@ -97,6 +99,7 @@ struct TranscriptionManagerTests {
         #expect(harness.manager.sessionDisablePending == false)
         #expect(harness.transcriptionService.cancelCallCount == 1)
         #expect(harness.recorder.stopMonitoringCallCount == 1)
+        #expect(harness.recorder.lastStopMonitoringKeepAudioSessionActive == false)
     }
 
     @Test func idleTimeoutDisablesActiveIdleSession() async throws {
@@ -109,6 +112,7 @@ struct TranscriptionManagerTests {
 
         #expect(harness.manager.isSessionActive == false)
         #expect(harness.recorder.stopMonitoringCallCount == 1)
+        #expect(harness.recorder.lastStopMonitoringKeepAudioSessionActive == false)
     }
 
     @Test func idleTimeoutIsCancelledWhileRecordingAndRearmsAfterCompletion() async throws {
@@ -130,6 +134,7 @@ struct TranscriptionManagerTests {
 
         #expect(harness.manager.isSessionActive == false)
         #expect(harness.recorder.stopMonitoringCallCount == 1)
+        #expect(harness.recorder.lastStopMonitoringKeepAudioSessionActive == false)
     }
 
     @Test func enableSessionWithPermissionDeniedSurfacesError() async throws {
@@ -364,6 +369,7 @@ struct TranscriptionManagerTests {
 
         #expect(harness.manager.isSessionActive == false)
         #expect(harness.recorder.stopMonitoringCallCount == 1)
+        #expect(harness.recorder.lastStopMonitoringKeepAudioSessionActive == false)
     }
 
     @Test func immediatelyDisablesSessionAfterEmptyOutput() async throws {
@@ -377,6 +383,7 @@ struct TranscriptionManagerTests {
 
         #expect(harness.manager.isSessionActive == false)
         #expect(harness.recorder.stopMonitoringCallCount == 1)
+        #expect(harness.recorder.lastStopMonitoringKeepAudioSessionActive == false)
     }
 
     @Test func immediatelyDisablesSessionAfterMissingModel() async throws {
@@ -390,6 +397,22 @@ struct TranscriptionManagerTests {
 
         #expect(harness.manager.isSessionActive == false)
         #expect(harness.recorder.stopMonitoringCallCount == 1)
+        #expect(harness.recorder.lastStopMonitoringKeepAudioSessionActive == false)
+    }
+
+    @Test func immediatelyDisablesSessionAfterSuccessfulTranscriptionButKeepsAudioSessionActiveForTTS() async throws {
+        let harness = try makeHarness(sessionDisableTiming: .immediately, isTTSPlaybackActive: true)
+        defer { harness.cleanup() }
+        harness.recorder.stoppedCapture = acceptedCapture()
+        harness.transcriptionService.nextResult = TranscriptionProviderResult(text: "hello world", languageCode: "en")
+
+        await harness.manager.performStartRecordingCommand()
+        await harness.manager.performStopRecordingCommand()
+        await settleAsyncManagerWork()
+
+        #expect(harness.manager.isSessionActive == false)
+        #expect(harness.recorder.stopMonitoringCallCount == 1)
+        #expect(harness.recorder.lastStopMonitoringKeepAudioSessionActive == true)
     }
 
     @Test func changingDisableTimingWhileActiveAndIdleRearmsTimeout() async throws {
@@ -418,6 +441,7 @@ struct TranscriptionManagerTests {
 
         #expect(harness.manager.isSessionActive == false)
         #expect(harness.recorder.stopMonitoringCallCount == 1)
+        #expect(harness.recorder.lastStopMonitoringKeepAudioSessionActive == false)
     }
 
     @Test func changingDisableTimingWhileRecordingAppliesAfterUtteranceCompletes() async throws {
@@ -441,6 +465,7 @@ struct TranscriptionManagerTests {
 
         #expect(harness.manager.isSessionActive == false)
         #expect(harness.recorder.stopMonitoringCallCount == 1)
+        #expect(harness.recorder.lastStopMonitoringKeepAudioSessionActive == false)
     }
 
     @Test func repeatedStartWhileTranscribingIsIgnored() async throws {
@@ -575,6 +600,7 @@ struct TranscriptionManagerTests {
         serviceShouldSuspend: Bool = false,
         capsLockEnabled: Bool = false,
         sessionDisableTiming: SessionDisableTiming? = nil,
+        isTTSPlaybackActive: Bool = false,
         sessionPolicy: SessionPolicy = .default
     ) throws -> ManagerHarness {
         let tempRootURL = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -624,6 +650,7 @@ struct TranscriptionManagerTests {
             sessionDisableTimingProvider: sessionDisableTimingSubject.map { subject in
                 { subject.value }
             },
+            isTTSPlaybackActiveProvider: { isTTSPlaybackActive },
             sessionDisableTimingPublisher: sessionDisableTimingSubject?.eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher(),
             sessionPolicy: sessionPolicy
         )
@@ -768,6 +795,7 @@ private final class StubAudioRecorder: AudioRecording {
     var enableMonitoringCallCount = 0
     var ensureEngineRunningCallCount = 0
     var stopMonitoringCallCount = 0
+    var lastStopMonitoringKeepAudioSessionActive: Bool?
     var cancelCurrentUtteranceCallCount = 0
     var startError: Error?
     var enableMonitoringError: Error?
@@ -829,6 +857,7 @@ private final class StubAudioRecorder: AudioRecording {
 
     func stopMonitoring(keepAudioSessionActive: Bool) throws {
         stopMonitoringCallCount += 1
+        lastStopMonitoringKeepAudioSessionActive = keepAudioSessionActive
         isMonitoring = false
     }
 

--- a/iOS/KeyVoxiOSTests/Core/Transcription/TranscriptionManagerTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/Transcription/TranscriptionManagerTests.swift
@@ -827,7 +827,7 @@ private final class StubAudioRecorder: AudioRecording {
         isMonitoring = true
     }
 
-    func stopMonitoring() throws {
+    func stopMonitoring(keepAudioSessionActive: Bool) throws {
         stopMonitoringCallCount += 1
         isMonitoring = false
     }


### PR DESCRIPTION
## Summary

This branch fixes three iOS regressions around TTS startup and lifecycle handling: shortcut-triggered copied-text playback now routes immediately and reliably, dictation warm-session shutdown no longer tears down active TTS playback, and AirPods route handoff no longer leaves new TTS sessions stuck before audible playback begins.

## What This Branch Changes

This branch updates the app-intent and shortcut route handoff so pending URL routes are announced through a Darwin notification, staged in `AppLaunchRouteStore`, and handled immediately even when KeyVox is already active. That removes the delayed or second-try behavior from the official KeyVox Speak shortcut path.

It updates the dictation session shutdown path so expiring or disabling a warm dictation session can keep the shared audio session alive while TTS playback is active. That prevents session teardown from cutting off live speech.

It updates the TTS playback coordinator so a stopped `AVAudioEngine` is reasserted and restarted immediately before startup playback, buffered resume, or normal resume. That fixes the AirPods handoff regression where a brand-new TTS session could finish generation but never begin audible playback after audio switched away to the Mac and back.

It also cleans up the router TTS test so it no longer depends on the real system pasteboard, using an injected clipboard provider instead of `UIPasteboard.general` and avoiding the recurring paste permission prompt during test runs.

## Key Files

- `iOS/KeyVox iOS/App/AppLaunchRouteStore.swift`
- `iOS/KeyVox iOS/App/KeyVoxIPCBridge.swift`
- `iOS/KeyVox iOS/App/KeyVoxiOSApp.swift`
- `iOS/KeyVox iOS/Core/Audio/AudioRecorder.swift`
- `iOS/KeyVox iOS/Core/Audio/AudioRecorder+Session.swift`
- `iOS/KeyVox iOS/Core/Transcription/TranscriptionManager.swift`
- `iOS/KeyVox iOS/Core/Transcription/TranscriptionManager+SessionLifecycle.swift`
- `iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Lifecycle.swift`
- `iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Progress.swift`
- `iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Scheduling.swift`
- `iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift`
- `iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift`
- `iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift`
- `iOS/KeyVoxiOSTests/Core/Transcription/TranscriptionManagerTests.swift`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced audio engine reliability checks during TTS playback to ensure stable playback state.
  * Improved inter-process communication for shortcut URL routing.

* **Bug Fixes**
  * Fixed audio session handling to properly coordinate between transcription and TTS playback.
  * Improved audio engine state verification during playback resumption and startup.

* **Chores**
  * Updated build version to Build 14.
  * Removed unnecessary dependencies from TTS playback module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->