### PR TITLE
feat(ios-tts): simplify Alba onboarding and stabilize Speak intro flow

### DIFF
--- a/iOS/KeyVox iOS/App/AppLaunchRouteStore.swift
+++ b/iOS/KeyVox iOS/App/AppLaunchRouteStore.swift
@@ -31,8 +31,12 @@ final class AppLaunchRouteStore: ObservableObject {
         return route
     }
 
+    func consumePendingShortcutRoute() -> KeyVoxURLRoute? {
+        KeyVoxIPCBridge.consumePendingURLRoute().flatMap(KeyVoxURLRoute.init(url:))
+    }
+
     func consumePendingShortcutRouteIfNeeded() {
-        let route = KeyVoxIPCBridge.consumePendingURLRoute().flatMap(KeyVoxURLRoute.init(url:))
+        let route = consumePendingShortcutRoute()
         guard let route else { return }
         stage(route: route)
     }
@@ -45,10 +49,13 @@ final class AppLaunchRouteStore: ObservableObject {
 
     private func stage(route: KeyVoxURLRoute?) {
         pendingURLRoute = route
-        initialURLRoute = route
-        hasResolvedInitialLaunchContext = true
-        if route != nil {
-            routeEventSequence &+= 1
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.initialURLRoute = route
+            self.hasResolvedInitialLaunchContext = true
+            if route != nil {
+                self.routeEventSequence &+= 1
+            }
         }
     }
 

--- a/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
+++ b/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
@@ -83,8 +83,8 @@ struct KeyVoxApp: App {
                     Self.log("scenePhase=\(String(describing: newPhase))")
                     switch newPhase {
                     case .active:
-                        appLaunchRouteStore.consumePendingShortcutRouteIfNeeded()
-                        let initialRoute = appLaunchRouteStore.consumeInitialURLRoute()
+                        let initialRoute = appLaunchRouteStore.consumePendingShortcutRoute()
+                            ?? appLaunchRouteStore.consumeInitialURLRoute()
                         if let initialRoute {
                             handle(route: initialRoute, shouldPresentReturnToHost: true)
                         }

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakInstallCardView.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakInstallCardView.swift
@@ -158,12 +158,7 @@ struct KeyVoxSpeakInstallCardView: View {
                 }
             }
 
-            switch activeInstallState {
-            case .downloading(let progress), .installing(let progress):
-                ModelDownloadProgress(progress: progress, showLabel: false)
-            case .failed, .notInstalled, .ready, .none:
-                EmptyView()
-            }
+            downloadProgressView
 
             if let errorText {
                 Text(errorText)
@@ -205,6 +200,16 @@ struct KeyVoxSpeakInstallCardView: View {
                         .stroke(Color.white.opacity(0.08), lineWidth: 1)
                 )
         )
+    }
+
+    @ViewBuilder
+    private var downloadProgressView: some View {
+        switch activeInstallState {
+        case .downloading(let progress), .installing(let progress):
+            ModelDownloadProgress(progress: progress, showLabel: false)
+        case .failed, .notInstalled, .ready, .none:
+            EmptyView()
+        }
     }
 
     private func progressText(for state: PocketTTSInstallState) -> String? {

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakInstallCardView.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakInstallCardView.swift
@@ -1,14 +1,7 @@
 import SwiftUI
 
 struct KeyVoxSpeakInstallCardView: View {
-    fileprivate enum InstallStep: Int, CaseIterable, Identifiable {
-        case sharedModel
-        case albaVoice
-
-        var id: Int { rawValue }
-    }
-
-    static let installStepCount = InstallStep.allCases.count
+    static let installStepCount = 1
 
     @Environment(\.appHaptics) private var appHaptics
     @EnvironmentObject private var pocketTTSModelManager: PocketTTSModelManager
@@ -36,7 +29,7 @@ struct KeyVoxSpeakInstallCardView: View {
                         .font(.appFont(17, variant: .medium))
                         .foregroundStyle(.white)
 
-                    Text("Download the PocketTTS engine and the Alba voice you heard on the first page.")
+                    Text("Install Alba and KeyVox will handle the PocketTTS engine automatically.")
                         .font(.appFont(14, variant: .light))
                         .foregroundStyle(.white.opacity(0.68))
                         .fixedSize(horizontal: false, vertical: true)
@@ -46,13 +39,11 @@ struct KeyVoxSpeakInstallCardView: View {
             }
 
             VStack(spacing: 12) {
-                ForEach(Array(InstallStep.allCases.enumerated()), id: \.element) { index, step in
-                    installStepRow(step)
-                        .opacity(index < revealedStepCount ? 1 : 0)
-                        .offset(y: index < revealedStepCount ? 0 : 10)
-                        .allowsHitTesting(index < revealedStepCount)
-                        .accessibilityHidden(index >= revealedStepCount)
-                }
+                installRow
+                    .opacity(revealedStepCount > 0 ? 1 : 0)
+                    .offset(y: revealedStepCount > 0 ? 0 : 10)
+                    .allowsHitTesting(revealedStepCount > 0)
+                    .accessibilityHidden(revealedStepCount == 0)
             }
 
             if showsUnlockDetails {
@@ -97,42 +88,49 @@ struct KeyVoxSpeakInstallCardView: View {
         return false
     }
 
-    private func installState(for step: InstallStep) -> PocketTTSInstallState {
-        switch step {
-        case .sharedModel:
-            return sharedModelState
-        case .albaVoice:
+    private var activeInstallState: PocketTTSInstallState? {
+        if isSharedModelReady == false {
+            switch sharedModelState {
+            case .downloading, .installing:
+                return sharedModelState
+            case .notInstalled, .failed, .ready:
+                break
+            }
+        }
+
+        switch albaVoiceState {
+        case .downloading, .installing:
             return albaVoiceState
+        case .notInstalled, .failed, .ready:
+            return nil
         }
     }
 
-    private func installStepRow(_ step: InstallStep) -> some View {
-        let state = installState(for: step)
-
+    private var installRow: some View {
         return VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center, spacing: 12) {
                 HStack(alignment: .center, spacing: 10) {
                     Circle()
-                        .fill(step.isReady(in: pocketTTSModelManager) ? Color.green : AppTheme.accent.opacity(0.32))
+                        .fill(pocketTTSReadyForAlba ? Color.green : AppTheme.accent.opacity(0.32))
                         .frame(width: 22, height: 22)
                         .overlay {
-                            if step.isReady(in: pocketTTSModelManager) {
+                            if pocketTTSReadyForAlba {
                                 Image(systemName: "checkmark")
                                     .font(.system(size: 10, weight: .heavy))
                                     .foregroundStyle(.black)
                             } else {
-                                Text("\(step.rawValue + 1)")
+                                Text("1")
                                     .font(.appFont(12, variant: .medium))
                                     .foregroundStyle(.white)
                             }
                         }
 
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(step.title)
+                        Text("Model + Voice")
                             .font(.appFont(15, variant: .medium))
                             .foregroundStyle(.white)
 
-                        Text(step.statusText(in: pocketTTSModelManager))
+                        Text(installStatusText)
                             .font(.appFont(13, variant: .light))
                             .foregroundStyle(.white.opacity(0.62))
                             .fixedSize(horizontal: false, vertical: true)
@@ -140,34 +138,37 @@ struct KeyVoxSpeakInstallCardView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-                if let percentageText = progressText(for: state) {
+                if let activeInstallState,
+                   let percentageText = progressText(for: activeInstallState) {
                     Text(percentageText)
                         .font(.appFont(13, variant: .medium))
                         .foregroundStyle(.yellow)
-                } else if let buttonTitle = actionTitle(for: state) {
+                } else if let buttonTitle = actionTitle {
                     AppActionButton(
                         title: buttonTitle,
                         style: .primary,
                         size: .compact,
                         fontSize: 14,
-                        isEnabled: actionEnabled(for: step),
+                        isEnabled: isActionEnabled,
                         action: {
                             appHaptics.light()
-                            performAction(for: step, state: state)
+                            performAction()
                         }
                     )
                 }
             }
 
-            switch state {
+            switch activeInstallState {
             case .downloading(let progress), .installing(let progress):
                 ModelDownloadProgress(progress: progress, showLabel: false)
-            case .failed(let message):
-                Text(message)
+            case .failed, .notInstalled, .ready, .none:
+                EmptyView()
+            }
+
+            if let errorText {
+                Text(errorText)
                     .font(.appFont(12))
                     .foregroundStyle(.red)
-            case .notInstalled, .ready:
-                EmptyView()
             }
         }
         .padding(.horizontal, 14)
@@ -215,111 +216,89 @@ struct KeyVoxSpeakInstallCardView: View {
         }
     }
 
-    private func actionTitle(for state: PocketTTSInstallState) -> String? {
-        switch state {
-        case .notInstalled:
-            return "Install"
-        case .failed:
-            return "Repair"
-        case .downloading, .installing, .ready:
+    private var actionTitle: String? {
+        if pocketTTSReadyForAlba {
             return nil
         }
-    }
 
-    private func actionEnabled(for step: InstallStep) -> Bool {
-        switch step {
-        case .sharedModel:
-            return pocketTTSModelManager.isBusyInstallingAnotherTarget(sharedModel: true) == false
-        case .albaVoice:
-            return isSharedModelReady
-                && pocketTTSModelManager.isBusyInstallingAnotherTarget(voice: .alba) == false
+        if case .failed = sharedModelState {
+            return "Repair"
         }
-    }
 
-    private func performAction(for step: InstallStep, state: PocketTTSInstallState) {
-        switch step {
-        case .sharedModel:
-            switch state {
-            case .notInstalled:
-                pocketTTSModelManager.downloadSharedModel()
-            case .failed:
-                pocketTTSModelManager.repairSharedModelIfNeeded()
-            case .downloading, .installing, .ready:
-                break
-            }
-        case .albaVoice:
-            guard isSharedModelReady else { return }
-            if settingsStore.ttsVoice != .alba {
-                settingsStore.ttsVoice = .alba
-            }
-            switch state {
-            case .notInstalled:
-                pocketTTSModelManager.downloadVoice(.alba)
-            case .failed:
-                pocketTTSModelManager.repairVoiceIfNeeded(.alba)
-            case .downloading, .installing, .ready:
-                break
-            }
+        if case .failed = albaVoiceState {
+            return "Repair"
         }
-    }
-}
 
-fileprivate extension KeyVoxSpeakInstallCardView.InstallStep {
-    var title: String {
-        switch self {
-        case .sharedModel:
-            return "PocketTTS CoreML"
-        case .albaVoice:
-            return "Alba Voice"
+        if activeInstallState != nil {
+            return nil
         }
+
+        return "Install"
     }
 
-    func isReady(in modelManager: PocketTTSModelManager) -> Bool {
-        switch self {
-        case .sharedModel:
-            if case .ready = modelManager.sharedModelInstallState {
-                return true
-            }
-            return false
-        case .albaVoice:
-            if case .ready = modelManager.installState(for: .alba) {
-                return true
-            }
-            return false
+    private var isActionEnabled: Bool {
+        pocketTTSModelManager.isBusyInstallingAnotherTarget(voice: .alba) == false
+            && pocketTTSModelManager.isBusyInstallingAnotherTarget(sharedModel: true) == false
+    }
+
+    private var installStatusText: String {
+        if pocketTTSReadyForAlba {
+            return "Alba is installed, selected, and ready for KeyVox Speak."
         }
-    }
 
-    func statusText(in modelManager: PocketTTSModelManager) -> String {
-        switch self {
-        case .sharedModel:
-            switch modelManager.sharedModelInstallState {
+        switch sharedModelState {
+        case .notInstalled:
+            return "Install Alba and KeyVox will download PocketTTS first, then the Alba voice (~661 MB total)."
+        case .downloading:
+            return "Downloading the PocketTTS engine before installing Alba."
+        case .installing:
+            return "Installing the PocketTTS engine before Alba."
+        case .ready:
+            switch albaVoiceState {
             case .notInstalled:
-                return "Download the shared engine that powers KeyVox Speak (~642 MB)."
-            case .downloading:
-                return "Downloading the shared playback engine."
-            case .installing:
-                return "Installing the shared playback engine."
-            case .ready:
-                return "PocketTTS CoreML is ready."
-            case .failed:
-                return "The shared playback engine needs repair."
-            }
-        case .albaVoice:
-            switch modelManager.installState(for: .alba) {
-            case .notInstalled:
-                if case .ready = modelManager.sharedModelInstallState {
-                    return "Install Alba to match the preview voice from scene A (~19 MB)."
-                }
-                return "Install PocketTTS CoreML first, then download Alba (~19 MB)."
+                return "PocketTTS is ready. KeyVox will finish by installing Alba (~19 MB)."
             case .downloading:
                 return "Downloading Alba."
             case .installing:
                 return "Installing Alba."
             case .ready:
-                return "Alba is installed and selected."
+                return "Alba is installed, selected, and ready for KeyVox Speak."
             case .failed:
                 return "Alba needs repair."
             }
+        case .failed:
+            return "PocketTTS setup needs repair before Alba can finish installing."
         }
+    }
+
+    private var errorText: String? {
+        if case .failed(let message) = sharedModelState {
+            return message
+        }
+
+        if case .failed(let message) = albaVoiceState {
+            return message
+        }
+
+        return nil
+    }
+
+    private func performAction() {
+        if settingsStore.ttsVoice != .alba {
+            settingsStore.ttsVoice = .alba
+        }
+
+        if case .failed = sharedModelState {
+            pocketTTSModelManager.repairVoiceEnsuringSharedModel(.alba)
+            return
+        }
+
+        if case .failed = albaVoiceState {
+            pocketTTSModelManager.repairVoiceEnsuringSharedModel(.alba)
+            return
+        }
+
+        guard pocketTTSReadyForAlba == false else { return }
+        pocketTTSModelManager.installVoiceEnsuringSharedModel(.alba)
     }
 }

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSceneAView.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSceneAView.swift
@@ -4,6 +4,9 @@ struct KeyVoxSpeakSceneAView: View {
     private static let demoResourceName = "keyvox-speak-demo"
 
     @EnvironmentObject private var ttsPreviewPlayer: TTSPreviewPlayer
+
+    let isVisible: Bool
+
     @State private var logoOpacity: Double = 0
     @State private var logoScale: CGFloat = 0.7
     @State private var titleOpacity: Double = 0
@@ -55,8 +58,10 @@ struct KeyVoxSpeakSceneAView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, 24)
-        .onAppear { startEntrance() }
-        .onDisappear { stopEntrance() }
+        .onChange(of: isVisible, initial: true) { _, visible in
+            guard visible else { return }
+            startEntranceIfNeeded()
+        }
     }
 
     private var keyVoxSpeakDemoCard: some View {
@@ -123,10 +128,10 @@ struct KeyVoxSpeakSceneAView: View {
             .foregroundStyle(.yellow)
     }
 
-    private func startEntrance() {
+    private func startEntranceIfNeeded() {
         guard !hasAnimated else { return }
         hasAnimated = true
-        
+
         stopEntrance()
         logoOpacity = 0
         logoScale = 0.7

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSceneBView.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSceneBView.swift
@@ -15,6 +15,8 @@ struct KeyVoxSpeakSceneBView: View {
         AccessMethod(id: 3, icon: "link", title: "Shortcuts & Actions", subtitle: "Map to Action Button or Control Center.")
     ]
 
+    let isVisible: Bool
+
     @State private var circleOpacity: Double = 0
     @State private var circleScale: CGFloat = 0.8
     @State private var headerOpacity: Double = 0
@@ -71,8 +73,10 @@ struct KeyVoxSpeakSceneBView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, 24)
-        .onAppear { startEntrance() }
-        .onDisappear { stopEntrance() }
+        .onChange(of: isVisible, initial: true) { _, visible in
+            guard visible else { return }
+            startEntranceIfNeeded()
+        }
     }
 
     private var fastModeCard: some View {
@@ -150,10 +154,10 @@ struct KeyVoxSpeakSceneBView: View {
         )
     }
 
-    private func startEntrance() {
+    private func startEntranceIfNeeded() {
         guard !hasAnimated else { return }
         hasAnimated = true
-        
+
         stopEntrance()
         circleOpacity = 0
         circleScale = 0.8

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSceneCView.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSceneCView.swift
@@ -98,10 +98,10 @@ struct KeyVoxSpeakSceneCView: View {
         }
 
         if case .ready = sharedModelState {
-            return "PocketTTS is ready. Install Alba to match the preview voice from page one."
+            return "PocketTTS is ready. Finish installing Alba and you'll be ready to speak."
         }
 
-        return "Start by downloading PocketTTS CoreML, then install Alba."
+        return "Install Alba and KeyVox will take care of the PocketTTS setup for you."
     }
 
     private var fastModeHint: some View {

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSceneCView.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSceneCView.swift
@@ -64,15 +64,9 @@ struct KeyVoxSpeakSceneCView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, 24)
-        .onChange(of: isVisible) { _, visible in
-            if visible {
-                startEntrance()
-            } else {
-                resetEntrance()
-            }
-        }
-        .onDisappear {
-            resetEntrance()
+        .onChange(of: isVisible, initial: true) { _, visible in
+            guard visible else { return }
+            startEntranceIfNeeded()
         }
     }
 
@@ -130,7 +124,7 @@ struct KeyVoxSpeakSceneCView: View {
         .frame(maxWidth: .infinity, alignment: .center)
     }
 
-    private func startEntrance() {
+    private func startEntranceIfNeeded() {
         guard !hasAnimated else { return }
         hasAnimated = true
 
@@ -186,16 +180,5 @@ struct KeyVoxSpeakSceneCView: View {
     private func stopEntrance() {
         animationTask?.cancel()
         animationTask = nil
-    }
-
-    private func resetEntrance() {
-        stopEntrance()
-        hasAnimated = false
-        headerOpacity = 0
-        installCardOpacity = 0
-        installCardOffset = 18
-        stepRevealProgress = 0
-        fastModeHintOpacity = 0
-        footerOpacity = 0
     }
 }

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSheetView.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSheetView.swift
@@ -127,9 +127,9 @@ struct KeyVoxSpeakSheetView: View {
     private func sceneView(for scene: Scene) -> some View {
         switch scene {
         case .a:
-            KeyVoxSpeakSceneAView()
+            KeyVoxSpeakSceneAView(isVisible: selectedScene == .a)
         case .b:
-            KeyVoxSpeakSceneBView()
+            KeyVoxSpeakSceneBView(isVisible: selectedScene == .b)
         case .c:
             KeyVoxSpeakSceneCView(
                 showsUnlockDetails: showsUnlockDetails,


### PR DESCRIPTION
Simplify KeyVox Speak onboarding so Alba installs through one setup action, make the onboarding sheet animations deterministic during fast swipes, and remove launch route publishing warnings during SwiftUI updates.

## What Changed

- replace the two-step PocketTTS and Alba onboarding setup with a single combined Alba install action
- reuse the shared-model-aware Alba install and repair flow already used by the home Speak card
- update Scene C onboarding copy to match the one-step Alba setup flow
- make Speak onboarding scene animations run from visibility state instead of appear and disappear churn
- ensure each onboarding scene animates only once per sheet presentation
- prevent fast swipes from leaving onboarding pages stuck mid-animation
- stop publishing launch route state synchronously during SwiftUI scene phase updates
- preserve initial launch and pending shortcut route handling while avoiding SwiftUI view update warnings



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified PocketTTS installation flow into a single automated step.

* **Improvements**
  * Better startup routing: pending shortcut routes are prioritized for more reliable app launch behavior.
  * Scene animations are now visibility-driven, making transitions more consistent.
  * Scene views now receive explicit visibility state for clearer animation control.
  * More robust startup state updates to improve launch stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->