### PR TITLE
feat(ios): add Speak Timeout for warm TTS runtime retention

### DIFF
--- a/iOS/Docs/CODEMAP.md
+++ b/iOS/Docs/CODEMAP.md
@@ -155,6 +155,7 @@ iOS/
 │   │   │   │   ├── TTSManager.swift
 │   │   │   │   ├── TTSManager+AppLifecycle.swift
 │   │   │   │   ├── TTSManager+Playback.swift
+│   │   │   │   ├── TTSManager+RuntimeUnload.swift
 │   │   │   │   ├── TTSManager+State.swift
 │   │   │   │   ├── TTSManager+SystemPlayback.swift
 │   │   │   │   └── TTSManagerPolicy.swift
@@ -569,7 +570,7 @@ Packages/
   - Split playback transport owner for deterministic startup runway, background-safe continuation, replay capture, pause and resume, metering, progress publishing, playback scheduling, and preserved-TTS route-family selection.
 - `KeyVox iOS/Core/TTS/TTSManager/`
   - Split high-level copied-text playback owner for request lifecycle, preparation progress, replay state, paused replay restoration, lifecycle observation, system playback command routing, App Group TTS state publishing, and the consume-on-success free-speak hook used by phase-one monetization.
-  - Unloads the PocketTTS runtime when generated audio becomes replayable, playback is explicitly stopped, or playback errors.
+  - Owns user-configured Speak Timeout behavior by unloading the PocketTTS runtime immediately or after the selected warm-retention window when generated playback finishes, is stopped, or errors.
 - `KeyVox iOS/Core/TTS/TTSSystemPlaybackController.swift`
   - Public `MediaPlayer` integration owner for lock screen and Control Center now-playing metadata, replay scrubber command exposure, and remote transport command wiring.
 - `KeyVox iOS/Core/TTS/TTSReplayCache.swift`

--- a/iOS/Docs/ENGINEERING.md
+++ b/iOS/Docs/ENGINEERING.md
@@ -332,6 +332,7 @@ Keyboard onboarding detection is deliberately split across three signals:
 - `KeyVox.PreferBuiltInMicrophone`
 - `KeyVox.LiveActivitiesEnabled`
 - `KeyVox.SessionDisableTiming`
+- `KeyVox.SpeakTimeoutTiming`
 - `KeyVox.TTSVoice`
 - `KeyVox.FastPlaybackModeEnabled`
 
@@ -669,7 +670,7 @@ Primary owners:
 - `TTSPlaybackCoordinator` owns audio-engine playback, deterministic runway gating, background-safe continuation, replayable-audio capture, replay seeking, and pause/resume.
 - `AudioBluetoothRoutePolicy` owns the preserved-TTS Bluetooth route-family decision and is the only owner allowed to translate the built-in microphone preference into A2DP-vs-HFP playback behavior.
 - `TTSManager` owns request lifecycle, playback-preparation progress, home-card replay state, replay cache persistence, paused replay restoration, system playback coordination / metadata assembly, remote transport command routing, App Group TTS state publishing, and the free-speak consumption point once a new generation has actually started.
-- `TTSManager` is responsible for unloading the PocketTTS runtime once live generation is no longer needed: after generated playback becomes replayable, after explicit stop, or after playback error.
+- `TTSManager` is responsible for applying the user-facing Speak Timeout setting to PocketTTS runtime lifetime once live generation is no longer needed: immediate unload for the `Immediately` preset, or delayed unload after the selected warm-retention window.
 - `TTSSystemPlaybackController` owns MediaPlayer API integration and publication of transport & now-playing metadata for lock screen and Control Center transport.
 - `AudioModeCoordinator` is the only owner allowed to arbitrate dictation-versus-TTS transitions and to enforce the copied-text playback gate before new TTS starts.
 - the keyboard playback transport is intentionally split:
@@ -695,7 +696,8 @@ Primary owners:
 
 - `PocketTTSModelManager` is split by concern into `PocketTTSModelManager.swift`, `PocketTTSModelManager+InstallLifecycle.swift`, and `PocketTTSModelManager+Support.swift`
 - `PocketTTSEngine` owns the app-side runtime wrapper seam around `KeyVoxPocketTTSRuntime` so tests can verify runtime creation, preparation, compute-mode requests, and unload behavior without instantiating real Core ML assets.
-- `TTSManager` is split by concern into `TTSManager.swift`, `TTSManager+Playback.swift`, `TTSManager+State.swift`, `TTSManager+SystemPlayback.swift`, `TTSManager+AppLifecycle.swift`, and `TTSManagerPolicy.swift`
+- `TTSManager` is split by concern into `TTSManager.swift`, `TTSManager+Playback.swift`, `TTSManager+State.swift`, `TTSManager+RuntimeUnload.swift`, `TTSManager+SystemPlayback.swift`, `TTSManager+AppLifecycle.swift`, and `TTSManagerPolicy.swift`
+  - `TTSManager+RuntimeUnload.swift` owns Speak Timeout scheduling, cancelation on new playback, memory-warning unloads, asset-invalidation unloads, and debug unload-reason logging.
   - `TTSManager+SystemPlayback.swift` should stay as the TTSManager-facing adapter layer that translates internal playback state and events into system playback intent, assembles metadata, and decides when the system surface should update.
 - `TTSPlaybackCoordinator` is split by concern into `TTSPlaybackCoordinator.swift`, `TTSPlaybackCoordinator+Lifecycle.swift`, `TTSPlaybackCoordinator+Scheduling.swift`, `TTSPlaybackCoordinator+Progress.swift`, and `TTSPlaybackCoordinatorBufferingPolicy.swift`
 - `AudioBluetoothRoutePolicy.swift` stays separate from both recorder input preference resolution and TTS playback lifecycle code so Bluetooth route-family mapping remains isolated and testable.
@@ -711,7 +713,10 @@ Primary owners:
 - `PocketTTSEngine.unloadIfNeeded()` releases the runtime, clears the prepared flag, and clears loaded asset identity so the next generation rebuilds from the current installed assets.
 - Foreground/background compute-mode changes may only run against an existing prepared runtime.
 - Immediate compute-mode request helpers are hints for already prepared runtimes; they must not instantiate or prepare the runtime by themselves.
