### PR TITLE
fix(mac): Make paste clipboard restore evidence-driven

### DIFF
--- a/macOS/Core/Services/Paste/MenuFallback/PasteMenuFallbackCoordinator.swift
+++ b/macOS/Core/Services/Paste/MenuFallback/PasteMenuFallbackCoordinator.swift
@@ -3,7 +3,20 @@ import Cocoa
 struct PasteMenuFallbackExecutionResult {
     let didMenuFallbackInsert: Bool
     let menuAttempt: PasteMenuFallbackAttemptResult?
+    let completionEvidence: PasteMenuFallbackCompletionEvidence
     let suppressFirstWarmupFailureWarning: Bool
+
+    init(
+        didMenuFallbackInsert: Bool,
+        menuAttempt: PasteMenuFallbackAttemptResult?,
+        completionEvidence: PasteMenuFallbackCompletionEvidence = .none,
+        suppressFirstWarmupFailureWarning: Bool
+    ) {
+        self.didMenuFallbackInsert = didMenuFallbackInsert
+        self.menuAttempt = menuAttempt
+        self.completionEvidence = completionEvidence
+        self.suppressFirstWarmupFailureWarning = suppressFirstWarmupFailureWarning
+    }
 }
 
 protocol PasteMenuFallbackCoordinating {
@@ -53,6 +66,7 @@ final class PasteMenuFallbackCoordinator {
 
         var didMenuFallbackInsert = false
         var menuAttempt: PasteMenuFallbackAttemptResult?
+        var completionEvidence: PasteMenuFallbackCompletionEvidence = .none
         var isFirstMenuSuccessAttemptForProcess = false
 
         var textForMenuPaste = insertionText
@@ -81,6 +95,9 @@ final class PasteMenuFallbackCoordinator {
             didMenuFallbackInsert = Self.didMenuFallbackInsertForEmptyClipboardPayload(
                 didTypeLeadingSpaces: didTypeLeadingSpaces
             )
+            if didMenuFallbackInsert {
+                completionEvidence = .noClipboardPayload
+            }
         } else {
             let liveVerificationProcessID =
                 menuFallbackExecutor.frontmostProcessIDOnMainThread() ?? targetAppIdentity?.pid
@@ -138,6 +155,12 @@ final class PasteMenuFallbackCoordinator {
                 trustMenuSuccessWithoutAXVerification: trustWithoutAXVerification,
                 verificationPassed: verificationPassed
             )
+            completionEvidence = Self.completionEvidenceForMenuAttempt(
+                attempt: menuAttemptResult,
+                didMenuFallbackInsert: didMenuFallbackInsert,
+                trustMenuSuccessWithoutAXVerification: trustWithoutAXVerification,
+                verificationPassed: verificationPassed
+            )
         }
 
         let suppressFirstWarmupFailureWarning = Self.shouldSuppressFailureWarningForFirstMenuSuccessAttempt(
@@ -150,6 +173,7 @@ final class PasteMenuFallbackCoordinator {
         return PasteMenuFallbackExecutionResult(
             didMenuFallbackInsert: didMenuFallbackInsert,
             menuAttempt: menuAttempt,
+            completionEvidence: completionEvidence,
             suppressFirstWarmupFailureWarning: suppressFirstWarmupFailureWarning
         )
     }
@@ -172,6 +196,26 @@ final class PasteMenuFallbackCoordinator {
             return trustMenuSuccessWithoutAXVerification || verificationPassed
         case .actionErrored:
             return verificationPassed
+        }
+    }
+
+    static func completionEvidenceForMenuAttempt(
+        attempt: PasteMenuFallbackAttemptResult,
+        didMenuFallbackInsert: Bool,
+        trustMenuSuccessWithoutAXVerification: Bool,
+        verificationPassed: Bool
+    ) -> PasteMenuFallbackCompletionEvidence {
+        guard didMenuFallbackInsert else { return .none }
+        switch attempt {
+        case .unavailable:
+            return .none
+        case .actionSucceeded:
+            if verificationPassed {
+                return .verifiedInsertion
+            }
+            return trustMenuSuccessWithoutAXVerification ? .trustedWithoutVerification : .none
+        case .actionErrored:
+            return verificationPassed ? .verifiedInsertion : .none
         }
     }
 

--- a/macOS/Core/Services/Paste/PasteService.swift
+++ b/macOS/Core/Services/Paste/PasteService.swift
@@ -6,7 +6,6 @@ class PasteService {
 
     private let pasteQueue: DispatchQueue
     private let restoreDelayAfterMenuFallback: TimeInterval
-    private let restoreDelayAfterAccessibilityInjection: TimeInterval
     private var lastInsertionAppIdentity: PasteAppIdentity?
     private var lastInsertionAt: Date = .distantPast
     private var lastInsertedTrailingCharacter: Character?
@@ -28,7 +27,6 @@ class PasteService {
         pasteQueue: DispatchQueue = DispatchQueue(label: "com.KeyVox.paste", qos: .userInteractive),
         heuristicTTL: TimeInterval = 10,
         restoreDelayAfterMenuFallback: TimeInterval = 0.8,
-        restoreDelayAfterAccessibilityInjection: TimeInterval = 0.25,
         menuFallbackVerificationTimeout: TimeInterval = 0.6,
         menuFallbackVerificationPollInterval: TimeInterval = 0.05,
         frontmostAppIdentityProvider: (() -> PasteAppIdentity?)? = nil,
@@ -45,7 +43,6 @@ class PasteService {
     ) {
         self.pasteQueue = pasteQueue
         self.restoreDelayAfterMenuFallback = restoreDelayAfterMenuFallback
-        self.restoreDelayAfterAccessibilityInjection = restoreDelayAfterAccessibilityInjection
         self.frontmostAppIdentityProvider = frontmostAppIdentityProvider
             ?? { PasteService.defaultFrontmostAppIdentity() }
         self.clockNow = clockNow
@@ -125,6 +122,7 @@ class PasteService {
 
             var didMenuFallbackInsert = false
             var suppressFirstWarmupFailureWarning = false
+            var menuFallbackCompletionEvidence: PasteMenuFallbackCompletionEvidence = .none
             if accessibilityDecision.needsMenuFallback {
                 let menuFallbackExecution = self.menuFallbackCoordinator.executeMenuFallback(
                     insertionText: insertionText,
@@ -137,19 +135,20 @@ class PasteService {
                 )
                 didMenuFallbackInsert = menuFallbackExecution.didMenuFallbackInsert
                 suppressFirstWarmupFailureWarning = menuFallbackExecution.suppressFirstWarmupFailureWarning
+                menuFallbackCompletionEvidence = menuFallbackExecution.completionEvidence
             }
 
             let executionPlan = PasteServiceExecutionPlan.build(
                 didAccessibilityInsertText: accessibilityDecision.didAccessibilityInsertText,
                 didMenuFallbackInsert: didMenuFallbackInsert,
                 usedMenuFallbackPath: accessibilityDecision.needsMenuFallback,
+                menuFallbackCompletionEvidence: menuFallbackCompletionEvidence,
                 suppressFirstWarmupFailureWarning: suppressFirstWarmupFailureWarning,
                 shouldStartFailureRecovery: Self.shouldStartFailureRecovery(
                     didAccessibilityInsertText: accessibilityDecision.didAccessibilityInsertText,
                     didMenuFallbackInsert: didMenuFallbackInsert
                 ),
-                restoreDelayAfterMenuFallback: self.restoreDelayAfterMenuFallback,
-                restoreDelayAfterAccessibilityInjection: self.restoreDelayAfterAccessibilityInjection
+                restoreDelayAfterMenuFallback: self.restoreDelayAfterMenuFallback
             )
 
             if executionPlan.shouldRememberInsertion {
@@ -159,8 +158,7 @@ class PasteService {
             if executionPlan.shouldStartFailureRecovery {
                 self.startFailureRecoveryOnMainThread(savedSnapshot: savedSnapshot)
             } else {
-                let delay = executionPlan.restoreDelay ?? self.restoreDelayAfterAccessibilityInjection
-                self.restoreClipboardOnMainThread(from: savedSnapshot, delay: delay)
+                self.restoreClipboardOnMainThread(from: savedSnapshot, policy: executionPlan.restorePolicy)
             }
         }
     }
@@ -230,13 +228,26 @@ class PasteService {
 
     private func restoreClipboardOnMainThread(
         from savedSnapshot: PasteClipboardSnapshot.Snapshot,
-        delay: TimeInterval
+        policy: PasteClipboardRestorePolicy
     ) {
         let restoreBlock = { [clipboardAdapter] in
             clipboardAdapter.restore(savedSnapshot)
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: restoreBlock)
+        switch policy {
+        case .immediate:
+            #if DEBUG
+            print("Clipboard restore policy: immediate")
+            #endif
+            DispatchQueue.main.async(execute: restoreBlock)
+        case .afterDelay(let delay):
+            #if DEBUG
+            print("Clipboard restore policy: delayed \(String(format: "%.3f", delay))s")
+            #endif
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: restoreBlock)
+        case .deferredToFailureRecovery:
+            break
+        }
     }
 
     static func shouldStartFailureRecovery(

--- a/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
+++ b/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
@@ -42,6 +42,13 @@ enum PasteMenuFallbackAttemptResult {
     case actionErrored
 }
 
+enum PasteMenuFallbackCompletionEvidence {
+    case none
+    case noClipboardPayload
+    case verifiedInsertion
+    case trustedWithoutVerification
+}
+
 struct PasteMenuFallbackVerificationContext {
     let snapshots: [PasteMenuFallbackVerificationSnapshot]
 }

--- a/macOS/Core/Services/Paste/Pipeline/PastePolicies.swift
+++ b/macOS/Core/Services/Paste/Pipeline/PastePolicies.swift
@@ -45,16 +45,16 @@ enum PastePolicies {
 struct PasteServiceExecutionPlan {
     let shouldRememberInsertion: Bool
     let shouldStartFailureRecovery: Bool
-    let restoreDelay: TimeInterval?
+    let restorePolicy: PasteClipboardRestorePolicy
 
     static func build(
         didAccessibilityInsertText: Bool,
         didMenuFallbackInsert: Bool,
         usedMenuFallbackPath: Bool,
+        menuFallbackCompletionEvidence: PasteMenuFallbackCompletionEvidence = .none,
         suppressFirstWarmupFailureWarning: Bool,
         shouldStartFailureRecovery: Bool,
-        restoreDelayAfterMenuFallback: TimeInterval,
-        restoreDelayAfterAccessibilityInjection: TimeInterval
+        restoreDelayAfterMenuFallback: TimeInterval
     ) -> PasteServiceExecutionPlan {
         let rememberInsertion = didAccessibilityInsertText || didMenuFallbackInsert
         let shouldRecover = !suppressFirstWarmupFailureWarning && shouldStartFailureRecovery
@@ -63,18 +63,45 @@ struct PasteServiceExecutionPlan {
             return PasteServiceExecutionPlan(
                 shouldRememberInsertion: rememberInsertion,
                 shouldStartFailureRecovery: true,
-                restoreDelay: nil
+                restorePolicy: .deferredToFailureRecovery
             )
         }
+
+        let restorePolicy = Self.clipboardRestorePolicy(
+            usedMenuFallbackPath: usedMenuFallbackPath,
+            menuFallbackCompletionEvidence: menuFallbackCompletionEvidence,
+            restoreDelayAfterMenuFallback: restoreDelayAfterMenuFallback
+        )
 
         return PasteServiceExecutionPlan(
             shouldRememberInsertion: rememberInsertion,
             shouldStartFailureRecovery: false,
-            restoreDelay: usedMenuFallbackPath
-                ? restoreDelayAfterMenuFallback
-                : restoreDelayAfterAccessibilityInjection
+            restorePolicy: restorePolicy
         )
     }
+
+    private static func clipboardRestorePolicy(
+        usedMenuFallbackPath: Bool,
+        menuFallbackCompletionEvidence: PasteMenuFallbackCompletionEvidence,
+        restoreDelayAfterMenuFallback: TimeInterval
+    ) -> PasteClipboardRestorePolicy {
+        guard usedMenuFallbackPath else {
+            return .immediate
+        }
+
+        switch menuFallbackCompletionEvidence {
+        case .noClipboardPayload, .verifiedInsertion:
+            return .immediate
+        case .trustedWithoutVerification, .none:
+            return .afterDelay(restoreDelayAfterMenuFallback)
+        }
+    }
+}
+
+enum PasteClipboardRestorePolicy: Equatable {
+    case immediate
+    case afterDelay(TimeInterval)
+    case deferredToFailureRecovery
 }
 
 struct PasteAccessibilityExecutionDecision {

--- a/macOS/KeyVoxTests/Services/DictationPipelineSmokeTests.swift
+++ b/macOS/KeyVoxTests/Services/DictationPipelineSmokeTests.swift
@@ -364,7 +364,6 @@ final class DictationPipelineSmokeTests: XCTestCase {
             pasteQueue: DispatchQueue(label: "DictationPipelineSmokeTests.queue.\(UUID().uuidString)"),
             heuristicTTL: 10,
             restoreDelayAfterMenuFallback: 0,
-            restoreDelayAfterAccessibilityInjection: 0,
             menuFallbackVerificationTimeout: 0.01,
             menuFallbackVerificationPollInterval: 0.001,
             frontmostAppIdentityProvider: { PasteAppIdentity(bundleID: "com.example.app", pid: 777) },

--- a/macOS/KeyVoxTests/Services/PasteDecisionMatrixTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteDecisionMatrixTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import KeyVox
 
+@MainActor
 final class PasteDecisionMatrixTests: XCTestCase {
     func testNoWarningWhenAccessibilityInsertionSucceeds() {
         XCTAssertFalse(
@@ -40,6 +41,38 @@ final class PasteDecisionMatrixTests: XCTestCase {
                 didAccessibilityInsertText: false,
                 didMenuFallbackInsert: didMenuInsert
             )
+        )
+    }
+
+    func testMenuCompletionEvidenceDistinguishesVerifiedAndTrustedSuccess() {
+        XCTAssertEqual(
+            PasteMenuFallbackCoordinator.completionEvidenceForMenuAttempt(
+                attempt: .actionSucceeded,
+                didMenuFallbackInsert: true,
+                trustMenuSuccessWithoutAXVerification: false,
+                verificationPassed: true
+            ),
+            .verifiedInsertion
+        )
+
+        XCTAssertEqual(
+            PasteMenuFallbackCoordinator.completionEvidenceForMenuAttempt(
+                attempt: .actionSucceeded,
+                didMenuFallbackInsert: true,
+                trustMenuSuccessWithoutAXVerification: true,
+                verificationPassed: false
+            ),
+            .trustedWithoutVerification
+        )
+
+        XCTAssertEqual(
+            PasteMenuFallbackCoordinator.completionEvidenceForMenuAttempt(
+                attempt: .actionSucceeded,
+                didMenuFallbackInsert: false,
+                trustMenuSuccessWithoutAXVerification: true,
+                verificationPassed: false
+            ),
+            .none
         )
     }
 

--- a/macOS/KeyVoxTests/Services/PasteServiceExecutionTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteServiceExecutionTests.swift
@@ -24,8 +24,7 @@ final class PasteServiceExecutionTests: XCTestCase {
             spacing: spacing,
             injector: injector,
             coordinator: coordinator,
-            restoreDelayAfterMenuFallback: 0.5,
-            restoreDelayAfterAccessibilityInjection: 0
+            restoreDelayAfterMenuFallback: 0.5
         )
 
         service.pasteText("hello")
@@ -59,8 +58,7 @@ final class PasteServiceExecutionTests: XCTestCase {
             spacing: spacing,
             injector: injector,
             coordinator: coordinator,
-            restoreDelayAfterMenuFallback: 0.5,
-            restoreDelayAfterAccessibilityInjection: 0
+            restoreDelayAfterMenuFallback: 0.5
         )
 
         service.pasteText("Hello")
@@ -83,6 +81,7 @@ final class PasteServiceExecutionTests: XCTestCase {
         let coordinator = MockMenuFallbackCoordinator(result: .init(
             didMenuFallbackInsert: true,
             menuAttempt: .actionSucceeded,
+            completionEvidence: .verifiedInsertion,
             suppressFirstWarmupFailureWarning: false
         ))
         let service = try makeService(
@@ -92,18 +91,49 @@ final class PasteServiceExecutionTests: XCTestCase {
             spacing: spacing,
             injector: injector,
             coordinator: coordinator,
-            restoreDelayAfterMenuFallback: 0,
-            restoreDelayAfterAccessibilityInjection: 999
+            restoreDelayAfterMenuFallback: 10
         )
 
         service.pasteText("hello")
 
-        try await waitForCondition {
+        try await waitForCondition(timeout: 0.2) {
             clipboard.restoreCalls == 1
         }
 
         XCTAssertEqual(recovery.startCalls, 0)
         XCTAssertEqual(coordinator.executeCalls, 1)
+    }
+
+    func testTrustedMenuFallbackKeepsGraceDelayBeforeRestoringClipboard() async throws {
+        let clipboard = MockClipboardAdapter(snapshot: [[:]])
+        let recovery = MockFailureRecoveryController()
+        let capitalization = MockCapitalizationHeuristics(outputText: "hello")
+        let injector = MockAccessibilityInjector(outcome: .failureNeedsFallback)
+        let coordinator = MockMenuFallbackCoordinator(result: .init(
+            didMenuFallbackInsert: true,
+            menuAttempt: .actionSucceeded,
+            completionEvidence: .trustedWithoutVerification,
+            suppressFirstWarmupFailureWarning: false
+        ))
+        let service = try makeService(
+            clipboard: clipboard,
+            recovery: recovery,
+            capitalization: capitalization,
+            spacing: MockSpacingHeuristics(),
+            injector: injector,
+            coordinator: coordinator,
+            restoreDelayAfterMenuFallback: 0.15
+        )
+
+        service.pasteText("hello")
+
+        try await Task.sleep(nanoseconds: 40_000_000)
+        XCTAssertEqual(clipboard.restoreCalls, 0)
+
+        try await waitForCondition {
+            clipboard.restoreCalls == 1
+        }
+        XCTAssertEqual(recovery.startCalls, 0)
     }
 
     func testMenuFallbackFailureStartsRecoveryWhenNotSuppressed() async throws {
@@ -123,8 +153,7 @@ final class PasteServiceExecutionTests: XCTestCase {
             spacing: MockSpacingHeuristics(),
             injector: injector,
             coordinator: coordinator,
-            restoreDelayAfterMenuFallback: 0,
-            restoreDelayAfterAccessibilityInjection: 0
+            restoreDelayAfterMenuFallback: 0
         )
 
         service.pasteText("hello")
@@ -153,8 +182,7 @@ final class PasteServiceExecutionTests: XCTestCase {
             spacing: MockSpacingHeuristics(),
             injector: injector,
             coordinator: coordinator,
-            restoreDelayAfterMenuFallback: 0,
-            restoreDelayAfterAccessibilityInjection: 0
+            restoreDelayAfterMenuFallback: 0
         )
 
         service.pasteText("hello")
@@ -190,7 +218,6 @@ final class PasteServiceExecutionTests: XCTestCase {
             injector: injector,
             coordinator: coordinator,
             restoreDelayAfterMenuFallback: 0,
-            restoreDelayAfterAccessibilityInjection: 0,
             clockNow: { timestamps.next() }
         )
 
@@ -215,12 +242,37 @@ final class PasteServiceExecutionTests: XCTestCase {
             usedMenuFallbackPath: false,
             suppressFirstWarmupFailureWarning: false,
             shouldStartFailureRecovery: false,
-            restoreDelayAfterMenuFallback: 0.8,
-            restoreDelayAfterAccessibilityInjection: 0.25
+            restoreDelayAfterMenuFallback: 0.8
         )
         XCTAssertTrue(restorePlan.shouldRememberInsertion)
         XCTAssertFalse(restorePlan.shouldStartFailureRecovery)
-        XCTAssertEqual(restorePlan.restoreDelay ?? -1, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(restorePlan.restorePolicy, .immediate)
+
+        let verifiedMenuRestorePlan = PasteServiceExecutionPlan.build(
+            didAccessibilityInsertText: false,
+            didMenuFallbackInsert: true,
+            usedMenuFallbackPath: true,
+            menuFallbackCompletionEvidence: .verifiedInsertion,
+            suppressFirstWarmupFailureWarning: false,
+            shouldStartFailureRecovery: false,
+            restoreDelayAfterMenuFallback: 0.8
+        )
+        XCTAssertTrue(verifiedMenuRestorePlan.shouldRememberInsertion)
+        XCTAssertFalse(verifiedMenuRestorePlan.shouldStartFailureRecovery)
+        XCTAssertEqual(verifiedMenuRestorePlan.restorePolicy, .immediate)
+
+        let trustedMenuRestorePlan = PasteServiceExecutionPlan.build(
+            didAccessibilityInsertText: false,
+            didMenuFallbackInsert: true,
+            usedMenuFallbackPath: true,
+            menuFallbackCompletionEvidence: .trustedWithoutVerification,
+            suppressFirstWarmupFailureWarning: false,
+            shouldStartFailureRecovery: false,
+            restoreDelayAfterMenuFallback: 0.8
+        )
+        XCTAssertTrue(trustedMenuRestorePlan.shouldRememberInsertion)
+        XCTAssertFalse(trustedMenuRestorePlan.shouldStartFailureRecovery)
+        XCTAssertEqual(trustedMenuRestorePlan.restorePolicy, .afterDelay(0.8))
 
         let recoveryPlan = PasteServiceExecutionPlan.build(
             didAccessibilityInsertText: false,
@@ -228,12 +280,11 @@ final class PasteServiceExecutionTests: XCTestCase {
             usedMenuFallbackPath: true,
             suppressFirstWarmupFailureWarning: false,
             shouldStartFailureRecovery: true,
-            restoreDelayAfterMenuFallback: 0.8,
-            restoreDelayAfterAccessibilityInjection: 0.25
+            restoreDelayAfterMenuFallback: 0.8
         )
         XCTAssertFalse(recoveryPlan.shouldRememberInsertion)
         XCTAssertTrue(recoveryPlan.shouldStartFailureRecovery)
-        XCTAssertNil(recoveryPlan.restoreDelay)
+        XCTAssertEqual(recoveryPlan.restorePolicy, .deferredToFailureRecovery)
     }
 
     private func makeService(
@@ -244,7 +295,6 @@ final class PasteServiceExecutionTests: XCTestCase {
         injector: MockAccessibilityInjector,
         coordinator: MockMenuFallbackCoordinator,
         restoreDelayAfterMenuFallback: TimeInterval,
-        restoreDelayAfterAccessibilityInjection: TimeInterval,
         clockNow: @escaping () -> Date = Date.init
     ) throws -> PasteService {
         let queue = DispatchQueue(label: "PasteServiceExecutionTests.queue")
@@ -253,7 +303,6 @@ final class PasteServiceExecutionTests: XCTestCase {
             pasteQueue: queue,
             heuristicTTL: 10,
             restoreDelayAfterMenuFallback: restoreDelayAfterMenuFallback,
-            restoreDelayAfterAccessibilityInjection: restoreDelayAfterAccessibilityInjection,
             menuFallbackVerificationTimeout: 0.01,
             menuFallbackVerificationPollInterval: 0.001,
             frontmostAppIdentityProvider: { PasteAppIdentity(bundleID: "com.example.app", pid: 99) },


### PR DESCRIPTION
## What Changed

- Adds menu fallback completion evidence so the paste pipeline can distinguish verified insertion from trusted but unverified success.
- Replaces fixed clipboard restore delays with explicit restore policies for immediate, delayed, and recovery-managed restore paths.
- Restores the clipboard immediately after verified Accessibility insertion, verified menu fallback completion, or no-clipboard payload insertion.
- Preserves a grace delay for trusted menu fallback paths that do not expose concrete insertion evidence.
- Removes the stale Accessibility restore delay configuration now that non-menu restores are immediate.
- Adds debug restore-policy logging to make remaining timing decisions visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced paste fallback handling with improved completion state tracking for better detection of successful operations
  * Optimized clipboard restoration timing to intelligently adapt based on different paste operation outcomes and scenarios
  * Improved overall reliability and user experience for paste operations when standard methods aren't available

* **Tests**
  * Expanded test coverage for paste scenarios including fallback operations and clipboard restoration behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->