### PR TITLE
fix(mac): gate menu fallback clipboard restore on payload evidence

### DIFF
--- a/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
+++ b/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
@@ -8,6 +8,7 @@ protocol PasteAXInspecting {
     func stringForRange(_ range: CFRange, element: AXUIElement) -> String?
     func previousCharacterFromValueAttribute(element: AXUIElement, caretLocation: Int) -> Character?
     func valueLengthForMenuVerification(element: AXUIElement) -> Int?
+    func valueStringForMenuVerification(element: AXUIElement) -> String?
     func candidateVerificationElements(
         for pid: pid_t,
         maxDepth: Int,
@@ -177,12 +178,12 @@ final class PasteAXInspector: PasteAXInspecting {
     }
 
     func valueLengthForMenuVerification(element: AXUIElement) -> Int? {
-        var valueRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, kAXValueAttribute as CFString, &valueRef) == .success,
-              let value = valueRef as? String else {
-            return nil
-        }
+        guard let value = valueStringForMenuVerification(element: element) else { return nil }
         return (value as NSString).length
+    }
+
+    func valueStringForMenuVerification(element: AXUIElement) -> String? {
+        valueString(for: element)
     }
 
     func candidateVerificationElements(

--- a/macOS/Core/Services/Paste/MenuFallback/PasteMenuFallbackCoordinator.swift
+++ b/macOS/Core/Services/Paste/MenuFallback/PasteMenuFallbackCoordinator.swift
@@ -111,7 +111,7 @@ final class PasteMenuFallbackCoordinator {
             let menuAttemptResult = menuFallbackExecutor.pasteViaMenuBarOnMainThread()
             menuAttempt = menuAttemptResult
             var trustWithoutAXVerification = false
-            var verificationPassed = false
+            var verificationOutcome: PasteMenuFallbackVerificationOutcome = .none
 
             if case .actionSucceeded = menuAttemptResult,
                shouldAllowFirstMenuSuccessWarmupSuppression(for: targetAppIdentity) {
@@ -128,38 +128,48 @@ final class PasteMenuFallbackCoordinator {
                     if verificationContext != nil {
                         // Even when AXPress reports success, verify resulting AX state when possible
                         // so we can catch no-op "successful" actions in apps like browser-based editors.
-                        verificationPassed = menuFallbackExecutor.verifyInsertion(using: verificationContext)
+                        verificationOutcome = menuFallbackExecutor.verifyInsertionOutcome(
+                            using: verificationContext,
+                            expectedText: textForMenuPaste
+                        )
                     } else {
-                        verificationPassed = menuFallbackExecutor.verifyInsertionWithoutAXContextOnMainThread(
+                        if menuFallbackExecutor.verifyInsertionWithoutAXContextOnMainThread(
                             initialUndoState: initialUndoState
-                        )
+                        ) {
+                            verificationOutcome = .structuralInsertionObserved
+                        }
                     }
-                    if !verificationPassed {
-                        verificationPassed = menuFallbackExecutor.verifyInsertionUsingLiveValueChangeSession(
-                            liveValueChangeSession
-                        )
+                    if !verificationOutcome.didObserveInsertion {
+                        if menuFallbackExecutor.verifyInsertionUsingLiveValueChangeSession(liveValueChangeSession) {
+                            verificationOutcome = .structuralInsertionObserved
+                        }
                     }
                 }
             case .actionErrored:
                 if verificationContext != nil {
-                    verificationPassed = menuFallbackExecutor.verifyInsertion(using: verificationContext)
-                } else {
-                    verificationPassed = menuFallbackExecutor.verifyInsertionWithoutAXContextOnMainThread(
-                        initialUndoState: initialUndoState
+                    verificationOutcome = menuFallbackExecutor.verifyInsertionOutcome(
+                        using: verificationContext,
+                        expectedText: textForMenuPaste
                     )
+                } else {
+                    if menuFallbackExecutor.verifyInsertionWithoutAXContextOnMainThread(
+                        initialUndoState: initialUndoState
+                    ) {
+                        verificationOutcome = .structuralInsertionObserved
+                    }
                 }
             }
 
             didMenuFallbackInsert = Self.didMenuFallbackInsertForMenuAttempt(
                 attempt: menuAttemptResult,
                 trustMenuSuccessWithoutAXVerification: trustWithoutAXVerification,
-                verificationPassed: verificationPassed
+                verificationPassed: verificationOutcome.didObserveInsertion
             )
             completionEvidence = Self.completionEvidenceForMenuAttempt(
                 attempt: menuAttemptResult,
                 didMenuFallbackInsert: didMenuFallbackInsert,
                 trustMenuSuccessWithoutAXVerification: trustWithoutAXVerification,
-                verificationPassed: verificationPassed
+                verificationOutcome: verificationOutcome
             )
         }
 
@@ -203,19 +213,19 @@ final class PasteMenuFallbackCoordinator {
         attempt: PasteMenuFallbackAttemptResult,
         didMenuFallbackInsert: Bool,
         trustMenuSuccessWithoutAXVerification: Bool,
-        verificationPassed: Bool
+        verificationOutcome: PasteMenuFallbackVerificationOutcome
     ) -> PasteMenuFallbackCompletionEvidence {
         guard didMenuFallbackInsert else { return .none }
         switch attempt {
         case .unavailable:
             return .none
         case .actionSucceeded:
-            if verificationPassed {
-                return .verifiedInsertion
+            if verificationOutcome.didObserveInsertion {
+                return verificationOutcome.completionEvidence
             }
             return trustMenuSuccessWithoutAXVerification ? .trustedWithoutVerification : .none
         case .actionErrored:
-            return verificationPassed ? .verifiedInsertion : .none
+            return verificationOutcome.didObserveInsertion ? verificationOutcome.completionEvidence : .none
         }
     }
 

--- a/macOS/Core/Services/Paste/MenuFallback/PasteMenuFallbackExecutor.swift
+++ b/macOS/Core/Services/Paste/MenuFallback/PasteMenuFallbackExecutor.swift
@@ -5,6 +5,10 @@ protocol PasteMenuFallbackExecuting {
     func frontmostProcessIDOnMainThread() -> pid_t?
     func captureVerificationContext() -> PasteMenuFallbackVerificationContext?
     func verifyInsertion(using context: PasteMenuFallbackVerificationContext?) -> Bool
+    func verifyInsertionOutcome(
+        using context: PasteMenuFallbackVerificationContext?,
+        expectedText: String
+    ) -> PasteMenuFallbackVerificationOutcome
     func captureUndoStateOnMainThread() -> PasteMenuFallbackUndoState?
     func verifyInsertionWithoutAXContextOnMainThread(
         initialUndoState: PasteMenuFallbackUndoState?
@@ -95,29 +99,47 @@ final class PasteMenuFallbackExecutor: PasteMenuFallbackExecuting {
     }
 
     func verifyInsertion(using context: PasteMenuFallbackVerificationContext?) -> Bool {
-        guard let context, !context.snapshots.isEmpty else { return false }
+        verifyInsertionOutcome(using: context, expectedText: "").didObserveInsertion
+    }
+
+    func verifyInsertionOutcome(
+        using context: PasteMenuFallbackVerificationContext?,
+        expectedText: String
+    ) -> PasteMenuFallbackVerificationOutcome {
+        guard let context, !context.snapshots.isEmpty else { return .none }
         let deadline = Date().addingTimeInterval(verificationTimeout)
+        var didObserveStructuralInsertion = false
 
         while Date() < deadline {
             for snapshot in context.snapshots {
                 let currentRange = axInspector.selectedRange(for: snapshot.element)
                 let currentLength = axInspector.valueLengthForMenuVerification(element: snapshot.element)
+                let currentValue = axInspector.valueStringForMenuVerification(element: snapshot.element)
+
+                if expectedPayloadObserved(
+                    expectedText,
+                    snapshot: snapshot,
+                    currentRange: currentRange,
+                    currentValue: currentValue
+                ) {
+                    return .expectedPayloadObserved
+                }
 
                 if let oldRange = snapshot.selectedRange, let currentRange {
                     if oldRange.location != currentRange.location || oldRange.length != currentRange.length {
-                        return true
+                        didObserveStructuralInsertion = true
                     }
                 }
 
                 if let oldLength = snapshot.valueLength, let currentLength, oldLength != currentLength {
-                    return true
+                    didObserveStructuralInsertion = true
                 }
             }
 
             usleep(useconds_t(verificationPollInterval * 1_000_000))
         }
 
-        return false
+        return didObserveStructuralInsertion ? .structuralInsertionObserved : .none
     }
 
     func captureUndoStateOnMainThread() -> PasteMenuFallbackUndoState? {
@@ -270,8 +292,64 @@ final class PasteMenuFallbackExecutor: PasteMenuFallbackExecuting {
         PasteMenuFallbackVerificationSnapshot(
             element: element,
             selectedRange: axInspector.selectedRange(for: element),
-            valueLength: axInspector.valueLengthForMenuVerification(element: element)
+            valueLength: axInspector.valueLengthForMenuVerification(element: element),
+            valueText: axInspector.valueStringForMenuVerification(element: element)
         )
+    }
+
+    private func expectedPayloadObserved(
+        _ expectedText: String,
+        snapshot: PasteMenuFallbackVerificationSnapshot,
+        currentRange: CFRange?,
+        currentValue: String?
+    ) -> Bool {
+        guard !expectedText.isEmpty else { return false }
+        let expectedLength = (expectedText as NSString).length
+
+        if let currentRange,
+           currentRange.location >= expectedLength,
+           let rangeText = axInspector.stringForRange(
+                CFRange(location: currentRange.location - expectedLength, length: expectedLength),
+                element: snapshot.element
+           ),
+           rangeText == expectedText {
+            return true
+        }
+
+        guard let currentValue else { return false }
+        let currentNSString = currentValue as NSString
+
+        if let currentRange,
+           currentRange.location >= expectedLength {
+            let insertedRange = NSRange(
+                location: currentRange.location - expectedLength,
+                length: expectedLength
+            )
+            if NSMaxRange(insertedRange) <= currentNSString.length,
+               currentNSString.substring(with: insertedRange) == expectedText {
+                return true
+            }
+        }
+
+        guard let originalValue = snapshot.valueText else { return false }
+        if let selectedRange = snapshot.selectedRange {
+            let replacementRange = NSRange(location: selectedRange.location, length: selectedRange.length)
+            let originalNSString = originalValue as NSString
+            if replacementRange.location >= 0,
+               NSMaxRange(replacementRange) <= originalNSString.length {
+                let expectedValue = originalNSString.replacingCharacters(
+                    in: replacementRange,
+                    with: expectedText
+                )
+                if currentValue == expectedValue {
+                    return true
+                }
+            }
+        }
+
+        return currentValue != originalValue
+            && !originalValue.contains(expectedText)
+            && currentValue.contains(expectedText)
     }
 
     private func undoStateChanged(

--- a/macOS/Core/Services/Paste/PasteService.swift
+++ b/macOS/Core/Services/Paste/PasteService.swift
@@ -136,6 +136,9 @@ class PasteService {
                 didMenuFallbackInsert = menuFallbackExecution.didMenuFallbackInsert
                 suppressFirstWarmupFailureWarning = menuFallbackExecution.suppressFirstWarmupFailureWarning
                 menuFallbackCompletionEvidence = menuFallbackExecution.completionEvidence
+                #if DEBUG
+                print("Menu fallback completion evidence: \(menuFallbackCompletionEvidence)")
+                #endif
             }
 
             let executionPlan = PasteServiceExecutionPlan.build(

--- a/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
+++ b/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
@@ -42,11 +42,38 @@ enum PasteMenuFallbackAttemptResult {
     case actionErrored
 }
 
-enum PasteMenuFallbackCompletionEvidence {
+enum PasteMenuFallbackCompletionEvidence: Equatable {
     case none
     case noClipboardPayload
-    case verifiedInsertion
+    case expectedPayloadObserved
+    case structuralInsertionObserved
     case trustedWithoutVerification
+}
+
+enum PasteMenuFallbackVerificationOutcome: Equatable {
+    case none
+    case structuralInsertionObserved
+    case expectedPayloadObserved
+
+    var didObserveInsertion: Bool {
+        switch self {
+        case .none:
+            return false
+        case .structuralInsertionObserved, .expectedPayloadObserved:
+            return true
+        }
+    }
+
+    var completionEvidence: PasteMenuFallbackCompletionEvidence {
+        switch self {
+        case .none:
+            return .none
+        case .structuralInsertionObserved:
+            return .structuralInsertionObserved
+        case .expectedPayloadObserved:
+            return .expectedPayloadObserved
+        }
+    }
 }
 
 struct PasteMenuFallbackVerificationContext {
@@ -57,6 +84,19 @@ struct PasteMenuFallbackVerificationSnapshot {
     let element: AXUIElement
     let selectedRange: CFRange?
     let valueLength: Int?
+    let valueText: String?
+
+    init(
+        element: AXUIElement,
+        selectedRange: CFRange?,
+        valueLength: Int?,
+        valueText: String? = nil
+    ) {
+        self.element = element
+        self.selectedRange = selectedRange
+        self.valueLength = valueLength
+        self.valueText = valueText
+    }
 }
 
 struct PasteMenuFallbackUndoState {

--- a/macOS/Core/Services/Paste/Pipeline/PastePolicies.swift
+++ b/macOS/Core/Services/Paste/Pipeline/PastePolicies.swift
@@ -90,9 +90,9 @@ struct PasteServiceExecutionPlan {
         }
 
         switch menuFallbackCompletionEvidence {
-        case .noClipboardPayload, .verifiedInsertion:
+        case .noClipboardPayload, .expectedPayloadObserved:
             return .immediate
-        case .trustedWithoutVerification, .none:
+        case .structuralInsertionObserved, .trustedWithoutVerification, .none:
             return .afterDelay(restoreDelayAfterMenuFallback)
         }
     }

--- a/macOS/KeyVoxTests/Services/DictationPipelineSmokeTests.swift
+++ b/macOS/KeyVoxTests/Services/DictationPipelineSmokeTests.swift
@@ -527,6 +527,14 @@ private final class NoopFallbackExecutor: PasteMenuFallbackExecuting {
         _ = context
         return false
     }
+    func verifyInsertionOutcome(
+        using context: PasteMenuFallbackVerificationContext?,
+        expectedText: String
+    ) -> PasteMenuFallbackVerificationOutcome {
+        _ = context
+        _ = expectedText
+        return .none
+    }
     func captureUndoStateOnMainThread() -> PasteMenuFallbackUndoState? { nil }
     func verifyInsertionWithoutAXContextOnMainThread(initialUndoState: PasteMenuFallbackUndoState?) -> Bool {
         _ = initialUndoState
@@ -567,6 +575,10 @@ private final class NoopAXInspector: PasteAXInspecting {
         return nil
     }
     func valueLengthForMenuVerification(element: AXUIElement) -> Int? {
+        _ = element
+        return nil
+    }
+    func valueStringForMenuVerification(element: AXUIElement) -> String? {
         _ = element
         return nil
     }

--- a/macOS/KeyVoxTests/Services/PasteCapitalizationHeuristicsTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteCapitalizationHeuristicsTests.swift
@@ -408,6 +408,7 @@ private final class MockPasteAXInspector: PasteAXInspecting {
     func stringForRange(_ range: CFRange, element: AXUIElement) -> String? { nil }
     func previousCharacterFromValueAttribute(element: AXUIElement, caretLocation: Int) -> Character? { nil }
     func valueLengthForMenuVerification(element: AXUIElement) -> Int? { nil }
+    func valueStringForMenuVerification(element: AXUIElement) -> String? { nil }
     func candidateVerificationElements(
         for pid: pid_t,
         maxDepth: Int,

--- a/macOS/KeyVoxTests/Services/PasteDecisionMatrixTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteDecisionMatrixTests.swift
@@ -44,15 +44,25 @@ final class PasteDecisionMatrixTests: XCTestCase {
         )
     }
 
-    func testMenuCompletionEvidenceDistinguishesVerifiedAndTrustedSuccess() {
+    func testMenuCompletionEvidenceDistinguishesPayloadStructuralAndTrustedSuccess() {
         XCTAssertEqual(
             PasteMenuFallbackCoordinator.completionEvidenceForMenuAttempt(
                 attempt: .actionSucceeded,
                 didMenuFallbackInsert: true,
                 trustMenuSuccessWithoutAXVerification: false,
-                verificationPassed: true
+                verificationOutcome: .expectedPayloadObserved
             ),
-            .verifiedInsertion
+            .expectedPayloadObserved
+        )
+
+        XCTAssertEqual(
+            PasteMenuFallbackCoordinator.completionEvidenceForMenuAttempt(
+                attempt: .actionSucceeded,
+                didMenuFallbackInsert: true,
+                trustMenuSuccessWithoutAXVerification: false,
+                verificationOutcome: .structuralInsertionObserved
+            ),
+            .structuralInsertionObserved
         )
 
         XCTAssertEqual(
@@ -60,7 +70,7 @@ final class PasteDecisionMatrixTests: XCTestCase {
                 attempt: .actionSucceeded,
                 didMenuFallbackInsert: true,
                 trustMenuSuccessWithoutAXVerification: true,
-                verificationPassed: false
+                verificationOutcome: .none
             ),
             .trustedWithoutVerification
         )
@@ -70,7 +80,7 @@ final class PasteDecisionMatrixTests: XCTestCase {
                 attempt: .actionSucceeded,
                 didMenuFallbackInsert: false,
                 trustMenuSuccessWithoutAXVerification: true,
-                verificationPassed: false
+                verificationOutcome: .none
             ),
             .none
         )

--- a/macOS/KeyVoxTests/Services/PasteMenuFallbackCoordinatorExecutionTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteMenuFallbackCoordinatorExecutionTests.swift
@@ -258,6 +258,7 @@ private final class MockPasteMenuFallbackExecutor: PasteMenuFallbackExecuting {
     var verificationContext: PasteMenuFallbackVerificationContext?
     var undoState: PasteMenuFallbackUndoState?
     var verifyInsertionResult = false
+    var verifyInsertionOutcomeResult: PasteMenuFallbackVerificationOutcome?
     var verifyInsertionWithoutAXResult = false
     var verifyLiveResult = false
     var liveSession: PasteAXLiveSessioning?
@@ -286,6 +287,19 @@ private final class MockPasteMenuFallbackExecutor: PasteMenuFallbackExecuting {
         _ = context
         verifyInsertionCalls += 1
         return verifyInsertionResult
+    }
+
+    func verifyInsertionOutcome(
+        using context: PasteMenuFallbackVerificationContext?,
+        expectedText: String
+    ) -> PasteMenuFallbackVerificationOutcome {
+        _ = context
+        _ = expectedText
+        verifyInsertionCalls += 1
+        if let verifyInsertionOutcomeResult {
+            return verifyInsertionOutcomeResult
+        }
+        return verifyInsertionResult ? .structuralInsertionObserved : .none
     }
 
     func captureUndoStateOnMainThread() -> PasteMenuFallbackUndoState? {

--- a/macOS/KeyVoxTests/Services/PasteMenuFallbackExecutorTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteMenuFallbackExecutorTests.swift
@@ -48,6 +48,59 @@ final class PasteMenuFallbackExecutorTests: XCTestCase {
         XCTAssertTrue(executor.verifyInsertion(using: context))
     }
 
+    func testVerifyInsertionOutcomeObservesExpectedPayloadBeforeCaret() {
+        let inspector = MockPasteAXInspector()
+        let element = makeRetainedElement()
+        inspector.setRange(
+            for: element,
+            values: [CFRange(location: 5, length: 0)]
+        )
+        inspector.setStringForRange("hello", location: 0, length: 5, element: element)
+
+        let executor = makeExecutor(inspector: inspector)
+
+        let context = PasteMenuFallbackVerificationContext(
+            snapshots: [
+                PasteMenuFallbackVerificationSnapshot(
+                    element: element,
+                    selectedRange: CFRange(location: 0, length: 0),
+                    valueLength: nil
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            executor.verifyInsertionOutcome(using: context, expectedText: "hello"),
+            .expectedPayloadObserved
+        )
+    }
+
+    func testVerifyInsertionOutcomeKeepsRangeMovementStructuralWhenPayloadIsNotObserved() {
+        let inspector = MockPasteAXInspector()
+        let element = makeRetainedElement()
+        inspector.setRange(
+            for: element,
+            values: [CFRange(location: 5, length: 0)]
+        )
+
+        let executor = makeExecutor(inspector: inspector)
+
+        let context = PasteMenuFallbackVerificationContext(
+            snapshots: [
+                PasteMenuFallbackVerificationSnapshot(
+                    element: element,
+                    selectedRange: CFRange(location: 0, length: 0),
+                    valueLength: nil
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            executor.verifyInsertionOutcome(using: context, expectedText: "hello"),
+            .structuralInsertionObserved
+        )
+    }
+
     func testVerifyInsertionReturnsTrueWhenValueLengthChanges() {
         let inspector = MockPasteAXInspector()
         let element = makeRetainedElement()
@@ -112,6 +165,9 @@ private final class MockPasteAXInspector: PasteAXInspecting {
     private var rangeIndex = 0
     private var valueLengthSequence: [Int?] = [nil]
     private var valueLengthIndex = 0
+    private var valueStringSequence: [String?] = [nil]
+    private var valueStringIndex = 0
+    private var rangeStringByLocationAndLength: [String: String] = [:]
 
     func setRange(for element: AXUIElement, values: [CFRange]) {
         _ = element
@@ -125,10 +181,24 @@ private final class MockPasteAXInspector: PasteAXInspecting {
         valueLengthIndex = 0
     }
 
+    func setValueStrings(for element: AXUIElement, values: [String]) {
+        _ = element
+        valueStringSequence = values.map { Optional($0) }
+        valueStringIndex = 0
+    }
+
+    func setStringForRange(_ text: String, location: Int, length: Int, element: AXUIElement) {
+        _ = element
+        rangeStringByLocationAndLength["\(location):\(length)"] = text
+    }
+
     func focusedInsertionContext() -> PasteInsertionContext? { nil }
     func focusedUIElement() -> AXUIElement? { nil }
     func roleString(for element: AXUIElement) -> String? { nil }
-    func stringForRange(_ range: CFRange, element: AXUIElement) -> String? { nil }
+    func stringForRange(_ range: CFRange, element: AXUIElement) -> String? {
+        _ = element
+        return rangeStringByLocationAndLength["\(range.location):\(range.length)"]
+    }
     func previousCharacterFromValueAttribute(element: AXUIElement, caretLocation: Int) -> Character? { nil }
     func candidateVerificationElements(
         for pid: pid_t,
@@ -150,6 +220,13 @@ private final class MockPasteAXInspector: PasteAXInspecting {
         _ = element
         let value = valueLengthSequence[min(valueLengthIndex, valueLengthSequence.count - 1)]
         valueLengthIndex += 1
+        return value
+    }
+
+    func valueStringForMenuVerification(element: AXUIElement) -> String? {
+        _ = element
+        let value = valueStringSequence[min(valueStringIndex, valueStringSequence.count - 1)]
+        valueStringIndex += 1
         return value
     }
 }

--- a/macOS/KeyVoxTests/Services/PasteServiceExecutionMocks.swift
+++ b/macOS/KeyVoxTests/Services/PasteServiceExecutionMocks.swift
@@ -166,6 +166,14 @@ final class PasteServiceNoopFallbackExecutor: PasteMenuFallbackExecuting {
         _ = context
         return false
     }
+    func verifyInsertionOutcome(
+        using context: PasteMenuFallbackVerificationContext?,
+        expectedText: String
+    ) -> PasteMenuFallbackVerificationOutcome {
+        _ = context
+        _ = expectedText
+        return .none
+    }
     func captureUndoStateOnMainThread() -> PasteMenuFallbackUndoState? { nil }
     func verifyInsertionWithoutAXContextOnMainThread(initialUndoState: PasteMenuFallbackUndoState?) -> Bool {
         _ = initialUndoState
@@ -206,6 +214,10 @@ final class MockAXInspector: PasteAXInspecting {
         return nil
     }
     func valueLengthForMenuVerification(element: AXUIElement) -> Int? {
+        _ = element
+        return nil
+    }
+    func valueStringForMenuVerification(element: AXUIElement) -> String? {
         _ = element
         return nil
     }

--- a/macOS/KeyVoxTests/Services/PasteServiceExecutionTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteServiceExecutionTests.swift
@@ -81,7 +81,7 @@ final class PasteServiceExecutionTests: XCTestCase {
         let coordinator = MockMenuFallbackCoordinator(result: .init(
             didMenuFallbackInsert: true,
             menuAttempt: .actionSucceeded,
-            completionEvidence: .verifiedInsertion,
+            completionEvidence: .expectedPayloadObserved,
             suppressFirstWarmupFailureWarning: false
         ))
         let service = try makeService(
@@ -102,6 +102,38 @@ final class PasteServiceExecutionTests: XCTestCase {
 
         XCTAssertEqual(recovery.startCalls, 0)
         XCTAssertEqual(coordinator.executeCalls, 1)
+    }
+
+    func testStructuralMenuFallbackKeepsGraceDelayBeforeRestoringClipboard() async throws {
+        let clipboard = MockClipboardAdapter(snapshot: [[:]])
+        let recovery = MockFailureRecoveryController()
+        let capitalization = MockCapitalizationHeuristics(outputText: "hello")
+        let injector = MockAccessibilityInjector(outcome: .failureNeedsFallback)
+        let coordinator = MockMenuFallbackCoordinator(result: .init(
+            didMenuFallbackInsert: true,
+            menuAttempt: .actionSucceeded,
+            completionEvidence: .structuralInsertionObserved,
+            suppressFirstWarmupFailureWarning: false
+        ))
+        let service = try makeService(
+            clipboard: clipboard,
+            recovery: recovery,
+            capitalization: capitalization,
+            spacing: MockSpacingHeuristics(),
+            injector: injector,
+            coordinator: coordinator,
+            restoreDelayAfterMenuFallback: 0.15
+        )
+
+        service.pasteText("hello")
+
+        try await Task.sleep(nanoseconds: 40_000_000)
+        XCTAssertEqual(clipboard.restoreCalls, 0)
+
+        try await waitForCondition {
+            clipboard.restoreCalls == 1
+        }
+        XCTAssertEqual(recovery.startCalls, 0)
     }
 
     func testTrustedMenuFallbackKeepsGraceDelayBeforeRestoringClipboard() async throws {
@@ -252,7 +284,7 @@ final class PasteServiceExecutionTests: XCTestCase {
             didAccessibilityInsertText: false,
             didMenuFallbackInsert: true,
             usedMenuFallbackPath: true,
-            menuFallbackCompletionEvidence: .verifiedInsertion,
+            menuFallbackCompletionEvidence: .expectedPayloadObserved,
             suppressFirstWarmupFailureWarning: false,
             shouldStartFailureRecovery: false,
             restoreDelayAfterMenuFallback: 0.8
@@ -260,6 +292,19 @@ final class PasteServiceExecutionTests: XCTestCase {
         XCTAssertTrue(verifiedMenuRestorePlan.shouldRememberInsertion)
         XCTAssertFalse(verifiedMenuRestorePlan.shouldStartFailureRecovery)
         XCTAssertEqual(verifiedMenuRestorePlan.restorePolicy, .immediate)
+
+        let structuralMenuRestorePlan = PasteServiceExecutionPlan.build(
+            didAccessibilityInsertText: false,
+            didMenuFallbackInsert: true,
+            usedMenuFallbackPath: true,
+            menuFallbackCompletionEvidence: .structuralInsertionObserved,
+            suppressFirstWarmupFailureWarning: false,
+            shouldStartFailureRecovery: false,
+            restoreDelayAfterMenuFallback: 0.8
+        )
+        XCTAssertTrue(structuralMenuRestorePlan.shouldRememberInsertion)
+        XCTAssertFalse(structuralMenuRestorePlan.shouldStartFailureRecovery)
+        XCTAssertEqual(structuralMenuRestorePlan.restorePolicy, .afterDelay(0.8))
 
         let trustedMenuRestorePlan = PasteServiceExecutionPlan.build(
             didAccessibilityInsertText: false,

--- a/macOS/KeyVoxTests/Services/PasteSpacingHeuristicsTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteSpacingHeuristicsTests.swift
@@ -181,6 +181,7 @@ private final class MockPasteAXInspector: PasteAXInspecting {
     func stringForRange(_ range: CFRange, element: AXUIElement) -> String? { nil }
     func previousCharacterFromValueAttribute(element: AXUIElement, caretLocation: Int) -> Character? { nil }
     func valueLengthForMenuVerification(element: AXUIElement) -> Int? { nil }
+    func valueStringForMenuVerification(element: AXUIElement) -> String? { nil }
     func candidateVerificationElements(
         for pid: pid_t,
         maxDepth: Int,


### PR DESCRIPTION
## Summary

This updates the Mac paste fallback path so clipboard restoration is based on the quality of insertion evidence instead of treating every verified menu fallback the same.

## What Changed

- Distinguishes expected payload evidence from structural-only insertion evidence.
- Restores the clipboard immediately only when the expected dictated text is observed in the target field.
- Keeps the existing menu fallback grace delay when insertion is only inferred from caret movement, value length changes, undo state, live value changes, or trusted menu success.
- Captures AX value text during menu fallback verification so the expected paste payload can be matched directly.
- Adds debug logging for the menu fallback completion evidence path.
- Updates paste fallback tests and mocks for the new evidence model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection of successful paste operations by distinguishing between exact payload insertion and structural changes, improving reliability when using accessibility-based paste.
  * Refined clipboard restoration timing to match verification method—immediate restoration when expected text is detected, delayed when only structural changes are observed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->