### PR TITLE
fix(ios): refine Speak onboarding, replay transport, and home-card presentation

### DIFF
--- a/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
+++ b/iOS/KeyVox iOS.xcodeproj/xcshareddata/xcschemes/KeyVox iOS DEBUG.xcscheme
@@ -86,7 +86,7 @@
          <EnvironmentVariable
             key = "KEYVOX_FORCE_TTS_REGENERATION"
             value = "1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
       <StoreKitConfigurationFileReference

--- a/iOS/KeyVox iOS/App/KeyVoxSpeakIntroController.swift
+++ b/iOS/KeyVox iOS/App/KeyVoxSpeakIntroController.swift
@@ -7,7 +7,9 @@ final class KeyVoxSpeakIntroController: ObservableObject {
 
     private let defaults: UserDefaults
     private let forcePresentation: Bool
-    private var hasCountedEligibleOpenThisLaunch = false
+    private var pendingPresentationTask: Task<Void, Never>?
+
+    private let presentationDelayNanoseconds: UInt64 = 1_500_000_000
 
     init(
         defaults: UserDefaults,
@@ -18,34 +20,81 @@ final class KeyVoxSpeakIntroController: ObservableObject {
         self.isPresented = false
     }
 
-    func handleAppDidBecomeActive(onboardingStore: OnboardingStore) {
+    func markDeferredUntilNextEligibleLaunch() {
+        guard hasSeenIntro == false else { return }
+        guard hasUsedKeyVoxSpeak == false else { return }
+        defaults.set(true, forKey: UserDefaultsKeys.App.shouldShowKeyVoxSpeakIntroOnNextEligibleLaunch)
+    }
+
+    func handleAppDidBecomeActive(
+        onboardingStore: OnboardingStore,
+        isShowingReturnToHost: Bool
+    ) {
         if forcePresentation {
             isPresented = true
             return
         }
 
+        guard shouldShowOnNextEligibleLaunch else { return }
+        guard isShowingReturnToHost == false else { return }
         guard onboardingStore.shouldShowOnboarding == false else { return }
         guard onboardingStore.hasCompletedOnboardingThisLaunch == false else { return }
         guard hasSeenIntro == false else { return }
         guard hasUsedKeyVoxSpeak == false else { return }
-        guard hasCountedEligibleOpenThisLaunch == false else { return }
+        guard pendingPresentationTask == nil else { return }
 
-        let eligibleOpenCount = defaults.integer(forKey: UserDefaultsKeys.App.keyVoxSpeakEligibleOpenCount) + 1
-        defaults.set(eligibleOpenCount, forKey: UserDefaultsKeys.App.keyVoxSpeakEligibleOpenCount)
-        hasCountedEligibleOpenThisLaunch = true
+        pendingPresentationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: self.presentationDelayNanoseconds)
+            guard Task.isCancelled == false else { return }
+            guard shouldShowOnNextEligibleLaunch else { return }
+            guard hasSeenIntro == false else { return }
+            guard hasUsedKeyVoxSpeak == false else { return }
 
-        if eligibleOpenCount >= 3 {
+            defaults.set(false, forKey: UserDefaultsKeys.App.shouldShowKeyVoxSpeakIntroOnNextEligibleLaunch)
             isPresented = true
+            pendingPresentationTask = nil
         }
     }
 
+    func schedulePresentationIfEligible() {
+        if forcePresentation {
+            isPresented = true
+            return
+        }
+
+        guard shouldShowOnNextEligibleLaunch == false else { return }
+        guard hasSeenIntro == false else { return }
+        guard hasUsedKeyVoxSpeak == false else { return }
+        guard isPresented == false else { return }
+        guard pendingPresentationTask == nil else { return }
+
+        pendingPresentationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: self.presentationDelayNanoseconds)
+            guard Task.isCancelled == false else { return }
+            guard hasSeenIntro == false else { return }
+            guard hasUsedKeyVoxSpeak == false else { return }
+
+            isPresented = true
+            pendingPresentationTask = nil
+        }
+    }
+
+    func cancelPendingPresentation() {
+        pendingPresentationTask?.cancel()
+        pendingPresentationTask = nil
+    }
+
     func markFeatureUsed() {
+        cancelPendingPresentation()
         defaults.set(true, forKey: UserDefaultsKeys.App.hasUsedKeyVoxSpeak)
         defaults.set(true, forKey: UserDefaultsKeys.App.hasSeenKeyVoxSpeakIntro)
         isPresented = false
     }
 
     func dismiss() {
+        cancelPendingPresentation()
         defaults.set(true, forKey: UserDefaultsKeys.App.hasSeenKeyVoxSpeakIntro)
         isPresented = false
     }
