### PR TITLE
fix(macos-updater): keep update flows on the active display

### DIFF
--- a/macOS/App/UserDefaultsKeys.swift
+++ b/macOS/App/UserDefaultsKeys.swift
@@ -21,6 +21,7 @@ enum UserDefaultsKeys {
         static let pendingUpdatedVersion = "KeyVox.App.PendingUpdatedVersion"
         static let lastAcknowledgedUpdatedVersion = "KeyVox.App.LastAcknowledgedUpdatedVersion"
         static let resumeUpdaterAfterApplicationsMove = "KeyVox.App.ResumeUpdaterAfterApplicationsMove"
+        static let resumeUpdaterPreferredDisplayKey = "KeyVox.App.ResumeUpdaterPreferredDisplayKey"
         static let weeklyWordStatsPayload = "KeyVox.App.WeeklyWordStatsPayload"
         static let weeklyWordStatsInstallationID = "KeyVox.App.WeeklyWordStatsInstallationID"
         static let lastTranscription = "KeyVox.App.LastTranscription"

--- a/macOS/App/WindowManager+Updates.swift
+++ b/macOS/App/WindowManager+Updates.swift
@@ -71,13 +71,27 @@ final class AppUpdateDisplayCoordinator {
             fallbackDisplayKey: displayKey(for: NSScreen.screens.first)
         )
 
-        return screen(forDisplayKey: resolvedDisplayKey)
-            ?? window?.screen
-            ?? NSApp.keyWindow?.screen
-            ?? NSApp.mainWindow?.screen
-            ?? screenContaining(point: NSEvent.mouseLocation)
-            ?? NSScreen.main
-            ?? NSScreen.screens.first
+        if let screen = screen(forDisplayKey: resolvedDisplayKey) {
+            return screen
+        }
+
+        if let screen = window?.screen {
+            return screen
+        }
+
+        if let screen = NSApp.keyWindow?.screen {
+            return screen
+        }
+
+        if let screen = NSApp.mainWindow?.screen {
+            return screen
+        }
+
+        if let screen = screenContaining(point: NSEvent.mouseLocation) {
+            return screen
+        }
+
+        return NSScreen.main ?? NSScreen.screens.first
     }
 
     private func focusedDisplayKey() -> String? {

--- a/macOS/App/WindowManager+Updates.swift
+++ b/macOS/App/WindowManager+Updates.swift
@@ -1,6 +1,124 @@
 import AppKit
 import SwiftUI
 
+enum AppUpdateDisplaySelectionLogic {
+    static func focusedDisplayKey(
+        keyWindowDisplayKey: String?,
+        mainWindowDisplayKey: String?,
+        mouseDisplayKey: String?,
+        mainScreenDisplayKey: String?,
+        fallbackDisplayKey: String?
+    ) -> String? {
+        keyWindowDisplayKey
+            ?? mainWindowDisplayKey
+            ?? mouseDisplayKey
+            ?? mainScreenDisplayKey
+            ?? fallbackDisplayKey
+    }
+
+    static func interactionDisplayKey(
+        mouseDisplayKey: String?,
+        focusedDisplayKey: String?
+    ) -> String? {
+        mouseDisplayKey ?? focusedDisplayKey
+    }
+
+    static func resolvedDisplayKey(
+        preferredDisplayKey: String?,
+        windowDisplayKey: String?,
+        focusedDisplayKey: String?,
+        mainScreenDisplayKey: String?,
+        fallbackDisplayKey: String?
+    ) -> String? {
+        preferredDisplayKey
+            ?? windowDisplayKey
+            ?? focusedDisplayKey
+            ?? mainScreenDisplayKey
+            ?? fallbackDisplayKey
+    }
+}
+
+@MainActor
+final class AppUpdateDisplayCoordinator {
+    static let shared = AppUpdateDisplayCoordinator()
+
+    private(set) var preferredDisplayKey: String?
+
+    private init() {}
+
+    var preferredDisplayKeyForResume: String? {
+        preferredDisplayKey ?? interactionDisplayKey()
+    }
+
+    func captureManualCheckDisplay() {
+        preferredDisplayKey = interactionDisplayKey()
+    }
+
+    func captureAutomaticPromptDisplay() {
+        preferredDisplayKey = focusedDisplayKey()
+    }
+
+    func restorePreferredDisplayKeyForResumedUpdate(_ displayKey: String?) {
+        preferredDisplayKey = displayKey ?? focusedDisplayKey()
+    }
+
+    func preferredScreen(for window: NSWindow? = nil) -> NSScreen? {
+        let resolvedDisplayKey = AppUpdateDisplaySelectionLogic.resolvedDisplayKey(
+            preferredDisplayKey: preferredDisplayKey,
+            windowDisplayKey: displayKey(for: window?.screen),
+            focusedDisplayKey: focusedDisplayKey(),
+            mainScreenDisplayKey: displayKey(for: NSScreen.main),
+            fallbackDisplayKey: displayKey(for: NSScreen.screens.first)
+        )
+
+        return screen(forDisplayKey: resolvedDisplayKey)
+            ?? window?.screen
+            ?? NSApp.keyWindow?.screen
+            ?? NSApp.mainWindow?.screen
+            ?? screenContaining(point: NSEvent.mouseLocation)
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+    }
+
+    private func focusedDisplayKey() -> String? {
+        AppUpdateDisplaySelectionLogic.focusedDisplayKey(
+            keyWindowDisplayKey: displayKey(for: NSApp.keyWindow?.screen),
+            mainWindowDisplayKey: displayKey(for: NSApp.mainWindow?.screen),
+            mouseDisplayKey: displayKeyForMouseLocation(),
+            mainScreenDisplayKey: displayKey(for: NSScreen.main),
+            fallbackDisplayKey: displayKey(for: NSScreen.screens.first)
+        )
+    }
+
+    private func interactionDisplayKey() -> String? {
+        AppUpdateDisplaySelectionLogic.interactionDisplayKey(
+            mouseDisplayKey: displayKeyForMouseLocation(),
+            focusedDisplayKey: focusedDisplayKey()
+        )
+    }
+
+    private func displayKeyForMouseLocation() -> String? {
+        displayKey(for: screenContaining(point: NSEvent.mouseLocation))
+    }
+
+    private func screenContaining(point: NSPoint) -> NSScreen? {
+        NSScreen.screens.first(where: { $0.frame.contains(point) }) ?? NSScreen.main
+    }
+
+    private func displayKey(for screen: NSScreen?) -> String? {
+        guard let screen else { return nil }
+        guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
+            return nil
+        }
+        return String(number.uint32Value)
+    }
+
+    private func screen(forDisplayKey key: String?) -> NSScreen? {
+        guard let key else { return nil }
+        return NSScreen.screens.first(where: { displayKey(for: $0) == key })
+    }
+}
+
 extension WindowManager {
     @MainActor
     func openUpdateWindow(centered: Bool = true) {
@@ -124,7 +242,7 @@ extension WindowManager {
 
     @MainActor
     private func centerFloatingWindow(_ window: NSWindow) {
-        let screen = window.screen ?? NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens.first
+        let screen = AppUpdateDisplayCoordinator.shared.preferredScreen(for: window)
         guard let screen else { return }
 
         let visibleFrame = screen.visibleFrame

--- a/macOS/Core/Services/AppUpdate/AppUpdateApplicationsPrereflight.swift
+++ b/macOS/Core/Services/AppUpdate/AppUpdateApplicationsPrereflight.swift
@@ -1,6 +1,10 @@
 import Foundation
 import AppKit
 
+struct AppUpdateResumeAfterApplicationsMoveContext {
+    let preferredDisplayKey: String?
+}
+
 struct AppUpdateApplicationsPrereflight {
     private let fileManager: FileManager
     private let defaults: UserDefaults
@@ -23,16 +27,32 @@ struct AppUpdateApplicationsPrereflight {
             .appendingPathComponent(bundleURL.lastPathComponent, isDirectory: true)
     }
 
-    func stageResumeAfterApplicationsMove() {
+    func stageResumeAfterApplicationsMove(preferredDisplayKey: String?) {
         defaults.set(true, forKey: UserDefaultsKeys.App.resumeUpdaterAfterApplicationsMove)
+        if let preferredDisplayKey {
+            defaults.set(preferredDisplayKey, forKey: UserDefaultsKeys.App.resumeUpdaterPreferredDisplayKey)
+        } else {
+            defaults.removeObject(forKey: UserDefaultsKeys.App.resumeUpdaterPreferredDisplayKey)
+        }
+    }
+
+    func stageResumeAfterApplicationsMove() {
+        stageResumeAfterApplicationsMove(preferredDisplayKey: nil)
+    }
+
+    func consumeResumeAfterApplicationsMoveContext() -> AppUpdateResumeAfterApplicationsMoveContext? {
+        let shouldResume = defaults.bool(forKey: UserDefaultsKeys.App.resumeUpdaterAfterApplicationsMove)
+        let preferredDisplayKey = defaults.string(forKey: UserDefaultsKeys.App.resumeUpdaterPreferredDisplayKey)
+        if shouldResume {
+            defaults.removeObject(forKey: UserDefaultsKeys.App.resumeUpdaterAfterApplicationsMove)
+            defaults.removeObject(forKey: UserDefaultsKeys.App.resumeUpdaterPreferredDisplayKey)
+            return AppUpdateResumeAfterApplicationsMoveContext(preferredDisplayKey: preferredDisplayKey)
+        }
+        return nil
     }
 
     func consumeResumeAfterApplicationsMove() -> Bool {
-        let shouldResume = defaults.bool(forKey: UserDefaultsKeys.App.resumeUpdaterAfterApplicationsMove)
-        if shouldResume {
-            defaults.removeObject(forKey: UserDefaultsKeys.App.resumeUpdaterAfterApplicationsMove)
-        }
-        return shouldResume
+        consumeResumeAfterApplicationsMoveContext() != nil
     }
 
     func moveCurrentAppToApplications(bundleURL: URL = Bundle.main.bundleURL) throws -> URL {

--- a/macOS/Core/Services/AppUpdate/AppUpdateCoordinator.swift
+++ b/macOS/Core/Services/AppUpdate/AppUpdateCoordinator.swift
@@ -102,8 +102,11 @@ final class AppUpdateCoordinator: ObservableObject {
     func prepareForLaunch() {
         cleanupService.cleanupStaleArtifacts()
         postUpdateNoticeVersion = noticeService.consumePendingNoticeVersionIfNeeded()
-        if applicationsPrereflight.consumeResumeAfterApplicationsMove() {
+        if let resumeContext = applicationsPrereflight.consumeResumeAfterApplicationsMoveContext() {
             service.suppressNextAutomaticUpdatePrompt()
+            AppUpdateDisplayCoordinator.shared.restorePreferredDisplayKeyForResumedUpdate(
+                resumeContext.preferredDisplayKey
+            )
             WindowManager.shared.openUpdateWindow()
             startTrackedOperation {
                 await self.resumeInstallAfterApplicationsMove()
@@ -112,6 +115,7 @@ final class AppUpdateCoordinator: ObservableObject {
     }
 
     func openWindowForManualCheck() {
+        AppUpdateDisplayCoordinator.shared.captureManualCheckDisplay()
         WindowManager.shared.openUpdateWindow()
         startTrackedOperation {
             await self.refreshRelease(userInitiated: true)
@@ -272,7 +276,9 @@ final class AppUpdateCoordinator: ObservableObject {
         do {
             statusMessage = "Moving KeyVox to Applications..."
             let destinationURL = try applicationsPrereflight.moveCurrentAppToApplications()
-            applicationsPrereflight.stageResumeAfterApplicationsMove()
+            applicationsPrereflight.stageResumeAfterApplicationsMove(
+                preferredDisplayKey: AppUpdateDisplayCoordinator.shared.preferredDisplayKeyForResume
+            )
             NSWorkspace.shared.open(destinationURL)
             NSApplication.shared.terminate(nil)
         } catch {

--- a/macOS/Core/Services/AppUpdateService.swift
+++ b/macOS/Core/Services/AppUpdateService.swift
@@ -127,6 +127,10 @@ final class AppUpdateService: ObservableObject {
     }
 
     private func performUpdateCheck(isManualCheck: Bool) async {
+        if isManualCheck {
+            AppUpdateDisplayCoordinator.shared.captureManualCheckDisplay()
+        }
+
         if !isManualCheck, suppressNextAutomaticPrompt {
             suppressNextAutomaticPrompt = false
             return
@@ -161,6 +165,9 @@ final class AppUpdateService: ObservableObject {
         }
 
         guard let prompt = buildPrompt(from: remoteInfo, updateID: updateID, cooldown: cooldown) else { return }
+        if !isManualCheck {
+            AppUpdateDisplayCoordinator.shared.captureAutomaticPromptDisplay()
+        }
         promptPresenter.show(prompt: prompt)
     }
 

--- a/macOS/KeyVoxTests/Services/AppUpdateServiceTests.swift
+++ b/macOS/KeyVoxTests/Services/AppUpdateServiceTests.swift
@@ -262,6 +262,39 @@ final class AppUpdateServiceTests: XCTestCase {
         try await waitForCondition { promptPresenter.prompts.count == 2 }
     }
 
+    func testFocusedDisplaySelectionFallsBackDeterministically() {
+        let resolved = AppUpdateDisplaySelectionLogic.focusedDisplayKey(
+            keyWindowDisplayKey: nil,
+            mainWindowDisplayKey: "main-window",
+            mouseDisplayKey: "mouse",
+            mainScreenDisplayKey: "main-screen",
+            fallbackDisplayKey: "fallback"
+        )
+
+        XCTAssertTrue(resolved == "main-window")
+    }
+
+    func testInteractionDisplaySelectionPrefersMouseDisplay() {
+        let resolved = AppUpdateDisplaySelectionLogic.interactionDisplayKey(
+            mouseDisplayKey: "mouse",
+            focusedDisplayKey: "focused"
+        )
+
+        XCTAssertTrue(resolved == "mouse")
+    }
+
+    func testResolvedDisplaySelectionPrefersStoredDisplayBeforeFallbacks() {
+        let resolved = AppUpdateDisplaySelectionLogic.resolvedDisplayKey(
+            preferredDisplayKey: "stored",
+            windowDisplayKey: "window",
+            focusedDisplayKey: "focused",
+            mainScreenDisplayKey: "main-screen",
+            fallbackDisplayKey: "fallback"
+        )
+
+        XCTAssertTrue(resolved == "stored")
+    }
+
     private func makeService(
         promptPresenter: RecordingPromptPresenter,
         now: MutableNow,

--- a/macOS/Views/UpdatePromptOverlay.swift
+++ b/macOS/Views/UpdatePromptOverlay.swift
@@ -132,7 +132,7 @@ final class UpdatePromptManager {
 
     private func centerPromptWindow() {
         guard let window else { return }
-        let screen = window.screen ?? NSApp.keyWindow?.screen ?? NSScreen.main ?? NSScreen.screens.first
+        let screen = AppUpdateDisplayCoordinator.shared.preferredScreen(for: window)
         guard let screen else { return }
 
         let visibleFrame = screen.visibleFrame

--- a/macOS/Views/UpdatePromptOverlay.swift
+++ b/macOS/Views/UpdatePromptOverlay.swift
@@ -84,6 +84,7 @@ struct UpdatePromptOverlay: View {
     }
 }
 
+@MainActor
 final class UpdatePromptManager {
     static let shared = UpdatePromptManager()
     private var window: NSPanel?


### PR DESCRIPTION
## Summary
- route updater prompts and windows through a shared active-display resolver
- keep manual update checks anchored to the display where the user started the flow
- preserve the preferred display across the move-to-Applications relaunch handoff

## Details
- add display selection logic that prefers the active or interacting screen before falling back
- update the prompt overlay and updater window centering paths to use the shared display coordinator
- store and restore the preferred updater display during resume-after-move so the install flow stays on the same monitor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update prompts now track and remember which display they were shown on and persist that preference when resuming after relocating the app.
  * Capture display context for both manual checks and automatic prompts to improve where prompts reappear.

* **Bug Fixes / Reliability**
  * Improved display selection with deterministic fallback behavior so prompts open on the most appropriate screen.
  * Ensured update prompt management runs on the main thread.

* **Tests**
  * Added tests for display selection and fallback logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->