### PR TITLE
fix(macos): stabilize stop handoff and preserve trailing dictation audio

### DIFF
--- a/macOS/Core/Audio/AudioRecorder+PostProcessing.swift
+++ b/macOS/Core/Audio/AudioRecorder+PostProcessing.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AVFoundation
 import KeyVoxCore
 
 extension AudioRecorder {
@@ -57,13 +58,30 @@ extension AudioRecorder {
             #if DEBUG
             print("Audio processed: Preserving internal silence for transcription timing fidelity.")
             #endif
-            outputFrames = AudioPostProcessing.normalizeForTranscription(
+            let normalizedFrames = AudioPostProcessing.normalizeForTranscription(
                 snapshot,
                 targetPeak: normalizationTargetPeak,
                 maxGain: normalizationMaxGain
             )
+            outputFrames = appendTrailingSilenceForTranscription(normalizedFrames)
         }
 
         return outputFrames
+    }
+
+    private func appendTrailingSilenceForTranscription(_ samples: [Float]) -> [Float] {
+        guard !samples.isEmpty else { return samples }
+
+        let trailingFrameCount = Int((transcriptionTrailingSilenceDuration * outputFormat.sampleRate).rounded())
+        guard trailingFrameCount > 0 else { return samples }
+
+        #if DEBUG
+        print(
+            "Audio transcription pad: appendedFrames=\(trailingFrameCount) " +
+            "duration=\(String(format: "%.3f", transcriptionTrailingSilenceDuration))s"
+        )
+        #endif
+
+        return samples + Array(repeating: 0, count: trailingFrameCount)
     }
 }

