### PR TITLE
feat(ios-tts): improve TTS list pacing and strip colons

### DIFF
--- a/Packages/KeyVoxTTS/Sources/KeyVoxTTS/PocketTTSTextNormalizer.swift
+++ b/Packages/KeyVoxTTS/Sources/KeyVoxTTS/PocketTTSTextNormalizer.swift
@@ -6,7 +6,6 @@ enum PocketTTSTextNormalizer {
     private static let emailPattern = #"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b"#
     private static let markdownLinkPattern = #"\[([^\]]+)\]\((https?://[^)]+)\)"#
     private static let markdownHeadingPattern = #"(?m)^\s{0,3}#{1,6}\s*"#
-    private static let markdownBulletPattern = #"(?m)^\s*[-*•]+\s+"#
     private static let fencedCodeBlockPattern = #"(?s)```.*?```"#
     private static let inlineCodePattern = #"`([^`]+)`"#
     private static let dollarAmountPattern = #"\$([0-9]+(?:\.[0-9]+)?)"#
@@ -34,6 +33,7 @@ enum PocketTTSTextNormalizer {
         sanitized = sanitized.replacingOccurrences(of: "\u{2014}", with: " - ")
         sanitized = sanitized.replacingOccurrences(of: "\u{2026}", with: "...")
         sanitized = sanitized.replacingOccurrences(of: "&", with: " and ")
+        sanitized = normalizeListItemTerminalPeriods(in: sanitized)
 
         sanitized = sanitized.replacingOccurrences(
             of: fencedCodeBlockPattern,
@@ -48,11 +48,6 @@ enum PocketTTSTextNormalizer {
         sanitized = sanitized.replacingOccurrences(
             of: markdownHeadingPattern,
             with: "",
-            options: .regularExpression
-        )
-        sanitized = sanitized.replacingOccurrences(
-            of: markdownBulletPattern,
-            with: ", ",
             options: .regularExpression
         )
         sanitized = sanitized.replacingOccurrences(
@@ -106,6 +101,10 @@ enum PocketTTSTextNormalizer {
             options: .regularExpression
         )
         sanitized = sanitized.replacingOccurrences(
+            of: ":",
+            with: " "
+        )
+        sanitized = sanitized.replacingOccurrences(
             of: versionPattern,
             with: "version $1",
             options: [.regularExpression, .caseInsensitive]
@@ -141,7 +140,7 @@ enum PocketTTSTextNormalizer {
             options: .regularExpression
         )
         sanitized = sanitized.replacingOccurrences(
-            of: #"[^\p{L}\p{N}\s\.,!\?;:'"\/\-\n]"#,
+            of: #"[^\p{L}\p{N}\s\.,!\?;'"\/\-\*\)\n]"#,
             with: " ",
             options: .regularExpression
         )
@@ -172,5 +171,53 @@ enum PocketTTSTextNormalizer {
         )
 
         return sanitized
+    }
+
+    private static func normalizeListItemTerminalPeriods(in text: String) -> String {
+        text
+            .split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+            .map { normalizeListItemTerminalPeriod(in: String($0)) }
+            .joined(separator: "\n")
+    }
+
+    private static func normalizeListItemTerminalPeriod(in line: String) -> String {
+        let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+        guard trimmedLine.isEmpty == false else { return line }
+
+        let isNumberedListItem = trimmedLine.range(
+            of: #"^\d+[\.\)]\s+"#,
+            options: .regularExpression
+        ) != nil
+        let isBulletedListItem = trimmedLine.range(
+            of: #"^[-*•]\s+"#,
+            options: .regularExpression
+        ) != nil
+
+        guard isNumberedListItem || isBulletedListItem else { return line }
+
+        let normalizedMarkerLine = line.replacingOccurrences(
+            of: #"^(\s*)[\*•](\s+)"#,
+            with: "$1-$2",
+            options: .regularExpression
+        )
+
+        let withoutTrailingWhitespace = normalizedMarkerLine.replacingOccurrences(
+            of: #"\s+$"#,
+            with: "",
+            options: .regularExpression
+        )
+
+        if withoutTrailingWhitespace.range(
+            of: #"[,;:\.!?]+$"#,
+            options: .regularExpression
+        ) != nil {
+            return withoutTrailingWhitespace.replacingOccurrences(
+                of: #"[,;:\.!?]+$"#,
+                with: ".",
+                options: .regularExpression
+            )
+        }
+
+        return withoutTrailingWhitespace + "."
     }
 }

--- a/Packages/KeyVoxTTS/Sources/KeyVoxTTS/PocketTTSTextNormalizer.swift
+++ b/Packages/KeyVoxTTS/Sources/KeyVoxTTS/PocketTTSTextNormalizer.swift
@@ -114,11 +114,7 @@ enum PocketTTSTextNormalizer {
             with: ", ",
             options: .regularExpression
         )
-        sanitized = sanitized.replacingOccurrences(
-            of: closeAsidePattern,
-            with: ", ",
-            options: .regularExpression
-        )
+        sanitized = normalizeCloseAsides(in: sanitized)
         sanitized = sanitized.replacingOccurrences(
             of: slashJoinPattern,
             with: " ",
@@ -219,5 +215,69 @@ enum PocketTTSTextNormalizer {
         }
 
         return withoutTrailingWhitespace + "."
+    }
+
+    private static func normalizeCloseAsides(in text: String) -> String {
+        text
+            .split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+            .map { normalizeCloseAsidesInLine(String($0)) }
+            .joined(separator: "\n")
+    }
+
+    private static func normalizeCloseAsidesInLine(_ line: String) -> String {
+        let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+        let isNumberedListItem = trimmedLine.range(
+            of: #"^\d+\)\s+"#,
+            options: .regularExpression
+        ) != nil
+
+        guard isNumberedListItem else {
+            return line.replacingOccurrences(
+                of: closeAsidePattern,
+                with: ", ",
+                options: .regularExpression
+            )
+        }
+
+        let listMarkerPattern = #"^(\s*\d+\))(\s+)(.*)$"#
+        guard let range = line.range(
+            of: listMarkerPattern,
+            options: .regularExpression
+        ) else {
+            return line.replacingOccurrences(
+                of: closeAsidePattern,
+                with: ", ",
+                options: .regularExpression
+            )
+        }
+
+        let matchedLine = String(line[range])
+        let capturePattern = try? NSRegularExpression(pattern: listMarkerPattern)
+        guard
+            let regex = capturePattern,
+            let match = regex.firstMatch(
+                in: matchedLine,
+                range: NSRange(matchedLine.startIndex..., in: matchedLine)
+            ),
+            let markerRange = Range(match.range(at: 1), in: matchedLine),
+            let spacingRange = Range(match.range(at: 2), in: matchedLine),
+            let contentRange = Range(match.range(at: 3), in: matchedLine)
+        else {
+            return line.replacingOccurrences(
+                of: closeAsidePattern,
+                with: ", ",
+                options: .regularExpression
+            )
+        }
+
+        let marker = String(matchedLine[markerRange])
+        let spacing = String(matchedLine[spacingRange])
+        let content = String(matchedLine[contentRange]).replacingOccurrences(
+            of: closeAsidePattern,
+            with: ", ",
+            options: .regularExpression
+        )
+
+        return marker + spacing + content
     }
 }

--- a/Packages/KeyVoxTTS/Sources/KeyVoxTTS/PocketTTSTextNormalizer.swift
+++ b/Packages/KeyVoxTTS/Sources/KeyVoxTTS/PocketTTSTextNormalizer.swift
@@ -33,7 +33,6 @@ enum PocketTTSTextNormalizer {
         sanitized = sanitized.replacingOccurrences(of: "\u{2014}", with: " - ")
         sanitized = sanitized.replacingOccurrences(of: "\u{2026}", with: "...")
         sanitized = sanitized.replacingOccurrences(of: "&", with: " and ")
-        sanitized = normalizeListItemTerminalPeriods(in: sanitized)
 
         sanitized = sanitized.replacingOccurrences(
             of: fencedCodeBlockPattern,
@@ -135,8 +134,9 @@ enum PocketTTSTextNormalizer {
             with: " ",
             options: .regularExpression
         )
+        sanitized = normalizeListItemTerminalPeriods(in: sanitized)
         sanitized = sanitized.replacingOccurrences(
-            of: #"[^\p{L}\p{N}\s\.,!\?;'"\/\-\*\)\n]"#,
+            of: #"[^\p{L}\p{N}\s\.,!\?;'"\/\-\)\n]"#,
             with: " ",
             options: .regularExpression
         )

--- a/Packages/KeyVoxTTS/Tests/KeyVoxTTSTests/PocketTTSChunkPlannerTests.swift
+++ b/Packages/KeyVoxTTS/Tests/KeyVoxTTSTests/PocketTTSChunkPlannerTests.swift
@@ -81,6 +81,12 @@ final class PocketTTSChunkPlannerTests: XCTestCase {
         XCTAssertTrue(normalized.text.hasSuffix("1. first item. 2. second item."))
     }
 
+    func testNormalizePreservesParenthesizedNumberedListMarkers() {
+        let normalized = PocketTTSChunkPlanner.normalize("1) first item")
+        XCTAssertTrue(normalized.text.hasSuffix("1) first item."))
+        XCTAssertFalse(normalized.text.contains("1, first item."))
+    }
+
     func testNormalizeAddsTerminalPeriodsToHyphenLists() {
         let normalized = PocketTTSChunkPlanner.normalize("""
         - first item

--- a/Packages/KeyVoxTTS/Tests/KeyVoxTTSTests/PocketTTSChunkPlannerTests.swift
+++ b/Packages/KeyVoxTTS/Tests/KeyVoxTTSTests/PocketTTSChunkPlannerTests.swift
@@ -49,6 +49,11 @@ final class PocketTTSChunkPlannerTests: XCTestCase {
         XCTAssertTrue(normalized.text.hasSuffix("Meet me on 04 04 2026 at 3 05 PM."))
     }
 
+    func testNormalizeStripsColons() {
+        let normalized = PocketTTSChunkPlanner.normalize("Agenda: review: launch")
+        XCTAssertTrue(normalized.text.hasSuffix("Agenda review launch."))
+    }
+
     func testNormalizeStripsMarkdownAndCodeArtifacts() {
         let normalized = PocketTTSChunkPlanner.normalize("# Title\n- `inline_code`\nVisit [docs](https://example.com)")
         XCTAssertTrue(normalized.text.contains("Title"))
@@ -66,6 +71,30 @@ final class PocketTTSChunkPlannerTests: XCTestCase {
     func testNormalizeExpandsVersionPrefix() {
         let normalized = PocketTTSChunkPlanner.normalize("Updated in v1.2.3")
         XCTAssertTrue(normalized.text.hasSuffix("Updated in version 1.2.3."))
+    }
+
+    func testNormalizeAddsTerminalPeriodsToNumberedLists() {
+        let normalized = PocketTTSChunkPlanner.normalize("""
+        1. first item
+        2. second item
+        """)
+        XCTAssertTrue(normalized.text.hasSuffix("1. first item. 2. second item."))
+    }
+
+    func testNormalizeAddsTerminalPeriodsToHyphenLists() {
+        let normalized = PocketTTSChunkPlanner.normalize("""
+        - first item
+        - second item
+        """)
+        XCTAssertTrue(normalized.text.hasSuffix("- first item. - second item."))
+    }
+
+    func testNormalizeAddsTerminalPeriodsToBulletLists() {
+        let normalized = PocketTTSChunkPlanner.normalize("""
+        • first item
+        • second item
+        """)
+        XCTAssertTrue(normalized.text.hasSuffix("- first item. - second item."))
     }
 
     func testChunkPlannerKeepsShortTextInSingleChunk() throws {

--- a/Packages/KeyVoxTTS/Tests/KeyVoxTTSTests/PocketTTSChunkPlannerTests.swift
+++ b/Packages/KeyVoxTTS/Tests/KeyVoxTTSTests/PocketTTSChunkPlannerTests.swift
@@ -54,6 +54,17 @@ final class PocketTTSChunkPlannerTests: XCTestCase {
         XCTAssertTrue(normalized.text.hasSuffix("Agenda review launch."))
     }
 
+    func testNormalizePreservesTerminalPeriodsOnLinkListItems() {
+        let normalized = PocketTTSChunkPlanner.normalize("- https://example.com")
+        XCTAssertTrue(normalized.text.hasSuffix("- link."))
+    }
+
+    func testNormalizeStripsLiteralAsterisks() {
+        let normalized = PocketTTSChunkPlanner.normalize("*important*")
+        XCTAssertTrue(normalized.text.hasSuffix("Important."))
+        XCTAssertFalse(normalized.text.contains("*"))
+    }
+
     func testNormalizeStripsMarkdownAndCodeArtifacts() {
         let normalized = PocketTTSChunkPlanner.normalize("# Title\n- `inline_code`\nVisit [docs](https://example.com)")
         XCTAssertTrue(normalized.text.contains("Title"))


### PR DESCRIPTION
Summary:
- add list-aware TTS normalization so numbered, hyphen, and bullet items end with terminal periods for stronger pauses
- normalize bullet and star list markers into hyphens while preserving numbered list markers
- strip colons from normalized TTS text to simplify spoken output
- add KeyVoxTTS package coverage for numbered lists, hyphen lists, bullet lists, and colon stripping


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced text normalization for clearer speech, including:
    * Automatic insertion of terminal periods for numbered and bulleted list items
    * Normalization of bullet markers to a consistent form and preservation of numbered markers (e.g., "1)")
    * Removal of colons and improved handling of special characters for cleaner audio output

* **Tests**
  * Added unit tests covering the updated list and punctuation normalization behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->