-- Runtime unload must happen when the current generation is no longer needed, while replayable rendered audio stays available through the replay cache and playback coordinator.
+- Runtime unload after playback must follow `AppSettingsStore.speakTimeoutTiming`: `Immediately` unloads on replayable-audio readiness, explicit stop, finish, or error; timed presets keep the prepared runtime warm until the selected timeout expires.
+- Starting a new generated Speak request cancels any pending timed runtime unload and starts a new timeout window after that playback ends.
+- Memory warnings and PocketTTS shared-model or voice asset invalidation must unload immediately regardless of the user-selected Speak Timeout.
+- Warm-runtime UI indicators must represent only that the PocketTTS runtime has cleared the cold-load path; they must not imply first audio is ready.
 
 ### Fast Mode and Normal Mode Rules
 

--- a/iOS/Docs/ENGINEERING.md
+++ b/iOS/Docs/ENGINEERING.md
@@ -697,7 +697,7 @@ Primary owners:
 - `PocketTTSModelManager` is split by concern into `PocketTTSModelManager.swift`, `PocketTTSModelManager+InstallLifecycle.swift`, and `PocketTTSModelManager+Support.swift`
 - `PocketTTSEngine` owns the app-side runtime wrapper seam around `KeyVoxPocketTTSRuntime` so tests can verify runtime creation, preparation, compute-mode requests, and unload behavior without instantiating real Core ML assets.
 - `TTSManager` is split by concern into `TTSManager.swift`, `TTSManager+Playback.swift`, `TTSManager+State.swift`, `TTSManager+RuntimeUnload.swift`, `TTSManager+SystemPlayback.swift`, `TTSManager+AppLifecycle.swift`, and `TTSManagerPolicy.swift`
-  - `TTSManager+RuntimeUnload.swift` owns Speak Timeout scheduling, cancelation on new playback, memory-warning unloads, asset-invalidation unloads, and debug unload-reason logging.
+  - `TTSManager+RuntimeUnload.swift` owns Speak Timeout scheduling, cancellation on new playback, memory-warning unloads, asset-invalidation unloads, and debug unload-reason logging.
   - `TTSManager+SystemPlayback.swift` should stay as the TTSManager-facing adapter layer that translates internal playback state and events into system playback intent, assembles metadata, and decides when the system surface should update.
 - `TTSPlaybackCoordinator` is split by concern into `TTSPlaybackCoordinator.swift`, `TTSPlaybackCoordinator+Lifecycle.swift`, `TTSPlaybackCoordinator+Scheduling.swift`, `TTSPlaybackCoordinator+Progress.swift`, and `TTSPlaybackCoordinatorBufferingPolicy.swift`
 - `AudioBluetoothRoutePolicy.swift` stays separate from both recorder input preference resolution and TTS playback lifecycle code so Bluetooth route-family mapping remains isolated and testable.

--- a/iOS/KeyVox iOS/App/Composition/AppServiceRegistry.swift
+++ b/iOS/KeyVox iOS/App/Composition/AppServiceRegistry.swift
@@ -182,6 +182,11 @@ final class AppServiceRegistry {
                 keyVoxSpeakIntroController?.markFeatureUsed()
             }
         )
+        pocketTTSModelManager.onDidInvalidateInstalledAssets = { [weak ttsManager] in
+            Task { @MainActor [weak ttsManager] in
+                ttsManager?.unloadRuntimeImmediately(reason: .assetInvalidated)
+            }
+        }
         let audioModeCoordinator = AudioModeCoordinator(
             transcriptionManager: transcriptionManager,
             ttsManager: ttsManager,

--- a/iOS/KeyVox iOS/App/iCloud/AppSettingsStore.swift
+++ b/iOS/KeyVox iOS/App/iCloud/AppSettingsStore.swift
@@ -28,6 +28,33 @@ enum SessionDisableTiming: String, CaseIterable, Identifiable {
     }
 }
 
+enum SpeakTimeoutTiming: String, CaseIterable, Identifiable {
+    case immediately
+    case fiveMinutes
+    case fifteenMinutes
+    case oneHour
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .immediately: return "Immediately"
+        case .fiveMinutes: return "5 Minutes"
+        case .fifteenMinutes: return "15 Minutes"
+        case .oneHour: return "1 Hour"
+        }
+    }
+
+    var unloadDelay: TimeInterval? {
+        switch self {
+        case .immediately: return nil
+        case .fiveMinutes: return 300
+        case .fifteenMinutes: return 900
+        case .oneHour: return 3600
+        }
+    }
+}
+
 @MainActor
 final class AppSettingsStore: ObservableObject {
     typealias TTSVoice = KeyVoxPlaybackVoice
@@ -138,6 +165,12 @@ final class AppSettingsStore: ObservableObject {
         }
     }
 