--- a/macOS/Core/Audio/AudioRecorder+Session.swift
+++ b/macOS/Core/Audio/AudioRecorder+Session.swift
@@ -4,7 +4,7 @@ import KeyVoxCore
 
 extension AudioRecorder {
     func startRecordingSession() {
-        guard !isRecording else { return }
+        guard !isRecording, !isStopFinalizationPending else { return }
 
         let session = AVCaptureSession()
         session.beginConfiguration()
@@ -82,34 +82,25 @@ extension AudioRecorder {
     }
 
     func stopRecordingSession(completion: @escaping ([Float]) -> Void) {
-        defer {
-            audioCaptureOutput?.setSampleBufferDelegate(nil, queue: nil)
-
-            // Explicitly remove inputs/outputs before stopping to force OS to release BT profile
-            if let session = captureSession {
-                session.beginConfiguration()
-                if let input = captureInput {
-                    session.removeInput(input)
-                }
-                if let output = audioCaptureOutput {
-                    session.removeOutput(output)
-                }
-                session.commitConfiguration()
-                session.stopRunning()
-            }
-
-            drainPendingCaptureQueueWork()
-
-            captureSession = nil
-            captureInput = nil
-            audioCaptureOutput = nil
-            converter = nil
-            isRecording = false
-
+        guard isRecording else {
             completion(outputFramesForStoppedCapture())
+            return
+        }
+        guard !isStopFinalizationPending else { return }
+
+        isStopFinalizationPending = true
+        let stopRequestedAt = Date()
+        let bufferedFrameCountAtStopRequest = audioDataQueue.sync {
+            audioData.count
         }
 
-        guard isRecording else { return }
+        captureQueue.asyncAfter(deadline: .now() + stopCaptureTailDuration) { [weak self] in
+            self?.finalizeStopRecordingSession(
+                stopRequestedAt: stopRequestedAt,
+                bufferedFrameCountAtStopRequest: bufferedFrameCountAtStopRequest,
+                completion: completion
+            )
+        }
     }
 
     private func drainPendingCaptureQueueWork() {
@@ -117,5 +108,56 @@ extension AudioRecorder {
             return
         }
         captureQueue.sync {}
+    }
+
+    private func finalizeStopRecordingSession(
+        stopRequestedAt: Date,
+        bufferedFrameCountAtStopRequest: Int,
+        completion: @escaping ([Float]) -> Void
+    ) {
+        audioCaptureOutput?.setSampleBufferDelegate(nil, queue: nil)
+
+        // Finalize from the capture queue so anything already queued for delivery
+        // lands in the buffer before we tear the session down.
+        if let session = captureSession {
+            session.beginConfiguration()
+            if let input = captureInput {
+                session.removeInput(input)
+            }
+            if let output = audioCaptureOutput {
+                session.removeOutput(output)
+            }
+            session.commitConfiguration()
+            session.stopRunning()
+        }
+
+        drainPendingCaptureQueueWork()
+
+        let bufferedFrameCountBeforeTeardown = audioDataQueue.sync {
+            audioData.count
+        }
+
+        captureSession = nil
+        captureInput = nil
+        audioCaptureOutput = nil
+        converter = nil
+        isRecording = false
+        isStopFinalizationPending = false
+
+        #if DEBUG
+        let lateBufferedFrameCount = max(0, bufferedFrameCountBeforeTeardown - bufferedFrameCountAtStopRequest)
+        let tailSeconds = Date().timeIntervalSince(stopRequestedAt)
+        print(
+            "Audio stop finalize: tailSeconds=\(String(format: "%.3f", tailSeconds)) " +
+            "bufferedFramesAtRequest=\(bufferedFrameCountAtStopRequest) " +
+            "bufferedFramesBeforeTeardown=\(bufferedFrameCountBeforeTeardown) " +
+            "lateBufferedFrames=\(lateBufferedFrameCount)"
+        )
+        #endif
+
+        let outputFrames = outputFramesForStoppedCapture()
+        DispatchQueue.main.async {
+            completion(outputFrames)
+        }
     }
 }

--- a/macOS/Core/Audio/AudioRecorder.swift
+++ b/macOS/Core/Audio/AudioRecorder.swift
@@ -14,6 +14,7 @@ class AudioRecorder: NSObject, ObservableObject {
     var captureInput: AVCaptureDeviceInput?
     var audioCaptureOutput: AVCaptureAudioDataOutput?
     var converter: AVAudioConverter?
+    var isStopFinalizationPending = false
 
     var audioData: [Float] = []
     let audioDataQueue = DispatchQueue(label: "AudioRecorder.audioDataQueue")
@@ -28,6 +29,7 @@ class AudioRecorder: NSObject, ObservableObject {
     let outputFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)!
     let normalizationTargetPeak: Float = 0.9
     let normalizationMaxGain: Float = 3.0
+    var stopCaptureTailDuration: TimeInterval = 0.18
 
     @Published var isRecording = false
     @Published var audioLevel: Float = 0.0

--- a/macOS/Core/Audio/AudioRecorder.swift
+++ b/macOS/Core/Audio/AudioRecorder.swift
@@ -30,6 +30,7 @@ class AudioRecorder: NSObject, ObservableObject {
     let normalizationTargetPeak: Float = 0.9
     let normalizationMaxGain: Float = 3.0
     var stopCaptureTailDuration: TimeInterval = 0.18
+    var transcriptionTrailingSilenceDuration: TimeInterval = 0.24
 
     @Published var isRecording = false
     @Published var audioLevel: Float = 0.0

--- a/macOS/Core/Transcription/TranscriptionManager.swift
+++ b/macOS/Core/Transcription/TranscriptionManager.swift
@@ -162,6 +162,8 @@ class TranscriptionManager: ObservableObject {
     
     private func abortRecording() {
         guard state == .recording || state == .transcribing else { return }
+        activeStopRequestID = nil
+        stopRequestedAt = nil
         
         #if DEBUG
         print("!! ESCAPE pressed: Aborting session !!")
@@ -178,6 +180,10 @@ class TranscriptionManager: ObservableObject {
     
     private func handleTriggerKey(isPressed: Bool) {
         guard appSettings.hasCompletedOnboarding else { return }
+        guard stopRequestedAt == nil else {
+            updateOverlayHandsFreeVisualState()
+            return
+        }
 
         if isPressed {
             if state == .idle {
@@ -228,12 +234,16 @@ class TranscriptionManager: ObservableObject {
     }
     
     private var stopRequestedAt: Date?
+    private var activeStopRequestID: UUID?
     
     private func stopRecordingAndTranscribe() {
         guard case .recording = state else { return }
+        guard activeStopRequestID == nil else { return }
         
         let startTime = Date()
+        let stopRequestID = UUID()
         stopRequestedAt = startTime
+        activeStopRequestID = stopRequestID
         #if DEBUG
         print("--- Speed Profile Start ---")
         #endif
@@ -244,6 +254,9 @@ class TranscriptionManager: ObservableObject {
 
         audioRecorder.stopRecording { [weak self] frames in
             guard let self = self else { return }
+            guard self.activeStopRequestID == stopRequestID else { return }
+            self.activeStopRequestID = nil
+            self.stopRequestedAt = nil
             
             // Root Cause Fix: Bluetooth HFP/SCO to A2DP switching delay.
             // NSSound cannot play into a Bluetooth Voice channel (HFP).
@@ -359,6 +372,7 @@ class TranscriptionManager: ObservableObject {
 
     private func updateOverlayHandsFreeVisualState() {
         let isPreviewActive = state == .recording &&
+            stopRequestedAt == nil &&
             !isLocked &&
             keyboardMonitor.isTriggerKeyPressed &&
             keyboardMonitor.isShiftPressed

--- a/macOS/Core/Transcription/TranscriptionManager.swift
+++ b/macOS/Core/Transcription/TranscriptionManager.swift
@@ -13,6 +13,7 @@ class TranscriptionManager: ObservableObject {
     enum AppState: Equatable {
         case idle
         case recording
+        case stopping
         case transcribing
         case error(String)
     }
@@ -161,7 +162,7 @@ class TranscriptionManager: ObservableObject {
     }
     
     private func abortRecording() {
-        guard state == .recording || state == .transcribing else { return }
+        guard state == .recording || state == .stopping || state == .transcribing else { return }
         activeStopRequestID = nil
         stopRequestedAt = nil
         
@@ -181,6 +182,20 @@ class TranscriptionManager: ObservableObject {
     private func handleTriggerKey(isPressed: Bool) {
         guard appSettings.hasCompletedOnboarding else { return }
         guard stopRequestedAt == nil else {
+            #if DEBUG
+            if isPressed {
+                print("Trigger ignored while recorder stop finalization is pending.")
+            }
+            #endif
+            updateOverlayHandsFreeVisualState()
+            return
+        }
+        guard state != .stopping else {
+            #if DEBUG
+            if isPressed {
+                print("Trigger ignored while session is transitioning from recording to transcription.")
+            }
+            #endif
             updateOverlayHandsFreeVisualState()
             return
         }
@@ -244,6 +259,7 @@ class TranscriptionManager: ObservableObject {
         let stopRequestID = UUID()
         stopRequestedAt = startTime
         activeStopRequestID = stopRequestID
+        state = .stopping
         #if DEBUG
         print("--- Speed Profile Start ---")
         #endif

--- a/macOS/KeyVoxTests/Core/AudioRecorderStopRecordingTests.swift
+++ b/macOS/KeyVoxTests/Core/AudioRecorderStopRecordingTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AVFoundation
 import XCTest
 @testable import KeyVox
 
@@ -40,9 +41,13 @@ final class AudioRecorderStopRecordingTests: XCTestCase {
         let finalBufferedCount = recorder.audioDataQueue.sync {
             recorder.audioData.count
         }
+        let expectedTrailingPadFrames = Int(
+            (recorder.transcriptionTrailingSilenceDuration * recorder.outputFormat.sampleRate).rounded()
+        )
 
         XCTAssertEqual(finalBufferedCount, initialFrames.count + lateFrames.count)
-        XCTAssertEqual(returnedFrames.count, finalBufferedCount)
+        XCTAssertEqual(returnedFrames.count, finalBufferedCount + expectedTrailingPadFrames)
+        XCTAssertEqual(Array(returnedFrames.suffix(expectedTrailingPadFrames)), Array(repeating: 0, count: expectedTrailingPadFrames))
     }
 
     func testStopRecordingIncludesTailFramesDeliveredShortlyAfterStopRequest() {
@@ -76,8 +81,32 @@ final class AudioRecorderStopRecordingTests: XCTestCase {
         let finalBufferedCount = recorder.audioDataQueue.sync {
             recorder.audioData.count
         }
+        let expectedTrailingPadFrames = Int(
+            (recorder.transcriptionTrailingSilenceDuration * recorder.outputFormat.sampleRate).rounded()
+        )
 
         XCTAssertEqual(finalBufferedCount, initialFrames.count + tailFrames.count)
-        XCTAssertEqual(returnedFrames.count, finalBufferedCount)
+        XCTAssertEqual(returnedFrames.count, finalBufferedCount + expectedTrailingPadFrames)
+        XCTAssertEqual(Array(returnedFrames.suffix(expectedTrailingPadFrames)), Array(repeating: 0, count: expectedTrailingPadFrames))
+    }
+
+    func testOutputFramesForStoppedCaptureAppendsTranscriptionSilencePad() {
+        let recorder = AudioRecorder()
+        recorder.captureStartedAt = Date().addingTimeInterval(-0.2)
+
+        let samples = Array(repeating: Float(0.2), count: 1_600)
+        recorder.audioDataQueue.sync {
+            recorder.audioData = samples
+        }
+
+        let outputFrames = recorder.outputFramesForStoppedCapture()
+        let expectedTrailingPadFrames = Int(
+            (recorder.transcriptionTrailingSilenceDuration * recorder.outputFormat.sampleRate).rounded()
+        )
+        let expectedNormalizedFrames = Array(repeating: Float(0.6), count: samples.count)
+
+        XCTAssertEqual(outputFrames.count, samples.count + expectedTrailingPadFrames)
+        XCTAssertEqual(Array(outputFrames.prefix(samples.count)), expectedNormalizedFrames)
+        XCTAssertEqual(Array(outputFrames.suffix(expectedTrailingPadFrames)), Array(repeating: 0, count: expectedTrailingPadFrames))
     }
 }

--- a/macOS/KeyVoxTests/Core/AudioRecorderStopRecordingTests.swift
+++ b/macOS/KeyVoxTests/Core/AudioRecorderStopRecordingTests.swift
@@ -44,4 +44,40 @@ final class AudioRecorderStopRecordingTests: XCTestCase {
         XCTAssertEqual(finalBufferedCount, initialFrames.count + lateFrames.count)
         XCTAssertEqual(returnedFrames.count, finalBufferedCount)
     }
+
+    func testStopRecordingIncludesTailFramesDeliveredShortlyAfterStopRequest() {
+        let recorder = AudioRecorder()
+        recorder.captureStartedAt = Date()
+        recorder.isRecording = true
+        recorder.stopCaptureTailDuration = 0.06
+
+        let initialFrames = Array(repeating: Float(0.2), count: 1_600)
+        let tailFrames = Array(repeating: Float(0.2), count: 800)
+
+        recorder.audioDataQueue.sync {
+            recorder.audioData = initialFrames
+        }
+
+        recorder.captureQueue.asyncAfter(deadline: .now() + 0.02) {
+            recorder.audioDataQueue.sync {
+                recorder.audioData.append(contentsOf: tailFrames)
+            }
+        }
+
+        let stopFinished = expectation(description: "stop finished with tail frames")
+        var returnedFrames: [Float] = []
+        recorder.stopRecording { frames in
+            returnedFrames = frames
+            stopFinished.fulfill()
+        }
+
+        wait(for: [stopFinished], timeout: 1.0)
+
+        let finalBufferedCount = recorder.audioDataQueue.sync {
+            recorder.audioData.count
+        }
+
+        XCTAssertEqual(finalBufferedCount, initialFrames.count + tailFrames.count)
+        XCTAssertEqual(returnedFrames.count, finalBufferedCount)
+    }
 }

--- a/macOS/Views/Settings/SettingsView.swift
+++ b/macOS/Views/Settings/SettingsView.swift
@@ -126,6 +126,7 @@ struct SettingsView: View {
                 .padding(.bottom, 40)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .scrollIndicators(.hidden)
 
             if showsDictionaryFloatingAddButton {
                 DictionaryFloatingAddButton {

--- a/macOS/Views/StatusMenuView.swift
+++ b/macOS/Views/StatusMenuView.swift
@@ -156,6 +156,7 @@ struct StatusMenuView: View {
         switch manager.state {
         case .idle: return .idle
         case .recording: return .recording
+        case .stopping: return .transcribing
         case .transcribing: return .transcribing
         case .error(let msg): return .error(msg)
         }


### PR DESCRIPTION
## Summary
This branch improves the macOS dictation stop path so trailing speech is less likely to be cut off when recording ends, and it cleans up the settings tabs by hiding macOS scroll indicators.

## Changes
- delay recorder teardown briefly so late-arriving capture frames can be included before the session shuts down
- finalize recorder stop work on the capture queue and log late buffered frames during stop finalization
- append a short trailing silence pad to transcription audio after normalization
- add a dedicated stopping state so rapid trigger input is ignored while the session transitions from recording to transcription
- map the new stopping state to the existing processing status in the status menu
- hide scroll indicators in the shared settings tab scroll view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved audio processing during recording stop with automatic normalization and trailing silence handling for transcription accuracy.

* **Bug Fixes**
  * Enhanced recording termination flow to prevent race conditions during stop finalization.
  * Fixed UI state transitions during recording stop-to-transcription process.

* **UI/UX**
  * Removed scrollbar indicators from Settings view for a cleaner appearance.
  * Added proper status feedback when stopping a recording session.

* **Tests**
  * Added comprehensive tests for audio processing and recording stop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->