@@ -56,5 +105,9 @@ final class KeyVoxSpeakIntroController: ObservableObject {
 
     private var hasUsedKeyVoxSpeak: Bool {
         defaults.bool(forKey: UserDefaultsKeys.App.hasUsedKeyVoxSpeak)
+    }
+
+    private var shouldShowOnNextEligibleLaunch: Bool {
+        defaults.bool(forKey: UserDefaultsKeys.App.shouldShowKeyVoxSpeakIntroOnNextEligibleLaunch)
     }
 }

--- a/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
+++ b/iOS/KeyVox iOS/App/KeyVoxiOSApp.swift
@@ -95,7 +95,11 @@ struct KeyVoxApp: App {
                         onboardingStore.armPendingKeyboardTourRouteIfNeeded(
                             isKeyboardEnabledInSystemSettings: OnboardingKeyboardAccessProbe.isKeyboardEnabledInSystemSettings()
                         )
-                        keyVoxSpeakIntroController.handleAppDidBecomeActive(onboardingStore: onboardingStore)
+                        keyVoxSpeakIntroController.handleAppDidBecomeActive(
+                            onboardingStore: onboardingStore,
+                            isShowingReturnToHost: transcriptionManager.isReturnToHostViewPresented
+                                || appLaunchRouteStore.initialURLRoute == .startRecording
+                        )
                     case .background:
                         transcriptionManager.handleAppDidEnterBackground()
                         ttsManager.handleAppDidEnterBackground()

--- a/iOS/KeyVox iOS/App/iCloud/UserDefaultsKeys.swift
+++ b/iOS/KeyVox iOS/App/iCloud/UserDefaultsKeys.swift
@@ -25,7 +25,7 @@ nonisolated enum UserDefaultsKeys {
         static let hasPendingKeyboardTour = "KeyVox.App.HasPendingKeyboardTour"
         static let hasSeenKeyVoxSpeakIntro = "KeyVox.App.HasSeenKeyVoxSpeakIntro"
         static let hasUsedKeyVoxSpeak = "KeyVox.App.HasUsedKeyVoxSpeak"
-        static let keyVoxSpeakEligibleOpenCount = "KeyVox.App.KeyVoxSpeakEligibleOpenCount"
+        static let shouldShowKeyVoxSpeakIntroOnNextEligibleLaunch = "KeyVox.App.ShouldShowKeyVoxSpeakIntroOnNextEligibleLaunch"
     }
 
     enum iCloud {

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
@@ -28,10 +28,13 @@ extension TTSManager {
             self.hasReplayablePlayback = self.playbackCoordinator.hasReplayablePlayback
             self.isPlaybackPaused = false
             self.pausedReplaySampleOffset = nil
+            self.updateState(.finished)
             await self.onWillTeardownPlayback?()
             KeyVoxIPCBridge.markRecentTTSPlayback()
-            self.keyboardBridge.publishTTSFinished()
-            self.clearActiveRequest(clearSharedTransportState: false)
+            self.clearActiveRequest(
+                clearSharedTransportState: false,
+                preserveFinishedSystemPlayback: self.hasReplayablePlayback
+            )
         }
     }
 
@@ -85,7 +88,8 @@ extension TTSManager {
 
     func clearActiveRequest(
         clearPublishedState: Bool = true,
-        clearSharedTransportState: Bool = true
+        clearSharedTransportState: Bool = true,
+        preserveFinishedSystemPlayback: Bool = false
     ) {
         fastModeBackgroundSafetyTask?.cancel()
         fastModeBackgroundSafetyTask = nil
@@ -115,12 +119,19 @@ extension TTSManager {
         playbackCoordinator.setPreparationCompletionDelay(enabled: false)
         endBackgroundTaskIfNeeded()
 
-        if clearPublishedState {
+        if clearPublishedState && preserveFinishedSystemPlayback == false {
             state = .idle
             updateIdleSleepPrevention()
             if clearSharedTransportState {
                 KeyVoxIPCBridge.clearTTSState()
             }
+        }
+
+        if preserveFinishedSystemPlayback {
+            state = .finished
+            updateIdleSleepPrevention()
+        } else if clearPublishedState, clearSharedTransportState {
+            KeyVoxIPCBridge.clearTTSState()
         }
 
         refreshSystemPlaybackControls()

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
@@ -241,6 +241,7 @@ extension TTSManager {
             guard Task.isCancelled == false else { return }
 
             self.isFastModeBackgroundSafe = true
+            self.appHaptics.medium()
             self.fastModeBackgroundSafetyTask = nil
         }
     }

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
@@ -130,7 +130,7 @@ extension TTSManager {
         if preserveFinishedSystemPlayback {
             state = .finished
             updateIdleSleepPrevention()
-        } else if clearPublishedState, clearSharedTransportState {
+        } else if clearPublishedState == false, clearSharedTransportState {
             KeyVoxIPCBridge.clearTTSState()
         }
 

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+SystemPlayback.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+SystemPlayback.swift
@@ -2,6 +2,10 @@ import AVFoundation
 import Foundation
 
 extension TTSManager {
+    private var shouldExposeFinishedReplaySystemPlayback: Bool {
+        state == .finished && hasReplayablePlayback && lastReplayableRequest != nil
+    }
+
     func configureSystemPlaybackController() {
         systemPlaybackController?.onPlay = { [weak self] in
             self?.handleSystemPlayCommand()
@@ -20,13 +24,16 @@ extension TTSManager {
 
     func refreshSystemPlaybackControls() {
         guard let systemPlaybackController else { return }
-        guard state == .playing else {
+        guard state == .playing || shouldExposeFinishedReplaySystemPlayback else {
             Self.log("System playback controls cleared because state=\(state.rawValue)")
             systemPlaybackController.clear()
             return
         }
 
-        let isReplayTransport = isReplayingCachedPlayback || pausedReplaySampleOffset != nil
+        let isReplayTransport =
+            isReplayingCachedPlayback
+            || pausedReplaySampleOffset != nil
+            || shouldExposeFinishedReplaySystemPlayback
         guard let displayText = currentPlaybackDisplayText,
               displayText.isEmpty == false else {
             Self.log("System playback controls cleared because no playback display text was available.")
@@ -42,7 +49,7 @@ extension TTSManager {
         systemPlaybackController.update(
             displayText: displayText,
             voiceName: currentSystemPlaybackVoiceName,
-            isPlaying: isPlaybackPaused == false,
+            isPlaying: state == .playing && isPlaybackPaused == false,
             isReplay: isReplayTransport,
             elapsedSeconds: elapsedSeconds,
             durationSeconds: durationSeconds
@@ -121,6 +128,7 @@ extension TTSManager {
     private func currentSystemPlaybackElapsedSeconds(isReplayTransport: Bool) -> Double {
         let coordinatorElapsed = playbackCoordinator.currentPlaybackSeconds
         guard isReplayTransport else { return coordinatorElapsed }
+        guard shouldExposeFinishedReplaySystemPlayback == false else { return 0 }
         guard isPlaybackPaused, let pausedReplaySampleOffset else { return coordinatorElapsed }
         guard coordinatorElapsed == 0 else { return coordinatorElapsed }
 

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Lifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Lifecycle.swift
@@ -135,6 +135,7 @@ extension TTSPlaybackCoordinator {
             deactivateAudioSessionIfNeeded()
         } else {
             playerNode.pause()
+            audioEngine.pause()
             deactivateAudioSessionIfNeeded()
         }
         isPaused = true

--- a/iOS/KeyVox iOS/Core/TTS/TTSSystemPlaybackController.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSSystemPlaybackController.swift
@@ -133,36 +133,24 @@ final class TTSSystemPlaybackController {
     private func configureRemoteCommands() {
         playTarget = commandCenter.playCommand.addTarget { [weak self] _ in
             Self.log("Received remote play command.")
-            if Thread.isMainThread {
+            Task { @MainActor [weak self] in
                 self?.onPlay?()
-            } else {
-                DispatchQueue.main.sync {
-                    self?.onPlay?()
-                }
             }
             return .success
         }
 
         pauseTarget = commandCenter.pauseCommand.addTarget { [weak self] _ in
             Self.log("Received remote pause command.")
-            if Thread.isMainThread {
+            Task { @MainActor [weak self] in
                 self?.onPause?()
-            } else {
-                DispatchQueue.main.sync {
-                    self?.onPause?()
-                }
             }
             return .success
         }
 
         togglePlayPauseTarget = commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
             Self.log("Received remote togglePlayPause command.")
-            if Thread.isMainThread {
+            Task { @MainActor [weak self] in
                 self?.onTogglePlayPause?()
-            } else {
-                DispatchQueue.main.sync {
-                    self?.onTogglePlayPause?()
-                }
             }
             return .success
         }
@@ -175,12 +163,8 @@ final class TTSSystemPlaybackController {
             Self.log(
                 "Received remote changePlaybackPosition command position=\(String(format: "%.2f", positionEvent.positionTime))"
             )
-            if Thread.isMainThread {
+            Task { @MainActor [weak self] in
                 self?.onSeekToTime?(positionEvent.positionTime)
-            } else {
-                DispatchQueue.main.sync {
-                    self?.onSeekToTime?(positionEvent.positionTime)
-                }
             }
             return .success
         }

--- a/iOS/KeyVox iOS/Core/TTS/TTSSystemPlaybackController.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSSystemPlaybackController.swift
@@ -206,8 +206,8 @@ final class TTSSystemPlaybackController {
         isPlaying: Bool,
         canSeek: Bool
     ) {
-        commandCenter.playCommand.isEnabled = isActive
-        commandCenter.pauseCommand.isEnabled = isActive
+        commandCenter.playCommand.isEnabled = isActive && isPlaying == false
+        commandCenter.pauseCommand.isEnabled = isActive && isPlaying
         commandCenter.togglePlayPauseCommand.isEnabled = isActive
         commandCenter.changePlaybackPositionCommand.isEnabled = isActive && canSeek
         Self.log(

--- a/iOS/KeyVox iOS/Core/TTS/TTSSystemPlaybackController.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSSystemPlaybackController.swift
@@ -103,6 +103,8 @@ final class TTSSystemPlaybackController {
         }
 
         nowPlayingInfoCenter.nowPlayingInfo = info
+        nowPlayingInfoCenter.playbackState = isPlaying ? .playing : .paused
+
         Self.log(
             "Published now playing info titleLength=\(title.count) voice=\(voiceName ?? "nil") isPlaying=\(isPlaying) isReplay=\(isReplay) elapsed=\(String(format: "%.2f", elapsed)) duration=\(duration.map { String(format: "%.2f", $0) } ?? "nil")"
         )
@@ -131,24 +133,36 @@ final class TTSSystemPlaybackController {
     private func configureRemoteCommands() {
         playTarget = commandCenter.playCommand.addTarget { [weak self] _ in
             Self.log("Received remote play command.")
-            Task { @MainActor [weak self] in
+            if Thread.isMainThread {
                 self?.onPlay?()
+            } else {
+                DispatchQueue.main.sync {
+                    self?.onPlay?()
+                }
             }
             return .success
         }
 
         pauseTarget = commandCenter.pauseCommand.addTarget { [weak self] _ in
             Self.log("Received remote pause command.")
-            Task { @MainActor [weak self] in
+            if Thread.isMainThread {
                 self?.onPause?()
+            } else {
+                DispatchQueue.main.sync {
+                    self?.onPause?()
+                }
             }
             return .success
         }
 
         togglePlayPauseTarget = commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
             Self.log("Received remote togglePlayPause command.")
-            Task { @MainActor [weak self] in
+            if Thread.isMainThread {
                 self?.onTogglePlayPause?()
+            } else {
+                DispatchQueue.main.sync {
+                    self?.onTogglePlayPause?()
+                }
             }
             return .success
         }
@@ -161,8 +175,12 @@ final class TTSSystemPlaybackController {
             Self.log(
                 "Received remote changePlaybackPosition command position=\(String(format: "%.2f", positionEvent.positionTime))"
             )
-            Task { @MainActor [weak self] in
+            if Thread.isMainThread {
                 self?.onSeekToTime?(positionEvent.positionTime)
+            } else {
+                DispatchQueue.main.sync {
+                    self?.onSeekToTime?(positionEvent.positionTime)
+                }
             }
             return .success
         }
@@ -188,8 +206,8 @@ final class TTSSystemPlaybackController {
         isPlaying: Bool,
         canSeek: Bool
     ) {
-        commandCenter.playCommand.isEnabled = isActive && isPlaying == false
-        commandCenter.pauseCommand.isEnabled = isActive && isPlaying
+        commandCenter.playCommand.isEnabled = isActive
+        commandCenter.pauseCommand.isEnabled = isActive
         commandCenter.togglePlayPauseCommand.isEnabled = isActive
         commandCenter.changePlaybackPositionCommand.isEnabled = isActive && canSeek
         Self.log(

--- a/iOS/KeyVox iOS/Views/AppRootView.swift
+++ b/iOS/KeyVox iOS/Views/AppRootView.swift
@@ -94,9 +94,11 @@ struct AppRootView: View {
             previousDestination = destination
             onboardingOverlayState = destination == .onboarding ? .visible : .hidden
             onboardingOverlayOpacity = 1
+            updateKeyVoxSpeakIntroPresentation(for: destination)
         }
         .onChange(of: destination, initial: false) { oldValue, newValue in
             previousDestination = oldValue
+            updateKeyVoxSpeakIntroPresentation(for: newValue)
 
             if newValue == .onboarding {
                 onboardingOverlayState = .visible
@@ -118,6 +120,11 @@ struct AppRootView: View {
                 onboardingOverlayOpacity = 1
             }
         }
+        .onChange(of: onboardingStore.hasCompletedOnboardingThisLaunch, initial: false) { _, newValue in
+            guard newValue else { return }
+            keyVoxSpeakIntroController.markDeferredUntilNextEligibleLaunch()
+            keyVoxSpeakIntroController.cancelPendingPresentation()
+        }
         .animation(rootAnimation, value: destination)
     }
 
@@ -136,6 +143,14 @@ struct AppRootView: View {
 
         return previousDestination == .launchHold
             && (destination == .onboarding || destination == .main)
+    }
+
+    private func updateKeyVoxSpeakIntroPresentation(for destination: RootDestination) {
+        if destination == .main && onboardingStore.hasCompletedOnboardingThisLaunch == false {
+            keyVoxSpeakIntroController.schedulePresentationIfEligible()
+        } else {
+            keyVoxSpeakIntroController.cancelPendingPresentation()
+        }
     }
 
 }

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSceneBView.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSceneBView.swift
@@ -22,6 +22,7 @@ struct KeyVoxSpeakSceneBView: View {
     @State private var headerOpacity: Double = 0
     @State private var rowRevealProgress: Int = 0
     @State private var fastModeCardOpacity: Double = 0
+    @State private var disclosureOpacity: Double = 0
     @State private var animationTask: Task<Void, Never>?
     @State private var hasAnimated = false
 
@@ -65,6 +66,13 @@ struct KeyVoxSpeakSceneBView: View {
 
                     fastModeCard
                         .opacity(fastModeCardOpacity)
+
+                    Text("Speak currently supports English only.")
+                        .font(.appFont(13, variant: .light))
+                        .foregroundStyle(.yellow.opacity(0.7))
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.top, 10)
+                        .opacity(disclosureOpacity)
 
                     Spacer(minLength: 16)
                 }
@@ -164,6 +172,7 @@ struct KeyVoxSpeakSceneBView: View {
         headerOpacity = 0
         rowRevealProgress = 0
         fastModeCardOpacity = 0
+        disclosureOpacity = 0
 
         animationTask = Task { @MainActor in
             try? await Task.sleep(for: .seconds(0.15))
@@ -195,6 +204,13 @@ struct KeyVoxSpeakSceneBView: View {
 
             withAnimation(.easeOut(duration: 0.35)) {
                 fastModeCardOpacity = 1
+            }
+
+            try? await Task.sleep(for: .seconds(0.14))
+            guard !Task.isCancelled else { return }
+
+            withAnimation(.easeOut(duration: 0.3)) {
+                disclosureOpacity = 1
             }
         }
     }

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSheetView.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakSheetView.swift
@@ -5,6 +5,7 @@ struct KeyVoxSpeakSheetView: View {
         case a
         case b
         case c
+        case unlock
     }
 
     enum Mode {
@@ -22,6 +23,24 @@ struct KeyVoxSpeakSheetView: View {
 
     let mode: Mode
 
+    private var displayedScenes: [Scene] {
+        switch mode {
+        case .intro:
+            [.a, .b, .c]
+        case .unlock:
+            [.unlock, .b]
+        }
+    }
+
+    private var initialScene: Scene {
+        switch mode {
+        case .intro:
+            .a
+        case .unlock:
+            .unlock
+        }
+    }
+
     var body: some View {
         NavigationStack {
             ZStack {
@@ -36,7 +55,7 @@ struct KeyVoxSpeakSheetView: View {
                         .padding(.bottom, 4)
 
                     TabView(selection: $selectedScene) {
-                        ForEach(Scene.allCases, id: \.self) { scene in
+                        ForEach(displayedScenes, id: \.self) { scene in
                             sceneView(for: scene)
                                 .tag(scene)
                         }
@@ -88,6 +107,7 @@ struct KeyVoxSpeakSheetView: View {
             .navigationTitle("")
         }
         .onAppear {
+            selectedScene = initialScene
             startButtonAnimation()
         }
         .onDisappear {
@@ -136,6 +156,8 @@ struct KeyVoxSpeakSheetView: View {
                 purchaseSummaryText: ttsPurchaseSummaryText,
                 isVisible: selectedScene == .c
             )
+        case .unlock:
+            KeyVoxSpeakUnlockScene(isVisible: selectedScene == .unlock)
         }
     }
 

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakUnlockScene.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakUnlockScene.swift
@@ -50,6 +50,7 @@ struct KeyVoxSpeakUnlockScene: View {
                     LogoBarView(size: 60)
                         .opacity(logoOpacity)
                         .scaleEffect(logoScale)
+                        .scaleEffect(idlePulseScale)
                         .padding(.bottom, 14)
 
                     Text("Get Speak Unlimited")

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakUnlockScene.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakUnlockScene.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct KeyVoxSpeakUnlockScene: View {
+    let isVisible: Bool
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer(minLength: 24)
+
+            LogoBarView(size: 96)
+                .opacity(isVisible ? 1 : 0.72)
+
+            VStack(spacing: 8) {
+                Text("KeyVox Speak")
+                    .font(.appFont(30, variant: .medium))
+                    .foregroundStyle(.white)
+
+                Text("Unlock flow placeholder")
+                    .font(.appFont(18, variant: .light))
+                    .foregroundStyle(.white.opacity(0.72))
+            }
+
+            Spacer(minLength: 24)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 24)
+    }
+}
+
+#Preview {
+    KeyVoxSpeakUnlockScene(isVisible: true)
+        .background(AppTheme.screenBackground)
+}

--- a/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakUnlockScene.swift
+++ b/iOS/KeyVox iOS/Views/Components/KeyVoxSpeak/KeyVoxSpeakUnlockScene.swift
@@ -1,29 +1,192 @@
 import SwiftUI
 
 struct KeyVoxSpeakUnlockScene: View {
+    private struct Benefit: Identifiable {
+        let id: Int
+        let icon: String
+        let title: String
+        let subtitle: String
+    }
+
+    private static let benefits: [Benefit] = [
+        Benefit(
+            id: 0,
+            icon: "infinity",
+            title: "Unlimited Daily Speaks",
+            subtitle: "No daily cap. Use it as much as you need."
+        ),
+        Benefit(
+            id: 1,
+            icon: "lock.fill",
+            title: "Always Private",
+            subtitle: "AI voices run entirely on-device. Nothing leaves your iPhone."
+        ),
+        Benefit(
+            id: 2,
+            icon: "bolt.fill",
+            title: "Fast Mode Included",
+            subtitle: "Starts speaking ~50% faster with one tap."
+        )
+    ]
+
     let isVisible: Bool
 
+    @State private var logoOpacity: Double = 0
+    @State private var logoScale: CGFloat = 0.7
+    @State private var titleOpacity: Double = 0
+    @State private var taglineOpacity: Double = 0
+    @State private var rowRevealProgress: Int = 0
+    @State private var footerOpacity: Double = 0
+    @State private var idlePulseScale: CGFloat = 1.0
+    @State private var animationTask: Task<Void, Never>?
+    @State private var hasAnimated = false
+
     var body: some View {
-        VStack(spacing: 24) {
-            Spacer(minLength: 24)
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(spacing: 0) {
+                    Spacer(minLength: 16)
 
-            LogoBarView(size: 96)
-                .opacity(isVisible ? 1 : 0.72)
+                    LogoBarView(size: 60)
+                        .opacity(logoOpacity)
+                        .scaleEffect(logoScale)
+                        .padding(.bottom, 14)
 
-            VStack(spacing: 8) {
-                Text("KeyVox Speak")
-                    .font(.appFont(30, variant: .medium))
-                    .foregroundStyle(.white)
+                    Text("Get Speak Unlimited")
+                        .font(.appFont(28, variant: .medium))
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+                        .opacity(titleOpacity)
+                        .padding(.bottom, 6)
 
-                Text("Unlock flow placeholder")
-                    .font(.appFont(18, variant: .light))
-                    .foregroundStyle(.white.opacity(0.72))
+                    Text("Upgrade once. Use Speak forever.")
+                        .font(.appFont(18, variant: .light))
+                        .foregroundStyle(.white.opacity(0.78))
+                        .multilineTextAlignment(.center)
+                        .opacity(taglineOpacity)
+                        .padding(.bottom, 16)
+
+                    VStack(spacing: 0) {
+                        ForEach(Self.benefits) { benefit in
+                            benefitSpotlight(benefit)
+                                .opacity(benefit.id < rowRevealProgress ? 1 : 0)
+                                .offset(y: benefit.id < rowRevealProgress ? 0 : 12)
+
+                            if benefit.id < Self.benefits.count - 1 {
+                                Rectangle()
+                                    .fill(Color.white.opacity(0.06))
+                                    .frame(height: 1)
+                                    .padding(.horizontal, 32)
+                                    .opacity(benefit.id + 1 < rowRevealProgress ? 1 : 0)
+                            }
+                        }
+                    }
+                    .padding(.bottom, 14)
+
+                    Text("One-time purchase. No subscription.")
+                        .font(.appFont(15, variant: .light))
+                        .foregroundStyle(.yellow.opacity(0.72))
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .opacity(footerOpacity)
+
+                    Spacer(minLength: 16)
+                }
+                .frame(maxWidth: .infinity, minHeight: geometry.size.height)
             }
-
-            Spacer(minLength: 24)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, 24)
+        .onChange(of: isVisible, initial: true) { _, visible in
+            guard visible else { return }
+            startEntranceIfNeeded()
+        }
+    }
+
+    private func benefitSpotlight(_ benefit: Benefit) -> some View {
+        VStack(spacing: 4) {
+            Image(systemName: benefit.icon)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(.yellow)
+
+            Text(benefit.title)
+                .font(.appFont(15, variant: .medium))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+
+            Text(benefit.subtitle)
+                .font(.appFont(13, variant: .light))
+                .foregroundStyle(.white.opacity(0.55))
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
+    }
+
+    private func startEntranceIfNeeded() {
+        guard !hasAnimated else { return }
+        hasAnimated = true
+
+        stopEntrance()
+        logoOpacity = 0
+        logoScale = 0.7
+        titleOpacity = 0
+        taglineOpacity = 0
+        rowRevealProgress = 0
+        footerOpacity = 0
+        idlePulseScale = 1.0
+
+        animationTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(0.2))
+            guard !Task.isCancelled else { return }
+
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.78)) {
+                logoOpacity = 1
+                logoScale = 1.0
+            }
+
+            try? await Task.sleep(for: .seconds(0.35))
+            guard !Task.isCancelled else { return }
+
+            withAnimation(.easeOut(duration: 0.4)) {
+                titleOpacity = 1
+            }
+
+            try? await Task.sleep(for: .seconds(0.15))
+            guard !Task.isCancelled else { return }
+
+            withAnimation(.easeOut(duration: 0.4)) {
+                taglineOpacity = 1
+            }
+
+            for index in Self.benefits.indices {
+                try? await Task.sleep(for: .seconds(0.12))
+                guard !Task.isCancelled else { return }
+
+                withAnimation(.spring(response: 0.4, dampingFraction: 0.82)) {
+                    rowRevealProgress = index + 1
+                }
+            }
+
+            try? await Task.sleep(for: .seconds(0.18))
+            guard !Task.isCancelled else { return }
+
+            withAnimation(.easeOut(duration: 0.35)) {
+                footerOpacity = 1
+            }
+
+            try? await Task.sleep(for: .seconds(0.3))
+            guard !Task.isCancelled else { return }
+
+            withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                idlePulseScale = 1.12
+            }
+        }
+    }
+
+    private func stopEntrance() {
+        animationTask?.cancel()
+        animationTask = nil
     }
 }
 

--- a/iOS/KeyVox iOS/Views/HomeTabView/HomeTabView.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/HomeTabView.swift
@@ -11,6 +11,7 @@ struct HomeTabView: View {
     @EnvironmentObject private var weeklyWordStatsStore: WeeklyWordStatsStore
     @State var showsTTSPreparationSlot = false
     @State var isTTSPreparationVisible = false
+    @State var ttsPreparationRevealToken = UUID()
     @State var ttsPreparationCollapseTask: Task<Void, Never>?
     @State var showsTTSTranscriptPanelContainer = false
     @State var isTTSTranscriptPanelContentVisible = false
@@ -41,6 +42,8 @@ struct HomeTabView: View {
             updateTTSTranscriptPresentation()
         }
         .onDisappear {
+            ttsPreparationRevealToken = UUID()
+            ttsPreparationCollapseTask?.cancel()
             ttsTranscriptRevealTask?.cancel()
             ttsTranscriptCollapseTask?.cancel()
         }

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 
 extension HomeTabView {
+    private var ttsPreparationRevealDelaySeconds: Double {
+        0.5
+    }
+
     @ViewBuilder
     var ttsVoiceShortcutLabel: some View {
         if showsHomePlaybackVoiceShortcut == false {
@@ -123,11 +127,13 @@ extension HomeTabView {
     }
 
     func syncTTSPreparationPresentation() {
+        ttsPreparationRevealToken = UUID()
         showsTTSPreparationSlot = showsTTSPreparationProgress
         isTTSPreparationVisible = showsTTSPreparationProgress
     }
 
     func updateTTSPreparationPresentation() {
+        ttsPreparationRevealToken = UUID()
         ttsPreparationCollapseTask?.cancel()
 
         if showsTTSPreparationProgress {
@@ -135,8 +141,18 @@ extension HomeTabView {
                 showsTTSPreparationSlot = true
             }
 
-            withAnimation(.easeOut(duration: 0.14)) {
-                isTTSPreparationVisible = true
+            if isTTSPreparationVisible == false {
+                let revealToken = UUID()
+                ttsPreparationRevealToken = revealToken
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + ttsPreparationRevealDelaySeconds) {
+                    guard ttsPreparationRevealToken == revealToken else { return }
+                    guard showsTTSPreparationProgress else { return }
+
+                    withAnimation(.easeOut(duration: 0.14)) {
+                        isTTSPreparationVisible = true
+                    }
+                }
             }
             return
         }

--- a/iOS/KeyVox iOS/Views/SettingsTabView+TTS.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView+TTS.swift
@@ -171,6 +171,11 @@ extension SettingsTabView {
                 .font(.appFont(14, variant: .light))
                 .foregroundStyle(.white.opacity(0.7))
                 .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text("Speak currently supports English only.")
+                .font(.appFont(13, variant: .light))
+                .foregroundStyle(.yellow.opacity(0.7))
+                .frame(maxWidth: .infinity, alignment: .center)
         }
     }
 


### PR DESCRIPTION
## Summary
Improve the Speak experience across onboarding, unlock education, playback teardown, and home-card preparation behavior.

## What Changed
- keep finished Speak playback available in system transport so lock screen playback can be started again after a clip ends
- update system playback publication and remote command handling to better represent paused replay state
- pause the audio engine alongside the player node during replay pause
- add a medium haptic when fast mode background playback becomes safe
- delay the home-card preparation progress bar reveal so the card has time to expand before the bar appears
- replace the old third-launch Speak intro rule with delayed eligible presentation logic
- defer first-install Speak intro presentation until the next eligible launch after onboarding completes
- suppress Speak intro presentation while return-to-host, onboarding, or other non-main root destinations are active
- replace the old eligible-open counter with a next-eligible-launch flag
- add an unlock-specific Speak onboarding branch that uses a dedicated unlock scene followed by scene B
- design the new unlock onboarding scene with benefit messaging and staged animations
- add English-only disclosure messaging to the Speak onboarding/settings surfaces

## Notes
- the default Speak intro flow still uses the existing three-scene sequence
- the unlock flow now uses its own two-scene sequence starting with the new unlock scene


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KeyVox Speak unlock screen displaying upgrade information and feature benefits.
  * Added language support disclosure notices.

* **Improvements**
  * Refined KeyVox Speak intro presentation timing and deferral logic.
  * Enhanced text-to-speech playback state management and replay controls.
  * Improved audio playback remote command handling.
  * Enhanced animation sequences for intro screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->