+    @Published var speakTimeoutTiming: SpeakTimeoutTiming {
+        didSet {
+            defaults.set(speakTimeoutTiming.rawValue, forKey: UserDefaultsKeys.speakTimeoutTiming)
+        }
+    }
+
     @Published var ttsVoice: TTSVoice {
         didSet {
             defaults.set(ttsVoice.rawValue, forKey: UserDefaultsKeys.ttsVoice)
@@ -179,6 +212,13 @@ final class AppSettingsStore: ObservableObject {
             sessionDisableTiming = timing
         } else {
             sessionDisableTiming = .fiveMinutes
+        }
+
+        if let raw = defaults.string(forKey: UserDefaultsKeys.speakTimeoutTiming),
+           let timing = SpeakTimeoutTiming(rawValue: raw) {
+            speakTimeoutTiming = timing
+        } else {
+            speakTimeoutTiming = .fiveMinutes
         }
 
         if let raw = defaults.string(forKey: UserDefaultsKeys.ttsVoice),

--- a/iOS/KeyVox iOS/App/iCloud/UserDefaultsKeys.swift
+++ b/iOS/KeyVox iOS/App/iCloud/UserDefaultsKeys.swift
@@ -9,6 +9,7 @@ nonisolated enum UserDefaultsKeys {
     static let preferBuiltInMicrophone = "KeyVox.PreferBuiltInMicrophone"
     static let liveActivitiesEnabled = "KeyVox.LiveActivitiesEnabled"
     static let sessionDisableTiming = "KeyVox.SessionDisableTiming"
+    static let speakTimeoutTiming = "KeyVox.SpeakTimeoutTiming"
     static let ttsVoice = "KeyVox.TTSVoice"
     static let fastPlaybackModeEnabled = "KeyVox.FastPlaybackModeEnabled"
 

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSEngine.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSEngine.swift
@@ -59,6 +59,10 @@ final class PocketTTSEngine: TTSEngine {
     private var loadedAssetFingerprint: String?
 
     private let fileManager: FileManager
+
+    var isPreparedForSynthesis: Bool {
+        runtime != nil && isRuntimePrepared
+    }
     
     init(
         fileManager: FileManager = .default,
@@ -76,11 +80,15 @@ final class PocketTTSEngine: TTSEngine {
     }
 
     func prepareIfNeeded() async throws {
-        Self.log("PocketTTS model load begin.")
+        let wasPrepared = isPreparedForSynthesis
+        let startTime = CFAbsoluteTimeGetCurrent()
+        Self.log("PocketTTS model prepare begin warmStart=\(wasPrepared).")
         let runtime = try runtimeForInstalledAssets()
         try await runtime.prepareIfNeeded()
         isRuntimePrepared = true
-        Self.log("PocketTTS model load end.")
+        Self.log(
+            "PocketTTS model prepare end warmStart=\(wasPrepared) durationSeconds=\(String(format: "%.3f", CFAbsoluteTimeGetCurrent() - startTime))."
+        )
     }
 
     func prewarmVoiceIfNeeded(voiceID: String) async throws {

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+InstallLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+InstallLifecycle.swift
@@ -101,6 +101,7 @@ extension PocketTTSModelManager {
 
     func deleteSharedModel() {
         Self.log("Deleting installed PocketTTS shared model assets.")
+        onDidInvalidateInstalledAssets?()
         installTask?.cancel()
         installTask = nil
         activeInstallTarget = nil
@@ -136,6 +137,7 @@ extension PocketTTSModelManager {
     }
 
     func deleteVoice(_ voice: AppSettingsStore.TTSVoice) {
+        onDidInvalidateInstalledAssets?()
         if let voiceRootURL = SharedPaths.pocketTTSVoiceDirectoryURL(fileManager: fileManager)?
             .appendingPathComponent(voice.rawValue, isDirectory: true) {
             try? fileManager.removeItem(at: voiceRootURL)

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager.swift
@@ -40,6 +40,7 @@ final class PocketTTSModelManager: ObservableObject {
     let assetLocator: PocketTTSAssetLocator
     var installTask: Task<Void, Never>?
     var pendingVoiceInstallAfterSharedModel: AppSettingsStore.TTSVoice?
+    var onDidInvalidateInstalledAssets: (() -> Void)?
 
     init(
         fileManager: FileManager = .default,

--- a/iOS/KeyVox iOS/Core/TTS/TTSEngine.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSEngine.swift
@@ -2,6 +2,8 @@ import Foundation
 import KeyVoxTTS
 
 protocol TTSEngine {
+    var isPreparedForSynthesis: Bool { get }
+
     func prepareIfNeeded() async throws
     func prewarmVoiceIfNeeded(voiceID: String) async throws
     func unloadIfNeeded()

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+AppLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+AppLifecycle.swift
@@ -169,6 +169,11 @@ extension TTSManager {
     }
 
     @objc
+    func handleMemoryWarningNotification(_ notification: Notification) {
+        unloadRuntimeImmediately(reason: .memoryWarning)
+    }
+
+    @objc
     func handleAudioSessionInterruptionNotification(_ notification: Notification) {
         let typeDescription: String
         if let userInfo = notification.userInfo,

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
@@ -58,6 +58,7 @@ extension TTSManager {
 
     func startPlayback(_ request: KeyVoxTTSRequest, showPreparationView: Bool = false) async {
         clearWarningMessage()
+        cancelScheduledRuntimeUnload(reason: "newPlayback")
 
         if canReplayExistingAsset(for: request) {
             Self.log(
@@ -94,6 +95,10 @@ extension TTSManager {
         beginBackgroundTaskIfNeeded()
         await engine.prepareForForegroundSynthesis()
         playbackCoordinator.prepareForForegroundPlayback()
+        isCurrentPlaybackWarmStart = engine.isPreparedForSynthesis
+        Self.log(
+            "Playback start runtimeWarm=\(isCurrentPlaybackWarmStart) speakTimeout=\(settingsStore.speakTimeoutTiming.rawValue)"
+        )
         updateState(.preparing)
 
         do {
@@ -220,7 +225,7 @@ extension TTSManager {
             Self.log("Stop requested with no active request.")
         }
         playbackCoordinator.stop()
-        engine.unloadIfNeeded()
+        scheduleRuntimeUnloadAfterPlayback(reason: .stopPlayback)
         await onWillTeardownPlayback?()
         KeyVoxIPCBridge.clearTTSRequest()
         keyboardBridge.publishTTSStopped()

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
@@ -58,7 +58,7 @@ extension TTSManager {
 
     func startPlayback(_ request: KeyVoxTTSRequest, showPreparationView: Bool = false) async {
         clearWarningMessage()
-        cancelScheduledRuntimeUnload(reason: "newPlayback")
+        cancelScheduledRuntimeUnload(logContext: "newPlayback")
 
         if canReplayExistingAsset(for: request) {
             Self.log(

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+RuntimeUnload.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+RuntimeUnload.swift
@@ -21,10 +21,14 @@ extension TTSManager {
         unloadRuntimeImmediately(reason: .replayableAudioReady)
     }
 
-    func scheduleRuntimeUnloadAfterPlayback(reason: TTSRuntimeUnloadReason) {
+    func scheduleRuntimeUnloadAfterPlayback(
+        reason: TTSRuntimeUnloadReason,
+        startedAt: Date = Date()
+    ) {
         runtimeUnloadTask?.cancel()
         runtimeUnloadTask = nil
         pendingRuntimeUnloadReason = nil
+        pendingRuntimeUnloadStartedAt = nil
 
         guard let delay = settingsStore.speakTimeoutTiming.unloadDelay else {
             unloadRuntimeImmediately(reason: reason)
@@ -36,32 +40,40 @@ extension TTSManager {
             return
         }
 
+        let elapsedTime = max(0, Date().timeIntervalSince(startedAt))
+        let remainingDelay = max(0, delay - elapsedTime)
+        guard remainingDelay > 0 else {
+            unloadRuntimeImmediately(reason: .speakTimeoutExpired)
+            return
+        }
+
         pendingRuntimeUnloadReason = reason
+        pendingRuntimeUnloadStartedAt = startedAt
         Self.log(
-            "Scheduling PocketTTS runtime unload reason=\(reason.rawValue) delaySeconds=\(String(format: "%.0f", delay))."
+            "Scheduling PocketTTS runtime unload reason=\(reason.rawValue) delaySeconds=\(String(format: "%.0f", remainingDelay))."
         )
         runtimeUnloadTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            try? await Task.sleep(nanoseconds: UInt64(remainingDelay * 1_000_000_000))
             guard Task.isCancelled == false else { return }
-            self?.runtimeUnloadTask = nil
-            self?.pendingRuntimeUnloadReason = nil
             self?.unloadRuntimeImmediately(reason: .speakTimeoutExpired)
         }
     }
 
-    func cancelScheduledRuntimeUnload(reason: String) {
+    func cancelScheduledRuntimeUnload(logContext: String) {
         guard runtimeUnloadTask != nil else { return }
 
-        Self.log("Canceling scheduled PocketTTS runtime unload reason=\(reason).")
+        Self.log("Canceling scheduled PocketTTS runtime unload context=\(logContext).")
         runtimeUnloadTask?.cancel()
         runtimeUnloadTask = nil
         pendingRuntimeUnloadReason = nil
+        pendingRuntimeUnloadStartedAt = nil
     }
 
     func unloadRuntimeImmediately(reason: TTSRuntimeUnloadReason) {
         runtimeUnloadTask?.cancel()
         runtimeUnloadTask = nil
         pendingRuntimeUnloadReason = nil
+        pendingRuntimeUnloadStartedAt = nil
 
         guard engine.isPreparedForSynthesis else {
             Self.log("Skipping PocketTTS runtime unload reason=\(reason.rawValue) because runtime is not warm.")
@@ -80,6 +92,14 @@ extension TTSManager {
             return
         }
 
-        scheduleRuntimeUnloadAfterPlayback(reason: pendingRuntimeUnloadReason)
+        guard settingsStore.speakTimeoutTiming.unloadDelay != nil else {
+            unloadRuntimeImmediately(reason: .settingChangedToImmediate)
+            return
+        }
+
+        scheduleRuntimeUnloadAfterPlayback(
+            reason: pendingRuntimeUnloadReason,
+            startedAt: pendingRuntimeUnloadStartedAt ?? Date()
+        )
     }
 }

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+RuntimeUnload.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+RuntimeUnload.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+enum TTSRuntimeUnloadReason: String {
+    case assetInvalidated
+    case memoryWarning
+    case playbackError
+    case playbackFinished
+    case replayableAudioReady
+    case settingChangedToImmediate
+    case speakTimeoutExpired
+    case stopPlayback
+}
+
+extension TTSManager {
+    func releaseRuntimeWhenReplayableAudioIsReady() {
+        guard settingsStore.speakTimeoutTiming == .immediately else {
+            Self.log("Retaining PocketTTS runtime until playback ends because speakTimeout=\(settingsStore.speakTimeoutTiming.rawValue).")
+            return
+        }
+
+        unloadRuntimeImmediately(reason: .replayableAudioReady)
+    }
+
+    func scheduleRuntimeUnloadAfterPlayback(reason: TTSRuntimeUnloadReason) {
+        runtimeUnloadTask?.cancel()
+        runtimeUnloadTask = nil
+        pendingRuntimeUnloadReason = nil
+
+        guard let delay = settingsStore.speakTimeoutTiming.unloadDelay else {
+            unloadRuntimeImmediately(reason: reason)
+            return
+        }
+
+        guard engine.isPreparedForSynthesis else {
+            Self.log("Skipping PocketTTS runtime unload scheduling reason=\(reason.rawValue) because runtime is not warm.")
+            return
+        }
+
+        pendingRuntimeUnloadReason = reason
+        Self.log(
+            "Scheduling PocketTTS runtime unload reason=\(reason.rawValue) delaySeconds=\(String(format: "%.0f", delay))."
+        )
+        runtimeUnloadTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard Task.isCancelled == false else { return }
+            self?.runtimeUnloadTask = nil
+            self?.pendingRuntimeUnloadReason = nil
+            self?.unloadRuntimeImmediately(reason: .speakTimeoutExpired)
+        }
+    }
+
+    func cancelScheduledRuntimeUnload(reason: String) {
+        guard runtimeUnloadTask != nil else { return }
+
+        Self.log("Canceling scheduled PocketTTS runtime unload reason=\(reason).")
+        runtimeUnloadTask?.cancel()
+        runtimeUnloadTask = nil
+        pendingRuntimeUnloadReason = nil
+    }
+
+    func unloadRuntimeImmediately(reason: TTSRuntimeUnloadReason) {
+        runtimeUnloadTask?.cancel()
+        runtimeUnloadTask = nil
+        pendingRuntimeUnloadReason = nil
+
+        guard engine.isPreparedForSynthesis else {
+            Self.log("Skipping PocketTTS runtime unload reason=\(reason.rawValue) because runtime is not warm.")
+            return
+        }
+
+        Self.log("Unloading PocketTTS runtime reason=\(reason.rawValue).")
+        engine.unloadIfNeeded()
+    }
+
+    func handleSpeakTimeoutTimingChanged() {
+        guard let pendingRuntimeUnloadReason else {
+            if settingsStore.speakTimeoutTiming == .immediately, isActive == false {
+                unloadRuntimeImmediately(reason: .settingChangedToImmediate)
+            }
+            return
+        }
+
+        scheduleRuntimeUnloadAfterPlayback(reason: pendingRuntimeUnloadReason)
+    }
+}

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+State.swift
@@ -45,6 +45,7 @@ extension TTSManager {
             self.updateState(.finished)
             await self.onWillTeardownPlayback?()
             KeyVoxIPCBridge.markRecentTTSPlayback()
+            self.scheduleRuntimeUnloadAfterPlayback(reason: .playbackFinished)
             self.clearActiveRequest(
                 clearSharedTransportState: false,
                 preserveFinishedSystemPlayback: self.hasReplayablePlayback
@@ -57,7 +58,7 @@ extension TTSManager {
         lastReplayableRequest = activeRequest
         hasReplayablePlayback = playbackCoordinator.hasReplayablePlayback
         persistReplayablePlaybackIfNeeded(for: activeRequest)
-        engine.unloadIfNeeded()
+        releaseRuntimeWhenReplayableAudioIsReady()
         Self.log("Replayable playback became available for id=\(activeRequest.id.uuidString) voice=\(activeRequest.voiceID)")
     }
 
@@ -73,7 +74,7 @@ extension TTSManager {
             self.lastErrorMessage = message
             self.isPlaybackPaused = false
             self.pausedReplaySampleOffset = nil
-            self.engine.unloadIfNeeded()
+            self.scheduleRuntimeUnloadAfterPlayback(reason: .playbackError)
             self.dismissPlaybackPreparationView()
             self.updateState(.error)
             await self.onWillTeardownPlayback?()
@@ -115,6 +116,7 @@ extension TTSManager {
         hasStartedPlaybackForActiveRequest = false
         didEmitPreparationCompletionForActiveRequest = false
         shouldConsumeFreeSpeakOnPlaybackStart = false
+        isCurrentPlaybackWarmStart = false
         hasRequestedFastModeBackgroundContinuation = false
         isPlaybackPaused = false
         isReplayingCachedPlayback = false

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
@@ -22,6 +22,7 @@ final class TTSManager: ObservableObject {
     @Published var playbackProgress: Double = 0
     @Published var fastModeBackgroundSafetyProgress: Double = 0
     @Published var isFastModeBackgroundSafe = false
+    @Published var isCurrentPlaybackWarmStart = false
 
     let settingsStore: AppSettingsStore
     let appHaptics: AppHapticsEmitting
@@ -44,9 +45,12 @@ final class TTSManager: ObservableObject {
     var shouldPersistPlaybackPreparationViewUntilBackground = false
     var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
     var backgroundTaskReleaseTask: Task<Void, Never>?
+    var runtimeUnloadTask: Task<Void, Never>?
+    var pendingRuntimeUnloadReason: TTSRuntimeUnloadReason?
     var hasRequestedFastModeBackgroundContinuation = false
     var shouldExposeFinishedSystemPlayback = false
     var onWillTeardownPlayback: (() async -> Void)?
+    var cancellables = Set<AnyCancellable>()
 
     var shouldPreventIdleSleep: Bool {
         TTSManagerPolicy.shouldPreventIdleSleep(for: state, isPlaybackPaused: isPlaybackPaused)
@@ -198,6 +202,19 @@ final class TTSManager: ObservableObject {
             name: UIApplication.protectedDataDidBecomeAvailableNotification,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleMemoryWarningNotification(_:)),
+            name: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil
+        )
+
+        settingsStore.$speakTimeoutTiming
+            .dropFirst()
+            .sink { [weak self] _ in
+                self?.handleSpeakTimeoutTimingChanged()
+            }
+            .store(in: &cancellables)
 
         restoreReplayablePlaybackIfNeeded()
         configureSystemPlaybackController()

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
@@ -47,6 +47,7 @@ final class TTSManager: ObservableObject {
     var backgroundTaskReleaseTask: Task<Void, Never>?
     var runtimeUnloadTask: Task<Void, Never>?
     var pendingRuntimeUnloadReason: TTSRuntimeUnloadReason?
+    var pendingRuntimeUnloadStartedAt: Date?
     var hasRequestedFastModeBackgroundContinuation = false
     var shouldExposeFinishedSystemPlayback = false
     var onWillTeardownPlayback: (() async -> Void)?

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTS.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTS.swift
@@ -48,7 +48,7 @@ extension HomeTabView {
                         HStack(alignment: .center, spacing: 6) {
                             Image(systemName: "waveform")
                                 .font(.system(size: 11, weight: .medium))
-                                .foregroundStyle(.yellow)
+                                .foregroundStyle(ttsVoiceReadinessColor)
 
                             ttsVoiceShortcutLabel
                         }

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
@@ -1,5 +1,32 @@
 import SwiftUI
 
+enum TTSPreparationPresentationPolicy {
+    static func showsProgress(
+        state: KeyVoxTTSState,
+        progress: Double,
+        visibleThreshold: Double,
+        isWarmStart: Bool
+    ) -> Bool {
+        guard state == .preparing || state == .generating else { return false }
+        return isWarmStart || progress >= visibleThreshold
+    }
+
+    static func showsSpinner(
+        state: KeyVoxTTSState,
+        progress: Double,
+        visibleThreshold: Double,
+        isWarmStart: Bool
+    ) -> Bool {
+        guard state == .preparing || state == .generating else { return false }
+        return showsProgress(
+            state: state,
+            progress: progress,
+            visibleThreshold: visibleThreshold,
+            isWarmStart: isWarmStart
+        ) == false
+    }
+}
+
 extension HomeTabView {
     var ttsPreparationSlotHeight: CGFloat {
         12
@@ -78,6 +105,19 @@ extension HomeTabView {
         return effectiveTTSVoice.displayName
     }
 
+    var ttsVoiceReadinessColor: Color {
+        isTTSVoiceReadyIndicatorActive ? Color.yellow : Color.white
+    }
+
+    private var isTTSVoiceReadyIndicatorActive: Bool {
+        switch ttsManager.state {
+        case .preparing, .generating:
+            return showsTTSPreparationProgress
+        case .idle, .playing, .finished, .error:
+            return ttsManager.engine.isPreparedForSynthesis
+        }
+    }
+
     var ttsButtonTitle: String {
         if pocketTTSModelManager.isSharedModelReady() == false {
             return "Install"
@@ -99,13 +139,21 @@ extension HomeTabView {
     }
 
     var showsTTSPreparationProgress: Bool {
-        guard ttsManager.state == .preparing || ttsManager.state == .generating else { return false }
-        return ttsManager.playbackPreparationProgress >= ttsPreparationVisibleProgressThreshold
+        TTSPreparationPresentationPolicy.showsProgress(
+            state: ttsManager.state,
+            progress: ttsManager.playbackPreparationProgress,
+            visibleThreshold: ttsPreparationVisibleProgressThreshold,
+            isWarmStart: ttsManager.isCurrentPlaybackWarmStart
+        )
     }
 
     var showsPrimaryTTSLoadingSpinner: Bool {
-        (ttsManager.state == .preparing || ttsManager.state == .generating)
-            && showsTTSPreparationProgress == false
+        TTSPreparationPresentationPolicy.showsSpinner(
+            state: ttsManager.state,
+            progress: ttsManager.playbackPreparationProgress,
+            visibleThreshold: ttsPreparationVisibleProgressThreshold,
+            isWarmStart: ttsManager.isCurrentPlaybackWarmStart
+        )
     }
 
     var ttsPreparationProgressLabel: String {

--- a/iOS/KeyVox iOS/Views/SettingsTabView/SettingsRow.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView/SettingsRow.swift
@@ -76,8 +76,8 @@ struct SettingsRow<TrailingContent: View>: View {
             VStack(alignment: .leading, spacing: 16) {
                 SettingsRow(
                     icon: "waveform",
-                    title: "Keyboard Haptics",
-                    description: "Get haptic feedback from KeyVox Keyboard",
+                    title: SettingsTabCopy.Keyboard.hapticsTitle,
+                    description: SettingsTabCopy.Keyboard.hapticsDescription,
                     isOn: .constant(true)
                 )
             }

--- a/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView+About.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView+About.swift
@@ -31,7 +31,7 @@ extension SettingsTabView {
                     )
                 }
 
-                Text("Share your experience on the App Store")
+                Text("Share your experience on the App Store.")
                     .font(.appFont(15, variant: .light))
                     .foregroundStyle(.white.opacity(0.7))
             }

--- a/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView+General.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView+General.swift
@@ -18,7 +18,7 @@ extension SettingsTabView {
                         }
 
                         VStack(alignment: .leading, spacing: 4) {
-                            Text("Session Timeout")
+                            Text("Dictation Timeout")
                                 .font(.appFont(18))
                                 .foregroundStyle(.white)
 
@@ -43,7 +43,7 @@ extension SettingsTabView {
                         .padding(.top, 2)
                     }
 
-                    Text("Decide when the session turns off")
+                    Text("Decide when the dictation session turns off")
                         .font(.appFont(15, variant: .light))
                         .foregroundStyle(.white.opacity(0.7))
                 }
@@ -57,6 +57,54 @@ extension SettingsTabView {
                     description: "Allow KeyVox to show live activity updates",
                     isOn: $settingsStore.liveActivitiesEnabled
                 )
+            }
+        }
+    }
+
+    @ViewBuilder
+    var speakTimeoutSection: some View {
+        AppCard {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top, spacing: 12) {
+                    ZStack {
+                        Circle()
+                            .fill(AppTheme.accent.opacity(0.4))
+                            .frame(width: 32, height: 32)
+
+                        Image(systemName: "speaker.zzz.fill")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.yellow)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Speak Timeout")
+                            .font(.appFont(18))
+                            .foregroundStyle(.white)
+
+                        Text(settingsStore.speakTimeoutTiming.displayName)
+                            .font(.appFont(17))
+                            .foregroundStyle(.yellow)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Menu {
+                        Picker("", selection: $settingsStore.speakTimeoutTiming) {
+                            ForEach(SpeakTimeoutTiming.allCases) { timing in
+                                Text(timing.displayName).tag(timing)
+                            }
+                        }
+                        .pickerStyle(.inline)
+                    } label: {
+                        Text("Change")
+                            .font(.appFont(16))
+                            .foregroundColor(.yellow)
+                    }
+                    .padding(.top, 2)
+                }
+
+                Text("Decide how long KeyVox Speak stays ready after playback.")
+                    .font(.appFont(15, variant: .light))
+                    .foregroundStyle(.white.opacity(0.7))
             }
         }
     }

--- a/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView+General.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView+General.swift
@@ -109,7 +109,7 @@ extension SettingsTabView {
                     .padding(.top, 2)
                 }
 
-                Text("Decide how long KeyVox Speak stays ready after playback.")
+                Text("Decide how long KeyVox Speak stays ready to buffer playback.")
                     .font(.appFont(15, variant: .light))
                     .foregroundStyle(.white.opacity(0.7))
             }

--- a/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView+General.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView+General.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+enum SettingsTabCopy {
+    enum Keyboard {
+        static let hapticsTitle = "Keyboard Haptics"
+        static let hapticsDescription = "Get haptic feedback from KeyVox Keyboard."
+    }
+}
+
 extension SettingsTabView {
     @ViewBuilder
     var sessionSection: some View {
@@ -43,7 +50,7 @@ extension SettingsTabView {
                         .padding(.top, 2)
                     }
 
-                    Text("Decide when the dictation session turns off")
+                    Text("Decide when the dictation session turns off.")
                         .font(.appFont(15, variant: .light))
                         .foregroundStyle(.white.opacity(0.7))
                 }
@@ -54,7 +61,7 @@ extension SettingsTabView {
                 SettingsRow(
                     icon: "widget.small",
                     title: "Live Activities",
-                    description: "Allow KeyVox to show live activity updates",
+                    description: "Allow KeyVox to show live activity updates.",
                     isOn: $settingsStore.liveActivitiesEnabled
                 )
             }
@@ -114,8 +121,8 @@ extension SettingsTabView {
         AppCard {
             SettingsRow(
                 icon: "keyboard",
-                title: "Keyboard Haptics",
-                description: "Get haptic feedback from KeyVox Keyboard",
+                title: SettingsTabCopy.Keyboard.hapticsTitle,
+                description: SettingsTabCopy.Keyboard.hapticsDescription,
                 isOn: $settingsStore.keyboardHapticsEnabled
             )
         }

--- a/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView.swift
@@ -34,6 +34,7 @@ struct SettingsTabView: View {
         AppScrollScreen {
             VStack(alignment: .leading, spacing: 16) {
                 sessionSection
+                speakTimeoutSection
                 keyboardSection
                 audioSection
                 activeModelSection

--- a/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
+++ b/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
@@ -246,6 +246,8 @@ private final class StubDictationService: DictationProvider {
 }
 
 private struct StubTTSEngine: TTSEngine {
+    var isPreparedForSynthesis: Bool { false }
+
     func prepareIfNeeded() async throws {}
 
     func prewarmVoiceIfNeeded(voiceID: String) async throws {}

--- a/iOS/KeyVoxiOSTests/Core/TTS/TTSManager/TTSManagerLifecycleTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/TTS/TTSManager/TTSManagerLifecycleTests.swift
@@ -103,10 +103,19 @@ struct TTSManagerLifecycleTests {
         #expect(harness.manager.playbackCoordinator.isPaused)
     }
 
-    @Test func replayablePlaybackReadyUnloadsTTSEngine() {
+    @Test func defaultSpeakTimeoutKeepsRuntimeWarmForFiveMinutes() {
         let harness = makeHarness()
         defer { harness.cleanup() }
 
+        #expect(harness.manager.settingsStore.speakTimeoutTiming == .fiveMinutes)
+    }
+
+    @Test func replayablePlaybackReadyUnloadsTTSEngineWhenSpeakTimeoutIsImmediate() {
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+
+        harness.manager.settingsStore.speakTimeoutTiming = .immediately
+        harness.engine.isPreparedForSynthesis = true
         harness.manager.activeRequest = makeRequest(createdAt: 5)
 
         harness.manager.handleReplayablePlaybackReady()
@@ -114,27 +123,69 @@ struct TTSManagerLifecycleTests {
         #expect(harness.engine.unloadCallCount == 1)
     }
 
-    @Test func stopPlaybackUnloadsTTSEngine() async {
+    @Test func replayablePlaybackReadyRetainsTTSEngineWhenSpeakTimeoutIsTimed() {
         let harness = makeHarness()
         defer { harness.cleanup() }
 
+        harness.engine.isPreparedForSynthesis = true
         harness.manager.activeRequest = makeRequest(createdAt: 6)
+
+        harness.manager.handleReplayablePlaybackReady()
+
+        #expect(harness.engine.unloadCallCount == 0)
+        #expect(harness.engine.isPreparedForSynthesis)
+    }
+
+    @Test func stopPlaybackSchedulesTTSEngineUnloadWhenSpeakTimeoutIsTimed() async {
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+
+        harness.engine.isPreparedForSynthesis = true
+        harness.manager.activeRequest = makeRequest(createdAt: 7)
+
+        await harness.manager.stopPlayback()
+
+        #expect(harness.engine.unloadCallCount == 0)
+        #expect(harness.manager.runtimeUnloadTask != nil)
+    }
+
+    @Test func stopPlaybackUnloadsTTSEngineWhenSpeakTimeoutIsImmediate() async {
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+
+        harness.manager.settingsStore.speakTimeoutTiming = .immediately
+        harness.engine.isPreparedForSynthesis = true
+        harness.manager.activeRequest = makeRequest(createdAt: 8)
 
         await harness.manager.stopPlayback()
 
         #expect(harness.engine.unloadCallCount == 1)
     }
 
-    @Test func playbackErrorUnloadsTTSEngine() async {
+    @Test func playbackErrorSchedulesTTSEngineUnloadWhenSpeakTimeoutIsTimed() async {
         let harness = makeHarness()
         defer { harness.cleanup() }
 
-        harness.manager.activeRequest = makeRequest(createdAt: 7)
+        harness.engine.isPreparedForSynthesis = true
+        harness.manager.activeRequest = makeRequest(createdAt: 9)
 
         harness.manager.handleError("synthetic failure")
         await settleLifecycleTasks()
 
-        #expect(harness.engine.unloadCallCount == 1)
+        #expect(harness.engine.unloadCallCount == 0)
+        #expect(harness.manager.runtimeUnloadTask != nil)
+    }
+
+    @Test func warmRuntimeStartMarksCurrentPlaybackWarm() async {
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+
+        harness.engine.isPreparedForSynthesis = true
+        harness.engine.keepsAudioStreamOpen = true
+
+        await harness.manager.startPlayback(makeRequest(createdAt: 10))
+
+        #expect(harness.manager.isCurrentPlaybackWarmStart)
     }
 
     private func makeHarness() -> TTSManagerLifecycleHarness {
@@ -210,6 +261,7 @@ private struct TTSManagerLifecycleHarness {
     let manager: TTSManager
 
     func cleanup() {
+        manager.cancelScheduledRuntimeUnload(reason: "testCleanup")
         manager.endBackgroundTaskIfNeeded()
         manager.playbackCoordinator.playerNode.stop()
         manager.playbackCoordinator.audioEngine.stop()
@@ -220,18 +272,23 @@ private struct TTSManagerLifecycleHarness {
 
 @MainActor
 private final class SpyTTSEngine: TTSEngine {
+    var isPreparedForSynthesis = false
+    var keepsAudioStreamOpen = false
     private(set) var immediateForegroundRequestCount = 0
     private(set) var immediateBackgroundRequestCount = 0
     private(set) var prepareForegroundCallCount = 0
     private(set) var prepareBackgroundCallCount = 0
     private(set) var unloadCallCount = 0
 
-    func prepareIfNeeded() async throws {}
+    func prepareIfNeeded() async throws {
+        isPreparedForSynthesis = true
+    }
 
     func prewarmVoiceIfNeeded(voiceID: String) async throws {}
 
     func unloadIfNeeded() {
         unloadCallCount += 1
+        isPreparedForSynthesis = false
     }
 
     func requestForegroundSynthesisImmediately() {
@@ -256,7 +313,9 @@ private final class SpyTTSEngine: TTSEngine {
         fastModeEnabled: Bool
     ) async throws -> AsyncThrowingStream<KeyVoxTTSAudioFrame, Error> {
         AsyncThrowingStream { continuation in
-            continuation.finish()
+            if keepsAudioStreamOpen == false {
+                continuation.finish()
+            }
         }
     }
 }

--- a/iOS/KeyVoxiOSTests/Core/TTS/TTSManager/TTSManagerLifecycleTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/TTS/TTSManager/TTSManagerLifecycleTests.swift
@@ -147,6 +147,7 @@ struct TTSManagerLifecycleTests {
 
         #expect(harness.engine.unloadCallCount == 0)
         #expect(harness.manager.runtimeUnloadTask != nil)
+        #expect(harness.manager.pendingRuntimeUnloadReason == .stopPlayback)
     }
 
     @Test func stopPlaybackUnloadsTTSEngineWhenSpeakTimeoutIsImmediate() async {
@@ -261,7 +262,8 @@ private struct TTSManagerLifecycleHarness {
     let manager: TTSManager
 
     func cleanup() {
-        manager.cancelScheduledRuntimeUnload(reason: "testCleanup")
+        manager.cancelScheduledRuntimeUnload(logContext: "testCleanup")
+        engine.finishPendingStream()
         manager.endBackgroundTaskIfNeeded()
         manager.playbackCoordinator.playerNode.stop()
         manager.playbackCoordinator.audioEngine.stop()
@@ -279,6 +281,7 @@ private final class SpyTTSEngine: TTSEngine {
     private(set) var prepareForegroundCallCount = 0
     private(set) var prepareBackgroundCallCount = 0
     private(set) var unloadCallCount = 0
+    private var pendingStreamContinuation: AsyncThrowingStream<KeyVoxTTSAudioFrame, Error>.Continuation?
 
     func prepareIfNeeded() async throws {
         isPreparedForSynthesis = true
@@ -315,8 +318,16 @@ private final class SpyTTSEngine: TTSEngine {
         AsyncThrowingStream { continuation in
             if keepsAudioStreamOpen == false {
                 continuation.finish()
+            } else {
+                finishPendingStream()
+                pendingStreamContinuation = continuation
             }
         }
+    }
+
+    func finishPendingStream() {
+        pendingStreamContinuation?.finish()
+        pendingStreamContinuation = nil
     }
 }
 

--- a/iOS/KeyVoxiOSTests/Core/TTS/TTSSystemPlaybackTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/TTS/TTSSystemPlaybackTests.swift
@@ -370,6 +370,8 @@ private struct StubAppHaptics: AppHapticsEmitting {
 }
 
 private struct StubTTSEngine: TTSEngine {
+    var isPreparedForSynthesis: Bool { false }
+
     func prepareIfNeeded() async throws {}
     func prewarmVoiceIfNeeded(voiceID: String) async throws {}
     func unloadIfNeeded() {}

--- a/iOS/KeyVoxiOSTests/Views/TTSPreparationPresentationPolicyTests.swift
+++ b/iOS/KeyVoxiOSTests/Views/TTSPreparationPresentationPolicyTests.swift
@@ -39,4 +39,29 @@ struct TTSPreparationPresentationPolicyTests {
             )
         )
     }
+
+    @Test func progressAtOrAboveThresholdShowsProgressAndDismissesSpinner() {
+        let visibleThreshold = 0.02
+
+        for isWarmStart in [true, false] {
+            for progress in [visibleThreshold, visibleThreshold + 0.01] {
+                #expect(
+                    TTSPreparationPresentationPolicy.showsProgress(
+                        state: .generating,
+                        progress: progress,
+                        visibleThreshold: visibleThreshold,
+                        isWarmStart: isWarmStart
+                    )
+                )
+                #expect(
+                    TTSPreparationPresentationPolicy.showsSpinner(
+                        state: .generating,
+                        progress: progress,
+                        visibleThreshold: visibleThreshold,
+                        isWarmStart: isWarmStart
+                    ) == false
+                )
+            }
+        }
+    }
 }

--- a/iOS/KeyVoxiOSTests/Views/TTSPreparationPresentationPolicyTests.swift
+++ b/iOS/KeyVoxiOSTests/Views/TTSPreparationPresentationPolicyTests.swift
@@ -1,0 +1,42 @@
+import Testing
+@testable import KeyVox_iOS
+
+struct TTSPreparationPresentationPolicyTests {
+    @Test func warmStartShowsProgressWithoutSpinnerBeforeProgressThreshold() {
+        #expect(
+            TTSPreparationPresentationPolicy.showsProgress(
+                state: .preparing,
+                progress: 0,
+                visibleThreshold: 0.02,
+                isWarmStart: true
+            )
+        )
+        #expect(
+            TTSPreparationPresentationPolicy.showsSpinner(
+                state: .preparing,
+                progress: 0,
+                visibleThreshold: 0.02,
+                isWarmStart: true
+            ) == false
+        )
+    }
+
+    @Test func coldStartShowsSpinnerUntilProgressReachesThreshold() {
+        #expect(
+            TTSPreparationPresentationPolicy.showsProgress(
+                state: .generating,
+                progress: 0,
+                visibleThreshold: 0.02,
+                isWarmStart: false
+            ) == false
+        )
+        #expect(
+            TTSPreparationPresentationPolicy.showsSpinner(
+                state: .generating,
+                progress: 0,
+                visibleThreshold: 0.02,
+                isWarmStart: false
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Speak Timeout setting so KeyVox Speak can keep the PocketTTS runtime ready after playback, reducing repeated startup delay when users continue using text-to-speech.

## What Changed

- Added a Speak Timeout settings card with immediate, 5 minute, 15 minute, and 1 hour retention options.
- Defaulted Speak Timeout to 5 minutes for consistency with the dictation timeout behavior.
- Added delayed PocketTTS runtime unload scheduling after playback stops or finishes.
- Preserved immediate unload behavior when Speak Timeout is set to Immediately.
- Cancelled pending unloads when new playback begins so repeated Speak usage can reuse the warm runtime.
- Added runtime unload handling for memory pressure and PocketTTS asset invalidation.
- Updated the Home Speak voice readiness indicator so the wave icon reflects warm runtime availability.
- Updated TTS preparation presentation behavior so warm starts avoid the stop-button spinner and go straight to progress display.
- Documented the updated PocketTTS runtime lifetime contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Speak Timeout" setting to control how long KeyVox Speak remains ready after playback finishes.

* **Bug Fixes**
  * Improved handling of voice asset invalidation.
  * Enhanced system memory warning response.

* **UI Changes**
  * Renamed "Session Timeout" to "Dictation Timeout" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->