### PR TITLE
fix (ios): TTS startup pacing and keyboard UI regressions across containing app and keyboard flows

### DIFF
--- a/iOS/KeyVox Keyboard/Core/KeyboardLayoutGeometry.swift
+++ b/iOS/KeyVox Keyboard/Core/KeyboardLayoutGeometry.swift
@@ -27,11 +27,12 @@ enum KeyboardLayoutGeometry {
         private weak var cancelLandscapeReferenceView: UIView?
         private weak var capsLandscapeReferenceView: UIView?
         private var speakButtonCenterXConstraint: NSLayoutConstraint?
-        private var speakButtonBottomConstraint: NSLayoutConstraint?
+        private var speakButtonVerticalConstraint: NSLayoutConstraint?
         private var speakButtonWidthConstraint: NSLayoutConstraint?
         private var speakButtonHeightConstraint: NSLayoutConstraint?
         private weak var speakReferenceView: UIView?
         private var speakButtonUsesLandscapeHeight = false
+        private var speakButtonPortraitHeight: CGFloat = 0
 
         init(
             cancelButton: UIView,
@@ -65,33 +66,56 @@ enum KeyboardLayoutGeometry {
             guard let keyGridView else { return }
 
             if let speakButton,
-               let currentSpeakReferenceView = keyGridView.topRowKeyView(for: .nine),
-               speakReferenceView !== currentSpeakReferenceView || speakButtonUsesLandscapeHeight != isLandscape {
-                NSLayoutConstraint.deactivate([
-                    speakButtonCenterXConstraint,
-                    speakButtonBottomConstraint,
-                    speakButtonWidthConstraint,
-                    speakButtonHeightConstraint,
-                ].compactMap { $0 })
-
-                speakButtonCenterXConstraint = speakButton.centerXAnchor.constraint(equalTo: currentSpeakReferenceView.centerXAnchor)
-                speakButtonBottomConstraint = speakButton.bottomAnchor.constraint(
-                    equalTo: currentSpeakReferenceView.topAnchor,
-                    constant: -KeyboardStyle.keyboardRowSpacing
+               let currentSpeakReferenceView = keyGridView.topRowKeyView(for: .nine) {
+                let resolvedSpeakButtonPortraitHeight = min(
+                    currentSpeakReferenceView.bounds.width,
+                    KeyboardStyle.buttonSize
                 )
-                speakButtonWidthConstraint = speakButton.widthAnchor.constraint(equalTo: currentSpeakReferenceView.widthAnchor)
-                speakButtonHeightConstraint = isLandscape
-                    ? speakButton.heightAnchor.constraint(equalTo: currentSpeakReferenceView.heightAnchor)
-                    : speakButton.heightAnchor.constraint(equalTo: currentSpeakReferenceView.widthAnchor)
-                speakReferenceView = currentSpeakReferenceView
-                speakButtonUsesLandscapeHeight = isLandscape
+                let shouldRefreshSpeakConstraints =
+                    speakReferenceView !== currentSpeakReferenceView
+                    || speakButtonUsesLandscapeHeight != isLandscape
+                    || (
+                        isLandscape == false
+                        && abs(speakButtonPortraitHeight - resolvedSpeakButtonPortraitHeight) > 0.5
+                    )
 
-                NSLayoutConstraint.activate([
-                    speakButtonCenterXConstraint!,
-                    speakButtonBottomConstraint!,
-                    speakButtonWidthConstraint!,
-                    speakButtonHeightConstraint!,
-                ])
+                if shouldRefreshSpeakConstraints {
+                    NSLayoutConstraint.deactivate([
+                        speakButtonCenterXConstraint,
+                        speakButtonVerticalConstraint,
+                        speakButtonWidthConstraint,
+                        speakButtonHeightConstraint,
+                    ].compactMap { $0 })
+
+                    speakButtonCenterXConstraint = speakButton.centerXAnchor.constraint(equalTo: currentSpeakReferenceView.centerXAnchor)
+                    if isLandscape {
+                        speakButtonVerticalConstraint = speakButton.bottomAnchor.constraint(
+                            equalTo: currentSpeakReferenceView.topAnchor,
+                            constant: -KeyboardStyle.keyboardRowSpacing
+                        )
+                    } else if let capsLockButton {
+                        speakButtonVerticalConstraint = speakButton.centerYAnchor.constraint(equalTo: capsLockButton.centerYAnchor)
+                    } else {
+                        speakButtonVerticalConstraint = speakButton.bottomAnchor.constraint(
+                            equalTo: currentSpeakReferenceView.topAnchor,
+                            constant: -KeyboardStyle.keyboardRowSpacing
+                        )
+                    }
+                    speakButtonWidthConstraint = speakButton.widthAnchor.constraint(equalTo: currentSpeakReferenceView.widthAnchor)
+                    speakButtonHeightConstraint = isLandscape
+                        ? speakButton.heightAnchor.constraint(equalTo: currentSpeakReferenceView.heightAnchor)
+                        : speakButton.heightAnchor.constraint(equalToConstant: resolvedSpeakButtonPortraitHeight)
+                    speakReferenceView = currentSpeakReferenceView
+                    speakButtonUsesLandscapeHeight = isLandscape
+                    speakButtonPortraitHeight = resolvedSpeakButtonPortraitHeight
+
+                    NSLayoutConstraint.activate([
+                        speakButtonCenterXConstraint!,
+                        speakButtonVerticalConstraint!,
+                        speakButtonWidthConstraint!,
+                        speakButtonHeightConstraint!,
+                    ])
+                }
             }
 
             if !isLandscape {

--- a/iOS/KeyVox Keyboard/Core/KeyboardStyle.swift
+++ b/iOS/KeyVox Keyboard/Core/KeyboardStyle.swift
@@ -25,6 +25,8 @@ enum KeyboardStyle {
     static let keyCornerRadius: CGFloat = 8
     static let popupWidthMultiplier: CGFloat = 1.15
     static let popupHeightMultiplier: CGFloat = 1.25
+    static let popupContentInsets = UIEdgeInsets(top: 10, left: 12, bottom: 10, right: 12)
+    static let popupMinEdgeInset: CGFloat = 2
     static let popupCornerRadius: CGFloat = 10
     static let popupBorderWidth: CGFloat = 0.6
     static let popupShadowColor = UIColor.black

--- a/iOS/KeyVox Keyboard/Views/Components/KeyboardKeyPopupView.swift
+++ b/iOS/KeyVox Keyboard/Views/Components/KeyboardKeyPopupView.swift
@@ -9,6 +9,8 @@ final class KeyboardKeyPopupView: UIView {
         alpha = 0
         observeBorderAppearanceChanges()
 
+        let contentInsets = KeyboardStyle.popupContentInsets
+
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.font = KeyboardStyle.popupFont
         titleLabel.textColor = KeyboardStyle.popupLabelColor
@@ -18,8 +20,10 @@ final class KeyboardKeyPopupView: UIView {
         NSLayoutConstraint.activate([
             titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
             titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 8),
-            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -8),
+            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: contentInsets.left),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -contentInsets.right),
+            titleLabel.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: contentInsets.top),
+            titleLabel.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -contentInsets.bottom),
         ])
     }
 
@@ -55,13 +59,28 @@ final class KeyboardKeyPopupView: UIView {
         titleLabel.attributedText = keyView.model.attributedTitle(for: text)
 
         let keyFrame = keyView.convert(keyView.bounds, to: container)
+        let contentInsets = KeyboardStyle.popupContentInsets
+        let labelSize = titleLabel.sizeThatFits(
+            CGSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+        )
         let popupSize = CGSize(
-            width: keyFrame.width * KeyboardStyle.popupWidthMultiplier,
-            height: keyFrame.height * KeyboardStyle.popupHeightMultiplier
+            width: max(
+                keyFrame.width * KeyboardStyle.popupWidthMultiplier,
+                labelSize.width + contentInsets.left + contentInsets.right
+            ),
+            height: max(
+                keyFrame.height * KeyboardStyle.popupHeightMultiplier,
+                labelSize.height + contentInsets.top + contentInsets.bottom
+            )
         )
         let popupY = max(0, keyFrame.minY - popupSize.height - 2)
+        let minX = KeyboardStyle.popupMinEdgeInset
+        let maxX = max(minX, container.bounds.width - popupSize.width - KeyboardStyle.popupMinEdgeInset)
         let popupFrame = CGRect(
-            x: keyFrame.midX - popupSize.width / 2,
+            x: min(max(minX, keyFrame.midX - popupSize.width / 2), maxX),
             y: popupY,
             width: popupSize.width,
             height: popupSize.height

--- a/iOS/KeyVox iOS/App/KeyVoxURLRouter.swift
+++ b/iOS/KeyVox iOS/App/KeyVoxURLRouter.swift
@@ -33,7 +33,7 @@ final class KeyVoxURLRouter {
                     showPreparationView: request.sourceSurface == .keyboard && shouldPresentReturnToHost
                 )
             } else {
-                ttsManager.isPlaybackPreparationViewPresented = false
+                ttsManager.dismissPlaybackPreparationView()
                 audioModeCoordinator.handleSpeakClipboardFromApp()
             }
         }

--- a/iOS/KeyVox iOS/Core/TTS/AudioModeCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/TTS/AudioModeCoordinator.swift
@@ -54,7 +54,7 @@ final class AudioModeCoordinator: ObservableObject {
                 "handleStartTTSFromPendingRequest transcriptionState=\(String(describing: transcriptionManager.state)) isSessionActive=\(String(transcriptionManager.isSessionActive))"
             )
             guard ttsPurchaseGate.canStartNewTTSSpeak else {
-                ttsManager.isPlaybackPreparationViewPresented = false
+                ttsManager.dismissPlaybackPreparationView()
                 ttsPurchaseGate.presentUnlockSheet()
                 return
             }

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+AppLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+AppLifecycle.swift
@@ -60,7 +60,7 @@ extension TTSManager {
 
     func handleAppDidEnterBackground() {
         Self.log("handleAppDidEnterBackground state=\(state.rawValue) backgroundTaskActive=\(backgroundTaskID != .invalid) fastMode=\(settingsStore.fastPlaybackModeEnabled)")
-        isPlaybackPreparationViewPresented = false
+        dismissPlaybackPreparationView()
         guard settingsStore.fastPlaybackModeEnabled == false else {
             if hasStartedPlaybackForActiveRequest {
                 playbackCoordinator.didEnterBackground()
@@ -215,7 +215,7 @@ extension TTSManager {
             hasStartedPlaybackForActiveRequest = true
             didEmitPreparationCompletionForActiveRequest = true
             isPlaybackPaused = false
-            isPlaybackPreparationViewPresented = false
+            dismissPlaybackPreparationView()
             beginBackgroundTaskIfNeeded()
             playbackCoordinator.replayLastPlayback(startingAtSample: resumeOffset, shouldAutoplay: true)
         default:

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
@@ -23,8 +23,7 @@ extension TTSManager {
     func startPlaybackFromPendingRequest(showPreparationView: Bool = false) async {
         guard let request = KeyVoxIPCBridge.readTTSRequest(),
               request.trimmedText.isEmpty == false else {
-            isPlaybackPreparationViewPresented = false
-            resetPlaybackPreparationState()
+            dismissPlaybackPreparationView()
             return
         }
 
@@ -66,11 +65,10 @@ extension TTSManager {
         shouldConsumeFreeSpeakOnPlaybackStart = true
         isPlaybackPaused = false
         lastErrorMessage = nil
-        resetPlaybackPreparationState()
         if showPreparationView {
-            isPlaybackPreparationViewPresented = true
+            presentPlaybackPreparationView()
         } else {
-            isPlaybackPreparationViewPresented = false
+            dismissPlaybackPreparationView()
         }
         playbackCoordinator.setPreparationCompletionDelay(
             enabled: showPreparationView && settingsStore.fastPlaybackModeEnabled == false
@@ -115,8 +113,7 @@ extension TTSManager {
             shouldConsumeFreeSpeakOnPlaybackStart = false
             isPlaybackPaused = false
             lastErrorMessage = nil
-            resetPlaybackPreparationState()
-            isPlaybackPreparationViewPresented = false
+            dismissPlaybackPreparationView()
             beginBackgroundTaskIfNeeded()
             playbackCoordinator.replayLastPlayback(startingAtSample: pausedReplaySampleOffset)
             return
@@ -137,8 +134,7 @@ extension TTSManager {
         isPlaybackPaused = false
         pausedReplaySampleOffset = nil
         lastErrorMessage = nil
-        resetPlaybackPreparationState()
-        isPlaybackPreparationViewPresented = false
+        dismissPlaybackPreparationView()
         beginBackgroundTaskIfNeeded()
         playbackCoordinator.replayLastPlayback()
     }
@@ -157,8 +153,7 @@ extension TTSManager {
         didEmitPreparationCompletionForActiveRequest = true
         shouldConsumeFreeSpeakOnPlaybackStart = false
         lastErrorMessage = nil
-        resetPlaybackPreparationState()
-        isPlaybackPreparationViewPresented = false
+        dismissPlaybackPreparationView()
         beginBackgroundTaskIfNeeded()
         playbackCoordinator.replayLastPlayback(
             startingAtSample: sampleOffset,

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
@@ -1,6 +1,20 @@
 import Foundation
 
 extension TTSManager {
+    func presentPlaybackPreparationView() {
+        shouldPersistPlaybackPreparationViewUntilBackground = true
+        resetPlaybackPreparationState()
+        isPlaybackPreparationViewPresented = true
+        Self.log("Playback preparation view presented.")
+    }
+
+    func dismissPlaybackPreparationView() {
+        shouldPersistPlaybackPreparationViewUntilBackground = false
+        isPlaybackPreparationViewPresented = false
+        resetPlaybackPreparationState()
+        Self.log("Playback preparation view dismissed.")
+    }
+
     func finishPlayback() {
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -40,6 +54,7 @@ extension TTSManager {
             self.lastErrorMessage = message
             self.isPlaybackPaused = false
             self.pausedReplaySampleOffset = nil
+            self.dismissPlaybackPreparationView()
             self.updateState(.error)
             await self.onWillTeardownPlayback?()
             KeyVoxIPCBridge.markRecentTTSPlayback()
@@ -85,8 +100,14 @@ extension TTSManager {
         fastModeBackgroundSafetyProgress = 0
         isFastModeBackgroundSafe = false
         KeyVoxIPCBridge.clearTTSRequest()
-        isPlaybackPreparationViewPresented = false
-        resetPlaybackPreparationState()
+        let shouldPreservePlaybackPreparationView =
+            shouldPersistPlaybackPreparationViewUntilBackground
+            && playbackPreparationPhase == .readyToReturn
+        if shouldPreservePlaybackPreparationView {
+            Self.log("Preserving playback preparation view until background transition.")
+        } else {
+            dismissPlaybackPreparationView()
+        }
         playbackCoordinator.setPreparationCompletionDelay(enabled: false)
         endBackgroundTaskIfNeeded()
 

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
@@ -38,6 +38,7 @@ final class TTSManager: ObservableObject {
     var hasStartedPlaybackForActiveRequest = false
     var didEmitPreparationCompletionForActiveRequest = false
     var shouldConsumeFreeSpeakOnPlaybackStart = false
+    var shouldPersistPlaybackPreparationViewUntilBackground = false
     var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
     var backgroundTaskReleaseTask: Task<Void, Never>?
     var onWillTeardownPlayback: (() async -> Void)?

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Progress.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Progress.swift
@@ -212,6 +212,14 @@ extension TTSPlaybackCoordinator {
         return max(deterministicRunwaySamples, leadProtectedSamples)
     }
 
+    func fastModeStartupBufferedSampleCount(for chunkCount: Int, remainingEstimatedSamples: Int) -> Int {
+        TTSPlaybackCoordinatorBufferingPolicy.fastModeStartupBufferedSampleCount(
+            sampleRate: playbackFormat.sampleRate,
+            chunkCount: chunkCount,
+            remainingEstimatedSamples: remainingEstimatedSamples
+        )
+    }
+
     func backgroundContinuationBufferedSampleCount(for chunkCount: Int, remainingEstimatedSamples: Int) -> Int {
         TTSPlaybackCoordinatorBufferingPolicy.deterministicBackgroundContinuationSampleCount(
             sampleRate: playbackFormat.sampleRate,

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Scheduling.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Scheduling.swift
@@ -40,7 +40,7 @@ extension TTSPlaybackCoordinator {
                 : normalModeRequiredStartSampleCount(for: frame.chunkCount)
             activeRequiredStartSampleCount = requiredBufferedSamples
             let silentStartRequirement = fastModeEnabled
-                ? deterministicFastModeBufferedSampleCount(
+                ? fastModeStartupBufferedSampleCount(
                     for: frame.chunkCount,
                     remainingEstimatedSamples: frame.estimatedRemainingSampleCount
                 )
@@ -114,7 +114,7 @@ extension TTSPlaybackCoordinator {
                 : normalModeRequiredStartSampleCount(for: frame.chunkCount)
             activeRequiredStartSampleCount = requiredBufferedSamples
             let silentStartRequirement = fastModeEnabled
-                ? deterministicFastModeBufferedSampleCount(
+                ? fastModeStartupBufferedSampleCount(
                     for: frame.chunkCount,
                     remainingEstimatedSamples: frame.estimatedRemainingSampleCount
                 )

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinatorBufferingPolicy.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinatorBufferingPolicy.swift
@@ -9,6 +9,8 @@ enum TTSPlaybackCoordinatorBufferingPolicy {
     static let fastModeMinimumCoverageSeconds: Double = 1.35
     static let fastModeLongFormMinimumCoverageSeconds: Double = 2.4
     static let fastModeUltraLongFormMinimumCoverageSeconds: Double = 3.2
+    static let fastModeLongFormStartupLeadRatio: Double = 0.25
+    static let fastModeUltraLongFormStartupLeadRatio: Double = 0.35
     static let conservativeForegroundRealtimeFactor: Double = 0.88
     static let longFormForegroundRealtimeFactor: Double = 0.62
     static let ultraLongFormForegroundRealtimeFactor: Double = 0.56
@@ -109,6 +111,48 @@ enum TTSPlaybackCoordinatorBufferingPolicy {
         return queuedSampleCount >= requiredSampleCount
     }
 
+    static func fastModeStartupBufferedSampleCount(
+        sampleRate: Double,
+        chunkCount: Int,
+        remainingEstimatedSamples: Int
+    ) -> Int {
+        let requiredStartSamples = fastModeRequiredStartSampleCount(
+            sampleRate: sampleRate,
+            chunkCount: chunkCount
+        )
+
+        guard chunkCount > longFormChunkThreshold else {
+            let deterministicRunwaySamples = normalModeBufferedSampleCount(
+                sampleRate: sampleRate,
+                chunkCount: chunkCount,
+                remainingEstimatedSamples: remainingEstimatedSamples,
+                requiredStartSamples: requiredStartSamples,
+                minimumCoverageSeconds: fastModeMinimumCoverageSeconds(for: chunkCount),
+                realtimeFactor: foregroundRealtimeFactor(for: chunkCount),
+                remainingWorkSafetyMarginSeconds: fastModeRemainingWorkSafetyMarginSeconds,
+                allowFullRemainingDeficit: true
+            )
+            let leadProtectedSamples = leadProtectedBufferedSampleCount(
+                remainingEstimatedSamples: remainingEstimatedSamples,
+                realtimeFactor: foregroundRealtimeFactor(for: chunkCount),
+                minimumLeadRatio: fastModeMinimumLeadRatio
+            )
+            return max(deterministicRunwaySamples, leadProtectedSamples)
+        }
+
+        let minimumCoverageSamples = Int(sampleRate * fastModeMinimumCoverageSeconds(for: chunkCount))
+        let startupLeadRatio = fastModeStartupLeadRatio(for: chunkCount)
+        let startupLeadProtectedSamples = Int(
+            ceil(Double(remainingEstimatedSamples) * startupLeadRatio)
+        )
+
+        return max(
+            requiredStartSamples,
+            minimumCoverageSamples,
+            startupLeadProtectedSamples
+        )
+    }
+
     static func deterministicBackgroundContinuationSampleCount(
         sampleRate: Double,
         chunkCount: Int,
@@ -151,6 +195,17 @@ enum TTSPlaybackCoordinatorBufferingPolicy {
             return fastModeSingleChunkMinimumCoverageSeconds
         default:
             return fastModeMinimumCoverageSeconds
+        }
+    }
+
+    static func fastModeStartupLeadRatio(for chunkCount: Int) -> Double {
+        switch chunkCount {
+        case (ultraLongFormChunkThreshold + 1)...:
+            return fastModeUltraLongFormStartupLeadRatio
+        case (longFormChunkThreshold + 1)...:
+            return fastModeLongFormStartupLeadRatio
+        default:
+            return fastModeMinimumLeadRatio
         }
     }
 

--- a/iOS/KeyVox iOS/Views/HomeTabView/HomeTabView.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/HomeTabView.swift
@@ -14,6 +14,7 @@ struct HomeTabView: View {
     @State var ttsPreparationCollapseTask: Task<Void, Never>?
     @State var showsTTSTranscriptPanelContainer = false
     @State var isTTSTranscriptPanelContentVisible = false
+    @State var ttsTranscriptRevealTask: Task<Void, Never>?
     @State var ttsTranscriptCollapseTask: Task<Void, Never>?
     @StateObject var ttsTranscriptCopyFeedback = CopyFeedbackController()
     @AppStorage(
@@ -40,6 +41,7 @@ struct HomeTabView: View {
             updateTTSTranscriptPresentation()
         }
         .onDisappear {
+            ttsTranscriptRevealTask?.cancel()
             ttsTranscriptCollapseTask?.cancel()
         }
     }

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTS.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTS.swift
@@ -120,7 +120,6 @@ extension HomeTabView {
         .animation(.spring(response: 0.45, dampingFraction: 0.82), value: ttsManager.playbackPreparationProgress)
         .animation(.easeOut(duration: 0.14), value: isTTSPreparationVisible)
         .animation(.easeInOut(duration: 0.52), value: showsTTSPreparationSlot)
-        .animation(.spring(response: 0.32, dampingFraction: 0.86), value: showsExpandedTTSTranscript)
         .onAppear {
             syncTTSPreparationPresentation()
         }

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
@@ -118,6 +118,10 @@ extension HomeTabView {
         activeTTSInstallState != nil
     }
 
+    var isTTSPreparationPresentationActive: Bool {
+        showsTTSPreparationProgress || showsTTSPreparationSlot || isTTSPreparationVisible
+    }
+
     func syncTTSPreparationPresentation() {
         showsTTSPreparationSlot = showsTTSPreparationProgress
         isTTSPreparationVisible = showsTTSPreparationProgress

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTranscript.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTranscript.swift
@@ -89,7 +89,11 @@ extension HomeTabView {
     var shouldShowExpandedTTSTranscriptPanel: Bool {
         isTTSTranscriptExpanded
             && currentPlaybackTranscriptText.isEmpty == false
-            && isTTSPreparationPresentationActive == false
+            && (
+                isTTSPreparationPresentationActive == false
+                || showsTTSTranscriptPanelContainer
+                || isTTSTranscriptPanelContentVisible
+            )
     }
 
     var showsTTSTranscriptIdleCloseButton: Bool {

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTranscript.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTranscript.swift
@@ -83,11 +83,13 @@ extension HomeTabView {
     }
 
     var showsExpandedTTSTranscript: Bool {
-        showsTTSTranscriptPanelContainer
+        showsTTSTranscriptPanelContainer && isTTSTranscriptPanelContentVisible
     }
 
     var shouldShowExpandedTTSTranscriptPanel: Bool {
-        isTTSTranscriptExpanded && currentPlaybackTranscriptText.isEmpty == false
+        isTTSTranscriptExpanded
+            && currentPlaybackTranscriptText.isEmpty == false
+            && isTTSPreparationPresentationActive == false
     }
 
     var showsTTSTranscriptIdleCloseButton: Bool {
@@ -104,12 +106,14 @@ extension HomeTabView {
     }
 
     func syncTTSTranscriptPresentation() {
+        ttsTranscriptRevealTask?.cancel()
         ttsTranscriptCollapseTask?.cancel()
         showsTTSTranscriptPanelContainer = shouldShowExpandedTTSTranscriptPanel
         isTTSTranscriptPanelContentVisible = shouldShowExpandedTTSTranscriptPanel
     }
 
     func updateTTSTranscriptPresentation() {
+        ttsTranscriptRevealTask?.cancel()
         ttsTranscriptCollapseTask?.cancel()
 
         if shouldShowExpandedTTSTranscriptPanel {
@@ -117,8 +121,13 @@ extension HomeTabView {
                 showsTTSTranscriptPanelContainer = true
             }
 
-            withAnimation(.easeOut(duration: 0.18)) {
-                isTTSTranscriptPanelContentVisible = true
+            ttsTranscriptRevealTask = Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 180_000_000)
+                guard Task.isCancelled == false else { return }
+
+                withAnimation(.easeOut(duration: 0.18)) {
+                    isTTSTranscriptPanelContentVisible = true
+                }
             }
             return
         }

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTranscript.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSTranscript.swift
@@ -138,6 +138,7 @@ extension HomeTabView {
 
         ttsTranscriptCollapseTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 180_000_000)
+            guard Task.isCancelled == false else { return }
             withAnimation(.easeInOut(duration: 0.26)) {
                 showsTTSTranscriptPanelContainer = false
             }

--- a/iOS/KeyVox iOS/Views/PlaybackPreparationView.swift
+++ b/iOS/KeyVox iOS/Views/PlaybackPreparationView.swift
@@ -81,6 +81,8 @@ struct PlaybackPreparationView: View {
                         Text("Dismiss")
                             .font(.appFont(14, variant: .light))
                             .foregroundStyle(Color.white.opacity(0.8))
+                            .frame(minWidth: 44, minHeight: 44, alignment: .center)
+                            .contentShape(Rectangle())
                     }
                     .accessibilityLabel("Dismiss")
                     .padding(.top, 12)

--- a/iOS/KeyVox iOS/Views/PlaybackPreparationView.swift
+++ b/iOS/KeyVox iOS/Views/PlaybackPreparationView.swift
@@ -70,6 +70,25 @@ struct PlaybackPreparationView: View {
 
                 Spacer()
             }
+
+            VStack {
+                HStack {
+                    Spacer()
+
+                    Button {
+                        ttsManager.dismissPlaybackPreparationView()
+                    } label: {
+                        Text("Dismiss")
+                            .font(.appFont(14, variant: .light))
+                            .foregroundStyle(Color.white.opacity(0.8))
+                    }
+                    .accessibilityLabel("Dismiss")
+                    .padding(.top, 12)
+                    .padding(.trailing, 20)
+                }
+
+                Spacer()
+            }
         }
         .animation(.easeInOut(duration: 0.1), value: isVideoReady)
         .animation(.spring(response: 0.45, dampingFraction: 0.82), value: ttsManager.playbackPreparationProgress)

--- a/iOS/KeyVoxiOSTests/Core/TTS/TTSPlaybackCoordinatorBufferingPolicyTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/TTS/TTSPlaybackCoordinatorBufferingPolicyTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import KeyVox_iOS
 
@@ -13,6 +14,18 @@ struct TTSPlaybackCoordinatorBufferingPolicyTests {
         #expect(TTSPlaybackCoordinatorBufferingPolicy.minimumCompletedFastModeSegmentLead(for: 2) == 1)
         #expect(TTSPlaybackCoordinatorBufferingPolicy.minimumCompletedFastModeSegmentLead(for: 30) == 2)
         #expect(TTSPlaybackCoordinatorBufferingPolicy.minimumCompletedFastModeSegmentLead(for: 80) == 3)
+    }
+
+    @Test func fastModeStartupLeadRatioScalesByChunkTier() {
+        #expect(TTSPlaybackCoordinatorBufferingPolicy.fastModeStartupLeadRatio(for: 8) == 0.10)
+        #expect(
+            TTSPlaybackCoordinatorBufferingPolicy.fastModeStartupLeadRatio(for: 30)
+                == TTSPlaybackCoordinatorBufferingPolicy.fastModeLongFormStartupLeadRatio
+        )
+        #expect(
+            TTSPlaybackCoordinatorBufferingPolicy.fastModeStartupLeadRatio(for: 80)
+                == TTSPlaybackCoordinatorBufferingPolicy.fastModeUltraLongFormStartupLeadRatio
+        )
     }
 
     @Test func normalModeBufferedSampleCountHonorsMinimumCoverageFloor() {
@@ -141,25 +154,23 @@ struct TTSPlaybackCoordinatorBufferingPolicyTests {
         #expect(bufferedSampleCount == Int(expectedRequiredSeconds * sampleRate))
     }
 
-    @Test func fastModeForegroundBufferedSampleCountExceedsTheOldFortyTwoChunkStartupThreshold() {
+    @Test func fastModeLongFormStartupUsesRaisedLeadRatioInsteadOfCoverageFloorOnly() {
         let sampleRate = 24_000.0
         let remainingEstimatedSamples = 6_533_760
-        let requiredStartSamples = TTSPlaybackCoordinatorBufferingPolicy.fastModeRequiredStartSampleCount(
-            sampleRate: sampleRate,
-            chunkCount: 42
-        )
-
-        let bufferedSampleCount = TTSPlaybackCoordinatorBufferingPolicy.normalModeBufferedSampleCount(
+        let bufferedSampleCount = TTSPlaybackCoordinatorBufferingPolicy.fastModeStartupBufferedSampleCount(
             sampleRate: sampleRate,
             chunkCount: 42,
-            remainingEstimatedSamples: remainingEstimatedSamples,
-            requiredStartSamples: requiredStartSamples,
-            minimumCoverageSeconds: TTSPlaybackCoordinatorBufferingPolicy.fastModeMinimumCoverageSeconds(for: 42),
-            realtimeFactor: TTSPlaybackCoordinatorBufferingPolicy.foregroundRealtimeFactor(for: 42),
-            remainingWorkSafetyMarginSeconds: TTSPlaybackCoordinatorBufferingPolicy.fastModeRemainingWorkSafetyMarginSeconds,
-            allowFullRemainingDeficit: true
+            remainingEstimatedSamples: remainingEstimatedSamples
         )
 
-        #expect(bufferedSampleCount > 2_272_256)
+        #expect(
+            bufferedSampleCount
+                == Int(
+                    ceil(
+                        Double(remainingEstimatedSamples)
+                            * TTSPlaybackCoordinatorBufferingPolicy.fastModeLongFormStartupLeadRatio
+                    )
+                )
+        )
     }
 }


### PR DESCRIPTION
## Summary
This branch improves several iOS TTS and keyboard interaction issues, including long-form Fast Mode startup behavior, playback preparation presentation flow, transcript presentation timing, and keyboard key alignment/popup rendering.

## What Changed

- keep the playback preparation screen visible until the app backgrounds instead of dismissing it when audio starts or finishes
- add explicit playback preparation present/dismiss helpers and a manual Dismiss action in the preparation view
- update TTS lifecycle and routing paths to use the centralized preparation dismissal flow
- delay Home tab transcript presentation until preparation UI is gone and transcript content is actually ready to appear
- remove the transcript container animation that was causing shell flashing and visual noise
- add a startup-specific Fast Mode buffering budget for long-form playback using tiered startup lead ratios
- route pre-start Fast Mode scheduling through the startup-specific buffering helper while leaving background continuation behavior separate
- add buffering policy test coverage for the new long-form Fast startup lead behavior
- fix keyboard popup sizing so symbols like @ do not clip on smaller devices
- add shared popup padding and edge inset constants for keyboard key popups
- align the Speak key with Caps Lock in portrait layouts and cap its portrait height to the shared control size

## Why
The branch combines a set of related UX and startup behavior fixes that were all addressed together on this branch: the playback preparation screen and transcript UI were producing noisy transitions, long-form Fast Mode startup was too conservative compared with expected foreground behavior, and the custom keyboard still had a few layout inconsistencies on compact devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dismiss button added to playback preparation view
  * New playback preparation presentation helpers for improved UI control

* **Bug Fixes**
  * More reliable playback preparation view lifecycle and dismissal across app states
  * Improved buffering/startup behavior for long TTS content
  * Refined keyboard speak-button and popup sizing/positioning for better layout
  * Tighter transcript expand/collapse timing and cancellation handling

* **Tests**
  * Added tests for fast-mode buffering startup ratios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->