### PR TITLE
feat(mac-ssettings): refine Mac settings and updater UI

### DIFF
--- a/macOS/App/KeyVoxApp.swift
+++ b/macOS/App/KeyVoxApp.swift
@@ -36,7 +36,10 @@ final class KeyVoxAppDelegate: NSObject, NSApplicationDelegate {
             return .terminateCancel
         }
 
-        return .terminateNow
+        Task { @MainActor in
+            AppProcessTerminator.terminateImmediately()
+        }
+        return .terminateCancel
     }
 }
 

--- a/macOS/Core/Overlay/OverlayManager.swift
+++ b/macOS/Core/Overlay/OverlayManager.swift
@@ -295,7 +295,7 @@ class OverlayManager {
 
     func hide() {
         pendingHideWorkItem?.cancel()
-        resetVibeCyclePillState(orderOutVisiblePanel: false)
+        resetVibeCyclePillState(orderOutVisiblePanel: true)
         motionController.cancelPendingMotionAnimations(panel: window)
         hideVibeLabelWindow()
 

--- a/macOS/Core/Services/AppProcessTerminator.swift
+++ b/macOS/Core/Services/AppProcessTerminator.swift
@@ -1,0 +1,9 @@
+import Darwin
+
+enum AppProcessTerminator {
+    @MainActor
+    static func terminateImmediately() -> Never {
+        fflush(nil)
+        Darwin._exit(EXIT_SUCCESS)
+    }
+}

--- a/macOS/Core/Services/AppProcessTerminator.swift
+++ b/macOS/Core/Services/AppProcessTerminator.swift
@@ -1,9 +1,11 @@
 import Darwin
+import Foundation
 
 enum AppProcessTerminator {
     @MainActor
     static func terminateImmediately() -> Never {
         fflush(nil)
+        UserDefaults.standard.synchronize()
         Darwin._exit(EXIT_SUCCESS)
     }
 }

--- a/macOS/Core/Services/AppUpdate/AppUpdateApplicationsPrereflight.swift
+++ b/macOS/Core/Services/AppUpdate/AppUpdateApplicationsPrereflight.swift
@@ -55,6 +55,11 @@ struct AppUpdateApplicationsPrereflight {
         consumeResumeAfterApplicationsMoveContext() != nil
     }
 
+    func clearResumeAfterApplicationsMove() {
+        defaults.removeObject(forKey: UserDefaultsKeys.App.resumeUpdaterAfterApplicationsMove)
+        defaults.removeObject(forKey: UserDefaultsKeys.App.resumeUpdaterPreferredDisplayKey)
+    }
+
     func moveCurrentAppToApplications(bundleURL: URL = Bundle.main.bundleURL) throws -> URL {
         let sourceURL = bundleURL.standardizedFileURL
         let destinationURL = destinationURL(for: sourceURL)

--- a/macOS/Core/Services/AppUpdate/AppUpdateCoordinator.swift
+++ b/macOS/Core/Services/AppUpdate/AppUpdateCoordinator.swift
@@ -279,7 +279,14 @@ final class AppUpdateCoordinator: ObservableObject {
             applicationsPrereflight.stageResumeAfterApplicationsMove(
                 preferredDisplayKey: AppUpdateDisplayCoordinator.shared.preferredDisplayKeyForResume
             )
-            NSWorkspace.shared.open(destinationURL)
+            guard NSWorkspace.shared.open(destinationURL) else {
+                NSLog("[AppUpdateCoordinator] Failed to reopen KeyVox from Applications at %@", destinationURL.path)
+                applicationsPrereflight.clearResumeAfterApplicationsMove()
+                state = .failed
+                statusMessage = "KeyVox could not reopen from Applications."
+                failureMessage = "KeyVox was moved to Applications, but macOS could not reopen it. Open KeyVox from Applications and try the update again."
+                return
+            }
             AppProcessTerminator.terminateImmediately()
         } catch {
             state = .failed

--- a/macOS/Core/Services/AppUpdate/AppUpdateCoordinator.swift
+++ b/macOS/Core/Services/AppUpdate/AppUpdateCoordinator.swift
@@ -280,7 +280,7 @@ final class AppUpdateCoordinator: ObservableObject {
                 preferredDisplayKey: AppUpdateDisplayCoordinator.shared.preferredDisplayKeyForResume
             )
             NSWorkspace.shared.open(destinationURL)
-            NSApplication.shared.terminate(nil)
+            AppProcessTerminator.terminateImmediately()
         } catch {
             state = .failed
             statusMessage = "KeyVox could not move into Applications."

--- a/macOS/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
+++ b/macOS/Core/Services/AppUpdate/AppUpdateInstallLauncher.swift
@@ -57,6 +57,6 @@ struct AppUpdateInstallLauncher {
             try await Task.sleep(nanoseconds: 50_000_000)
         }
 
-        NSApplication.shared.terminate(nil)
+        AppProcessTerminator.terminateImmediately()
     }
 }

--- a/macOS/KeyVox.xcodeproj/project.pbxproj
+++ b/macOS/KeyVox.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D26000012FF0000100AA0001 /* AppProcessTerminator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26000022FF0000100AA0001 /* AppProcessTerminator.swift */; };
 		8E03671C2F49848500017017 /* PasteServiceExecutionMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E03671B2F49848500017017 /* PasteServiceExecutionMocks.swift */; };
 		8E37FC672FB0F954004DD69A /* WindowManagerOnboardingWindowLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E37FC662FB0F954004DD69A /* WindowManagerOnboardingWindowLevelTests.swift */; };
 		8E4B085D2F453E1700C5DB85 /* PasteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4B085C2F453E1700C5DB85 /* PasteService.swift */; };
@@ -199,6 +200,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D26000022FF0000100AA0001 /* AppProcessTerminator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppProcessTerminator.swift; sourceTree = "<group>"; };
 		8E03671B2F49848500017017 /* PasteServiceExecutionMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteServiceExecutionMocks.swift; sourceTree = "<group>"; };
 		8E37FC662FB0F954004DD69A /* WindowManagerOnboardingWindowLevelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowManagerOnboardingWindowLevelTests.swift; sourceTree = "<group>"; };
 		8E4B085C2F453E1700C5DB85 /* PasteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteService.swift; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 		8E6D05CA2F3C51D6003BD458 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				D26000022FF0000100AA0001 /* AppProcessTerminator.swift */,
 				F30000052FC2000100AA0001 /* AppUpdate */,
 				8F5501022F47010000EE5501 /* AppUpdateLogic.swift */,
 				8EE6025E2F3FC5C80094EC16 /* AppUpdateService.swift */,
@@ -958,6 +961,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D26000012FF0000100AA0001 /* AppProcessTerminator.swift in Sources */,
 				F30000382FC2000100AA0001 /* AppActionButton.swift in Sources */,
 				F30000042FC2000100AA0001 /* AppUpdateProgressBar.swift in Sources */,
 				F30000072FC2000100AA0001 /* AppReleaseInfo.swift in Sources */,

--- a/macOS/KeyVoxTests/Core/VibePillPresentationControllerTests.swift
+++ b/macOS/KeyVoxTests/Core/VibePillPresentationControllerTests.swift
@@ -183,6 +183,21 @@ final class VibePillPresentationControllerTests: XCTestCase {
         XCTAssertEqual(visibleCyclePillWindowCount, 0)
     }
 
+    func testHideOrdersOutVisibleCyclePillPanel() {
+        OverlayManager.shared.showVibeCyclePill(
+            title: "Casual",
+            duration: nil
+        )
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.02))
+        XCTAssertEqual(visibleCyclePillWindowCount, 1)
+
+        OverlayManager.shared.hide()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.02))
+
+        XCTAssertFalse(OverlayManager.shared.isVibeCyclePillVisible)
+        XCTAssertEqual(visibleCyclePillWindowCount, 0)
+    }
+
     func testStandalonePillCanBeAdoptedIntoCyclePill() {
         OverlayManager.shared.showVibePill(
             title: "Casual",

--- a/macOS/Views/Components/AppUpdateProgressBar.swift
+++ b/macOS/Views/Components/AppUpdateProgressBar.swift
@@ -10,21 +10,7 @@ struct AppUpdateProgressBar: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            ProgressView(value: clampedProgress)
-                .progressViewStyle(KeyVoxProgressStyle())
-                .frame(height: 8)
-
-            HStack(alignment: .firstTextBaseline) {
-                Text(label)
-                    .font(.appFont(11, variant: .light))
-                    .foregroundColor(.secondary)
-
-                Spacer()
-
-                Text("\(Int(clampedProgress * 100))%")
-                    .font(.appFont(11))
-                    .foregroundColor(MacAppTheme.accent)
-            }
+            LabeledProgressBar(progress: clampedProgress, statusText: label)
 
             if let detail, !detail.isEmpty {
                 Text(detail)

--- a/macOS/Views/Components/LogoBarView.swift
+++ b/macOS/Views/Components/LogoBarView.swift
@@ -265,7 +265,11 @@ private struct StaticLogoView: View {
 
         return ZStack {
             Circle()
-                .stroke(Color.yellow.opacity(0.6), lineWidth: 2 * scale)
+                .fill(Color.black)
+                .overlay(
+                    Circle()
+                        .stroke(Color.yellow.opacity(0.6), lineWidth: 2 * scale)
+                )
                 .frame(width: size, height: size)
                 .shadow(color: .yellow.opacity(0.3), radius: 4 * scale)
 

--- a/macOS/Views/Components/UIComponents.swift
+++ b/macOS/Views/Components/UIComponents.swift
@@ -86,27 +86,26 @@ struct KeyVoxProgressStyle: ProgressViewStyle {
     }
 }
 
-struct ModelDownloadProgress: View {
+struct LabeledProgressBar: View {
     let progress: Double
-    var showLabel: Bool = true
+    let statusText: String
     
     var body: some View {
         VStack(spacing: 8) {
+            HStack(alignment: .center, spacing: 12) {
+                Text(statusText)
+                    .font(.appFont(12, variant: .light))
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text("\(Int((progress * 100).rounded()))%")
+                    .font(.appFont(12))
+                    .foregroundStyle(.yellow)
+            }
+
             ProgressView(value: progress)
                 .progressViewStyle(KeyVoxProgressStyle())
                 .frame(height: 6)
-            
-            if showLabel {
-                HStack {
-                    Text("Preparing AI Assets...")
-                        .font(.appFont(10))
-                        .foregroundColor(.secondary)
-                    Spacer()
-                    Text("\(Int(progress * 100))%")
-                        .font(.appFont(11))
-                        .foregroundColor(MacAppTheme.accent)
-                }
-            }
         }
     }
 }

--- a/macOS/Views/OnboardingView.swift
+++ b/macOS/Views/OnboardingView.swift
@@ -3,7 +3,7 @@ import AppKit
 import AVFoundation
 
 struct OnboardingView: View {
-    static let preferredWindowSize = CGSize(width: 500, height: 560)
+    static let preferredWindowSize = CGSize(width: 560, height: 560)
 
     private struct HeightPreferenceKey: PreferenceKey {
         static var defaultValue: CGFloat = OnboardingView.preferredWindowSize.height
@@ -54,7 +54,7 @@ struct OnboardingView: View {
                         stepNumber: 1,
                         title: "AI Model Setup",
                         description: "OpenAI Whisper Base (~190 MB)",
-                        buttonTitle: downloader.isModelDownloaded ? "Ready" : (downloader.isDownloading ? "Downloading..." : "Download Now"),
+                        buttonTitle: downloader.isModelDownloaded ? "Ready" : (downloader.isDownloading ? "Downloading..." : "Download"),
                         action: setupModel
                     ) {
                         if downloader.isDownloading {
@@ -75,7 +75,7 @@ struct OnboardingView: View {
                         stepNumber: 2,
                         title: "Microphone Access",
                         description: "KeyVox needs to hear you to transcribe.",
-                        buttonTitle: microphoneStepController.microphoneStepButtonTitle,
+                        buttonTitle: microphoneStepController.isMicStepCompleted ? "Ready" : "Continue",
                         action: requestMicrophoneAccess
                     )
 
@@ -84,7 +84,7 @@ struct OnboardingView: View {
                         stepNumber: 3,
                         title: "Accessibility Access",
                         description: "Required to paste text into other apps.",
-                        buttonTitle: accessibilityAuthorized ? "Authorized" : "Grant Access",
+                        buttonTitle: accessibilityAuthorized ? "Ready" : "Open Settings",
                         action: requestAccessibilityAccess
                     )
                 }
@@ -274,21 +274,13 @@ struct OnboardingStepRow<Content: View>: View {
                 
                 Spacer()
                 
-                Button {
-                    action()
-                } label: {
-                    Text(buttonTitle)
-                        .font(.appFont(12))
-                        .foregroundColor(isCompleted ? .green : .white)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(isCompleted ? Color.green : Color.white.opacity(0.3), lineWidth: 1)
-                        )
-                }
-                .buttonStyle(.plain)
-                .disabled(isCompleted || (title == "AI Model Setup" && buttonTitle == "Downloading..."))
+                AppActionButton(
+                    title: buttonTitle,
+                    style: isCompleted ? .secondary : .primary,
+                    minWidth: 104,
+                    isEnabled: !isActionDisabled,
+                    action: action
+                )
             }
             
             extraContent
@@ -298,5 +290,9 @@ struct OnboardingStepRow<Content: View>: View {
             RoundedRectangle(cornerRadius: 12)
                 .fill(isCompleted ? Color.green.opacity(0.05) : MacAppTheme.tipFill)
         )
+    }
+
+    private var isActionDisabled: Bool {
+        isCompleted || (title == "AI Model Setup" && buttonTitle == "Downloading...")
     }
 }

--- a/macOS/Views/OnboardingView.swift
+++ b/macOS/Views/OnboardingView.swift
@@ -38,7 +38,7 @@ struct OnboardingView: View {
                     VStack(spacing: 4) {
                         Text("Welcome to KeyVox")
                             .font(.appFont(32))
-                            .foregroundColor(MacAppTheme.accent)
+                            .foregroundColor(.white)
 
                         Text("Let's get you set up in three quick steps.")
                             .font(.appFont(14, variant: .light))

--- a/macOS/Views/OnboardingView.swift
+++ b/macOS/Views/OnboardingView.swift
@@ -58,7 +58,7 @@ struct OnboardingView: View {
                         action: setupModel
                     ) {
                         if downloader.isDownloading {
-                            ModelDownloadProgress(progress: downloader.progress)
+                            LabeledProgressBar(progress: downloader.progress, statusText: "Downloading AI model.")
                                 .padding(.top, 8)
                         } else if let error = downloader.errorMessage {
                             Text(error)

--- a/macOS/Views/OnboardingView.swift
+++ b/macOS/Views/OnboardingView.swift
@@ -293,6 +293,6 @@ struct OnboardingStepRow<Content: View>: View {
     }
 
     private var isActionDisabled: Bool {
-        isCompleted || (title == "AI Model Setup" && buttonTitle == "Downloading...")
+        isCompleted || (stepNumber == 1 && buttonTitle == "Downloading...")
     }
 }

--- a/macOS/Views/Settings/SettingsComponents.swift
+++ b/macOS/Views/Settings/SettingsComponents.swift
@@ -355,21 +355,22 @@ struct SidebarItem: View {
 }
 
 // MARK: - Status Badge
+/// Compact status badge with yellow text and caller-controlled capsule background.
 struct StatusBadge: View {
     let title: String
-    let color: Color
+    let backgroundColor: Color
     
     var body: some View {
         Text(title.uppercased())
             .font(.appFont(9))
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .background(color.opacity(0.15))
+            .background(backgroundColor.opacity(0.15))
             .foregroundColor(.yellow)
             .clipShape(Capsule())
             .overlay(
                 Capsule()
-                    .stroke(color.opacity(0.3), lineWidth: 1)
+                    .stroke(backgroundColor.opacity(0.3), lineWidth: 1)
             )
     }
 }

--- a/macOS/Views/Settings/SettingsComponents.swift
+++ b/macOS/Views/Settings/SettingsComponents.swift
@@ -112,7 +112,7 @@ struct SettingsRow<Accessory: View>: View {
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
             ZStack {
-                RoundedRectangle(cornerRadius: 12)
+                Circle()
                     .fill(MacAppTheme.iconFill)
                     .frame(width: 44, height: 44)
                 iconView
@@ -141,12 +141,12 @@ struct SettingsRow<Accessory: View>: View {
         case .system(let name):
             Image(systemName: name)
                 .font(.appFont(20))
-                .foregroundColor(MacAppTheme.accent)
+                .foregroundColor(.yellow)
         case .assetTemplate(let name):
             Image(name)
                 .resizable()
                 .renderingMode(.template)
-                .foregroundColor(MacAppTheme.accent)
+                .foregroundColor(.yellow)
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 24, height: 24)
         }
@@ -277,13 +277,13 @@ struct DeveloperLinkCard: View {
                 .cornerRadius(12)
         case .assetTemplate(let name):
             ZStack {
-                RoundedRectangle(cornerRadius: 12)
+                Circle()
                     .fill(MacAppTheme.iconFill)
                     .frame(width: 44, height: 44)
                 Image(name)
                     .resizable()
                     .renderingMode(.template)
-                    .foregroundColor(.yellow.opacity(0.85))
+                    .foregroundColor(.yellow)
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 26, height: 26)
             }
@@ -305,7 +305,7 @@ struct DeveloperLinkCard: View {
             }
         case .systemImage(let name):
             ZStack {
-                RoundedRectangle(cornerRadius: 12)
+                Circle()
                     .fill(MacAppTheme.iconFill)
                     .frame(width: 44, height: 44)
                 Image(systemName: name)

--- a/macOS/Views/Settings/SettingsComponents.swift
+++ b/macOS/Views/Settings/SettingsComponents.swift
@@ -365,7 +365,7 @@ struct StatusBadge: View {
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(color.opacity(0.15))
-            .foregroundColor(color)
+            .foregroundColor(.yellow)
             .clipShape(Capsule())
             .overlay(
                 Capsule()

--- a/macOS/Views/Settings/SettingsVibesAIInstallCard.swift
+++ b/macOS/Views/Settings/SettingsVibesAIInstallCard.swift
@@ -85,19 +85,6 @@ struct SettingsVibesAIInstallCard: View {
 
     private var installContent: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .center, spacing: 12) {
-                Text(statusText)
-                    .font(.appFont(12, variant: .light))
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                if let percentageText {
-                    Text(percentageText)
-                        .font(.appFont(12))
-                        .foregroundStyle(.yellow)
-                }
-            }
-
             if let errorMessage {
                 Text(errorMessage)
                     .font(.appFont(10))
@@ -106,7 +93,7 @@ struct SettingsVibesAIInstallCard: View {
             }
 
             if let progress {
-                ModelDownloadProgress(progress: progress)
+                LabeledProgressBar(progress: progress, statusText: statusText)
             }
         }
     }
@@ -140,11 +127,6 @@ struct SettingsVibesAIInstallCard: View {
         case .notInstalled, .ready, .failed:
             return nil
         }
-    }
-
-    private var percentageText: String? {
-        guard let progress else { return nil }
-        return "\(Int((progress * 100).rounded()))%"
     }
 
     private var errorMessage: String? {

--- a/macOS/Views/Settings/SettingsVibesCard.swift
+++ b/macOS/Views/Settings/SettingsVibesCard.swift
@@ -111,14 +111,14 @@ struct SettingsVibesCard: View {
 
     private var statusContent: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(statusText)
-                .font(.appFont(15, variant: .light))
-                .foregroundStyle(.white.opacity(0.7))
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
             if let progress = matrix.progress {
-                ModelDownloadProgress(progress: progress)
+                LabeledProgressBar(progress: progress, statusText: statusText)
+            } else {
+                Text(statusText)
+                    .font(.appFont(15, variant: .light))
+                    .foregroundStyle(.white.opacity(0.7))
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             if let errorMessage = matrix.errorMessage {

--- a/macOS/Views/Settings/SettingsVibesCard.swift
+++ b/macOS/Views/Settings/SettingsVibesCard.swift
@@ -42,7 +42,7 @@ struct SettingsVibesCard: View {
     private var headerContent: some View {
         HStack(alignment: .top, spacing: 12) {
             ZStack {
-                RoundedRectangle(cornerRadius: 12)
+                Circle()
                     .fill(MacAppTheme.iconFill)
                     .frame(width: 44, height: 44)
 
@@ -50,7 +50,7 @@ struct SettingsVibesCard: View {
                     .resizable()
                     .renderingMode(.template)
                     .scaledToFit()
-                    .foregroundStyle(MacAppTheme.accent)
+                    .foregroundStyle(.yellow)
                     .frame(width: 24, height: 24)
             }
 

--- a/macOS/Views/Settings/SettingsVibesCard.swift
+++ b/macOS/Views/Settings/SettingsVibesCard.swift
@@ -95,7 +95,7 @@ struct SettingsVibesCard: View {
                 action: repairAction
             )
         case .progress:
-            StatusBadge(title: progressBadgeTitle, color: .yellow)
+            StatusBadge(title: progressBadgeTitle, backgroundColor: .yellow)
                 .frame(width: 84)
         case .change:
             Picker("", selection: $selectedVibe) {

--- a/macOS/Views/Settings/SettingsVibesCard.swift
+++ b/macOS/Views/Settings/SettingsVibesCard.swift
@@ -58,6 +58,10 @@ struct SettingsVibesCard: View {
                 Text(SettingsVibesCardCopy.cardTitle)
                     .font(.appFont(18))
                     .foregroundStyle(.white)
+
+                Text(SettingsVibesCardCopy.cardSubtitle)
+                    .font(.appFont(12, variant: .light))
+                    .foregroundColor(.secondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -168,6 +172,7 @@ struct SettingsVibesCard: View {
 
 enum SettingsVibesCardCopy {
     static let cardTitle = "KeyVox Vibes"
+    static let cardSubtitle = "On-device, reversible writing styles."
     static let pickerAccessibilityLabel = "KeyVox Vibes"
     static let downloadRequiredStatus = "Install Vibes AI first (~491 MB), then you can use KeyVox Vibes."
     static let downloadingStatus = "Downloading KeyVox Vibes AI."

--- a/macOS/Views/Settings/SettingsView+DictationModels.swift
+++ b/macOS/Views/Settings/SettingsView+DictationModels.swift
@@ -285,21 +285,13 @@ private struct DictationModelCardRow: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            HStack(alignment: .center, spacing: 12) {
+            if installState.isDownloading {
+                LabeledProgressBar(progress: installState.progress, statusText: statusText)
+            } else {
                 Text(statusText)
                     .font(.appFont(13, variant: .light))
                     .foregroundStyle(.white.opacity(0.56))
                     .frame(maxWidth: .infinity, alignment: .leading)
-
-                if installState.isDownloading {
-                    Text(progressPercentageText)
-                        .font(.appFont(14, variant: .medium))
-                        .foregroundStyle(.yellow)
-                }
-            }
-
-            if installState.isDownloading {
-                ModelDownloadProgress(progress: installState.progress, showLabel: false)
             }
 
             if let errorMessage = installState.errorMessage {
@@ -363,10 +355,6 @@ private struct DictationModelCardRow: View {
         }
 
         return DictationModelsCardCopy.notInstalledStatus
-    }
-
-    private var progressPercentageText: String {
-        "\(Int((installState.progress * 100).rounded()))%"
     }
 
     private var approximateSizeText: String? {

--- a/macOS/Views/Settings/SettingsView+DictationModels.swift
+++ b/macOS/Views/Settings/SettingsView+DictationModels.swift
@@ -20,6 +20,8 @@ private struct DictationModelsCard: View {
     @State private var modelExpandedContentHeight: CGFloat = 0
 
     private static let sectionExpansionAnimation = Animation.spring(response: 0.32, dampingFraction: 0.86)
+    // Ignore sub-point geometry jitter while still reacting to real content height changes.
+    private static let modelHeightTolerance: CGFloat = 0.5
 
     var body: some View {
         SettingsCard {
@@ -212,7 +214,7 @@ private struct DictationModelsCard: View {
 
     private func updateModelExpandedContentHeight(_ newHeight: CGFloat) {
         guard newHeight > 0 else { return }
-        if abs(modelExpandedContentHeight - newHeight) > 0.5 {
+        if abs(modelExpandedContentHeight - newHeight) > Self.modelHeightTolerance {
             modelExpandedContentHeight = newHeight
         }
     }

--- a/macOS/Views/Settings/SettingsView+DictationModels.swift
+++ b/macOS/Views/Settings/SettingsView+DictationModels.swift
@@ -5,7 +5,8 @@ extension SettingsView {
     var dictationModelsSection: some View {
         DictationModelsCard(
             appSettings: appSettings,
-            downloader: downloader
+            downloader: downloader,
+            requestDeleteConfirmation: { dictationModelDeleteTarget = $0 }
         )
     }
 }
@@ -13,52 +14,51 @@ extension SettingsView {
 private struct DictationModelsCard: View {
     @ObservedObject var appSettings: AppSettingsStore
     @ObservedObject var downloader: ModelDownloader
+    let requestDeleteConfirmation: (DictationModelID) -> Void
+
+    @State private var isModelSectionExpanded = false
+    @State private var modelExpandedContentHeight: CGFloat = 0
+
+    private static let sectionExpansionAnimation = Animation.spring(response: 0.32, dampingFraction: 0.86)
 
     var body: some View {
         SettingsCard {
-            VStack(alignment: .leading, spacing: 12) {
-                SettingsRow(
-                    icon: "cpu",
-                    title: "Active Model",
-                    subtitle: "Choose the active dictation model and manage installs."
-                ) {
-                    if selectableProviders.isEmpty {
-                        Picker("", selection: unavailableProviderSelection) {
-                            Text("Install model")
-                                .tag(AppSettingsStore.ActiveDictationProvider?.none)
-                        }
-                        .pickerStyle(.menu)
-                        .frame(width: 140)
-                        .labelsHidden()
-                        .disabled(true)
-                    } else {
-                        Picker("", selection: activeProviderSelection) {
-                            ForEach(selectableProviders) { provider in
-                                Text(provider.displayName).tag(provider)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .frame(width: 140)
-                        .labelsHidden()
-                    }
-                }
+            VStack(alignment: .leading, spacing: 16) {
+                headerContent
 
                 Divider()
-                    .overlay(Color.white.opacity(0.14))
+                    .overlay(Color.white.opacity(0.22))
 
-                ForEach(modelRows) { configuration in
-                    DictationModelCardRow(
-                        configuration: configuration,
-                        isActive: appSettings.activeDictationProvider.modelID == configuration.modelID,
-                        installState: downloader.state(for: configuration.modelID),
-                        downloader: downloader
-                    )
+                HStack(alignment: .top, spacing: 12) {
+                    Text(sectionDescriptionText)
+                        .font(.appFont(15, variant: .light))
+                        .foregroundStyle(.white.opacity(0.7))
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
-                    if configuration.modelID != modelRows.last?.modelID {
-                        Divider()
-                            .overlay(Color.white.opacity(0.14))
+                    Button {
+                        withAnimation(Self.sectionExpansionAnimation) {
+                            isModelSectionExpanded.toggle()
+                        }
+                    } label: {
+                        Image(systemName: isModelSectionExpanded ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 28, weight: .heavy))
+                            .foregroundStyle(.yellow)
+                            .frame(width: 56, height: 56)
+                            .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
                 }
+
+                modelExpandedContent
+                    .frame(height: shouldShowExpandedModelContent ? modelExpandedContentHeight : 0, alignment: .top)
+                    .clipped()
+                    .allowsHitTesting(shouldShowExpandedModelContent)
+                    .accessibilityHidden(!shouldShowExpandedModelContent)
+                    .background(alignment: .top) {
+                        if shouldShowExpandedModelContent || modelExpandedContentHeight == 0 {
+                            modelExpandedContentMeasurement
+                        }
+                    }
             }
         }
         .onAppear {
@@ -67,6 +67,98 @@ private struct DictationModelsCard: View {
         .onChange(of: selectableProviders) { _ in
             enforceSelectableActiveProvider()
         }
+    }
+
+    private var headerContent: some View {
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(MacAppTheme.iconFill)
+                    .frame(width: 44, height: 44)
+
+                Image(systemName: "character.cursor.ibeam")
+                    .font(.appFont(20))
+                    .foregroundColor(.yellow)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(DictationModelsCardCopy.cardTitle)
+                    .font(.appFont(18))
+                    .foregroundStyle(.white)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            pickerControl
+                .padding(.top, 2)
+        }
+    }
+
+    @ViewBuilder
+    private var pickerControl: some View {
+        if selectableProviders.isEmpty {
+            Picker("", selection: unavailableProviderSelection) {
+                Text(DictationModelsCardCopy.installModelPickerTitle)
+                    .tag(AppSettingsStore.ActiveDictationProvider?.none)
+            }
+            .pickerStyle(.menu)
+            .frame(width: 140)
+            .labelsHidden()
+            .disabled(true)
+        } else {
+            Picker("", selection: activeProviderSelection) {
+                ForEach(selectableProviders) { provider in
+                    Text(provider.displayName).tag(provider)
+                }
+            }
+            .pickerStyle(.menu)
+            .frame(width: 140)
+            .labelsHidden()
+        }
+    }
+
+    private var modelExpandedContent: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Divider()
+                .overlay(.white.opacity(0.22))
+
+            VStack(alignment: .leading, spacing: 14) {
+                ForEach(Array(modelRows.enumerated()), id: \.element.id) { index, configuration in
+                    DictationModelCardRow(
+                        configuration: configuration,
+                        isActive: appSettings.activeDictationProvider.modelID == configuration.modelID,
+                        installState: downloader.state(for: configuration.modelID),
+                        isBlockedByAnotherActiveInstall: isBlockedByAnotherActiveInstall(for: configuration.modelID),
+                        downloader: downloader,
+                        deleteAction: { requestDeleteConfirmation(configuration.modelID) }
+                    )
+
+                    if index < modelRows.count - 1 {
+                        Divider()
+                            .overlay(Color.white.opacity(0.22))
+                            .padding(.horizontal, 12)
+                    }
+                }
+            }
+        }
+    }
+
+    private var modelExpandedContentMeasurement: some View {
+        modelExpandedContent
+            .fixedSize(horizontal: false, vertical: true)
+            .hidden()
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+            .background(
+                GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            updateModelExpandedContentHeight(geometry.size.height)
+                        }
+                        .onChange(of: geometry.size.height) { newHeight in
+                            updateModelExpandedContentHeight(newHeight)
+                        }
+                }
+            )
     }
 
     private var activeProviderSelection: Binding<AppSettingsStore.ActiveDictationProvider> {
@@ -94,18 +186,43 @@ private struct DictationModelsCard: View {
         AppSettingsStore.ActiveDictationProvider.supportedCases().filter(isProviderSelectable)
     }
 
+    private var sectionDescriptionText: String {
+        if selectableProviders.isEmpty {
+            return DictationModelsCardCopy.installDescription
+        }
+
+        return DictationModelsCardCopy.readyDescription
+    }
+
+    private var shouldShowExpandedModelContent: Bool {
+        isModelSectionExpanded
+    }
+
     private func enforceSelectableActiveProvider() {
         guard !isProviderSelectable(appSettings.activeDictationProvider) else { return }
         guard let fallback = AppSettingsStore.ActiveDictationProvider.supportedCases().first(where: isProviderSelectable) else { return }
         appSettings.activeDictationProvider = fallback
     }
 
+    private func isBlockedByAnotherActiveInstall(for modelID: DictationModelID) -> Bool {
+        modelRows.contains { configuration in
+            configuration.modelID != modelID && downloader.state(for: configuration.modelID).isDownloading
+        }
+    }
+
+    private func updateModelExpandedContentHeight(_ newHeight: CGFloat) {
+        guard newHeight > 0 else { return }
+        if abs(modelExpandedContentHeight - newHeight) > 0.5 {
+            modelExpandedContentHeight = newHeight
+        }
+    }
+
     private var modelRows: [DictationModelCardConfiguration] {
         var rows = [
             DictationModelCardConfiguration(
                 modelID: .whisperBase,
-                title: "Whisper Base",
-                subtitle: "Locally powered multi-lingual model from OpenAI."
+                title: AppSettingsStore.ActiveDictationProvider.whisper.displayName,
+                subtitle: DictationModelsCardCopy.whisperDescription
             )
         ]
 
@@ -113,8 +230,8 @@ private struct DictationModelsCard: View {
             rows.append(
                 DictationModelCardConfiguration(
                     modelID: .parakeetTdtV3,
-                    title: "Parakeet TDT v3",
-                    subtitle: "Locally powered multi-lingual model from NVIDIA."
+                    title: AppSettingsStore.ActiveDictationProvider.parakeet.displayName,
+                    subtitle: DictationModelsCardCopy.parakeetDescription
                 )
             )
         }
@@ -135,81 +252,92 @@ private struct DictationModelCardRow: View {
     let configuration: DictationModelCardConfiguration
     let isActive: Bool
     let installState: DictationModelInstallState
+    let isBlockedByAnotherActiveInstall: Bool
 
     @ObservedObject var downloader: ModelDownloader
-    @State private var isReadyHovered = false
+    let deleteAction: () -> Void
 
     private let actionPillWidth: CGFloat = 84
 
     var body: some View {
-        VStack(spacing: 16) {
+        VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 6) {
-                        Text(configuration.title)
-                            .font(.appFont(13))
-                            .foregroundColor(.primary)
+                HStack(alignment: .center, spacing: 8) {
+                    Text(configuration.title)
+                        .font(.appFont(17))
+                        .foregroundStyle(.white)
 
-                        if isActive {
-                            Circle()
-                                .fill(Color.yellow)
-                                .frame(width: 7, height: 7)
-                        }
-                    }
-
-                    Text(configuration.subtitle)
-                        .font(.appFont(12, variant: .light))
-                        .foregroundColor(.secondary)
-                        .lineSpacing(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer(minLength: 12)
-
-                HStack(spacing: 8) {
-                    ZStack(alignment: .trailing) {
-                        if installState.isReady && !installState.isDownloading {
-                            Button(action: removeModel) {
-                                removeButtonLabel
-                                    .frame(width: actionPillWidth)
-                            }
-                            .buttonStyle(.plain)
-                            .opacity(isReadyHovered ? 1.0 : 0.0)
-                            .allowsHitTesting(isReadyHovered)
-
-                            readyBadgeLabel
-                                .frame(width: actionPillWidth)
-                                .opacity(isReadyHovered ? 0.0 : 1.0)
-                        } else if installState.isDownloading {
-                            StatusBadge(title: "Installing", color: .yellow)
-                                .frame(width: actionPillWidth)
-                        } else {
-                            AppActionButton(
-                                title: "Install",
-                                style: .primary,
-                                minWidth: actionPillWidth
-                            ) {
-                                installModel()
-                            }
-                        }
+                    if isActive && installState.isReady {
+                        Circle()
+                            .fill(Color.yellow)
+                            .frame(width: 8, height: 8)
                     }
                 }
-                .onHover { isReadyHovered = $0 }
-                .animation(.none, value: isReadyHovered)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                actionButton
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if !installState.isReady && !installState.isDownloading {
+                Text(configuration.subtitle)
+                    .font(.appFont(14, variant: .light))
+                    .foregroundStyle(.white.opacity(0.7))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            HStack(alignment: .center, spacing: 12) {
+                Text(statusText)
+                    .font(.appFont(13, variant: .light))
+                    .foregroundStyle(.white.opacity(0.56))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if installState.isDownloading {
+                    Text(progressPercentageText)
+                        .font(.appFont(14, variant: .medium))
+                        .foregroundStyle(.yellow)
+                }
+            }
 
             if installState.isDownloading {
-                ModelDownloadProgress(progress: installState.progress)
-                    .padding(.leading, 60)
+                ModelDownloadProgress(progress: installState.progress, showLabel: false)
             }
 
             if let errorMessage = installState.errorMessage {
                 Text(errorMessage)
-                    .font(.appFont(10))
-                    .foregroundColor(.red)
+                    .font(.appFont(12))
+                    .foregroundStyle(.red)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var actionButton: some View {
+        if installState.isDownloading {
+            EmptyView()
+        } else if installState.isReady {
+            AppActionButton(
+                title: DictationModelsCardCopy.deleteAction,
+                style: .destructive,
+                minWidth: actionPillWidth,
+                action: deleteAction
+            )
+        } else if installState.errorMessage != nil {
+            AppActionButton(
+                title: DictationModelsCardCopy.repairAction,
+                style: .primary,
+                minWidth: actionPillWidth,
+                isEnabled: !isBlockedByAnotherActiveInstall,
+                action: installModel
+            )
+        } else {
+            AppActionButton(
+                title: DictationModelsCardCopy.downloadAction,
+                style: .primary,
+                minWidth: actionPillWidth,
+                isEnabled: !isBlockedByAnotherActiveInstall,
+                action: installModel
+            )
         }
     }
 
@@ -217,38 +345,52 @@ private struct DictationModelCardRow: View {
         downloader.downloadModel(withID: configuration.modelID)
     }
 
-    private func removeModel() {
-        downloader.deleteModel(withID: configuration.modelID)
-    }
-
-    private var removeButtonLabel: some View {
-        HStack(spacing: 4) {
-            Image(systemName: "xmark.circle.fill")
-            Text("REMOVE")
+    private var statusText: String {
+        if installState.isDownloading {
+            return DictationModelsCardCopy.installingStatus
         }
-        .font(.appFont(9))
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(Color.red.opacity(0.15))
-        .foregroundColor(.red)
-        .clipShape(Capsule())
-        .overlay(
-            Capsule()
-                .stroke(Color.red.opacity(0.3), lineWidth: 1)
-        )
+
+        if installState.isReady {
+            return DictationModelsCardCopy.readyStatus
+        }
+
+        if installState.errorMessage != nil {
+            return DictationModelsCardCopy.failedStatus
+        }
+
+        if let approximateSizeText {
+            return "\(DictationModelsCardCopy.notInstalledStatus) (\(approximateSizeText))"
+        }
+
+        return DictationModelsCardCopy.notInstalledStatus
     }
 
-    private var readyBadgeLabel: some View {
-        Text("READY")
-            .font(.appFont(9))
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(Color.green.opacity(0.15))
-            .foregroundColor(.green)
-            .clipShape(Capsule())
-            .overlay(
-                Capsule()
-                    .stroke(Color.green.opacity(0.3), lineWidth: 1)
-            )
+    private var progressPercentageText: String {
+        "\(Int((installState.progress * 100).rounded()))%"
     }
+
+    private var approximateSizeText: String? {
+        switch configuration.modelID {
+        case .whisperBase:
+            return "~190 MB"
+        case .parakeetTdtV3:
+            return "~480 MB"
+        }
+    }
+}
+
+private enum DictationModelsCardCopy {
+    static let cardTitle = "Dictation Model"
+    static let installDescription = "Install a dictation model to let KeyVox transcribe speech on this Mac."
+    static let readyDescription = "Choose which installed model KeyVox uses when transcribing speech on this Mac."
+    static let installModelPickerTitle = "Install model"
+    static let whisperDescription = "Accurate and lightweight."
+    static let parakeetDescription = "Lightning fast, heavier footprint."
+    static let notInstalledStatus = "Not installed"
+    static let installingStatus = "Installing"
+    static let failedStatus = "Install failed"
+    static let readyStatus = "Ready"
+    static let downloadAction = "Download"
+    static let repairAction = "Repair"
+    static let deleteAction = "Delete"
 }

--- a/macOS/Views/Settings/SettingsView+DictionarySection.swift
+++ b/macOS/Views/Settings/SettingsView+DictionarySection.swift
@@ -16,13 +16,13 @@ extension SettingsView {
                 VStack(alignment: .leading, spacing: 12) {
                     HStack(alignment: .center, spacing: 12) {
                         ZStack {
-                            RoundedRectangle(cornerRadius: 12)
+                            Circle()
                                 .fill(MacAppTheme.iconFill)
                                 .frame(width: 44, height: 44)
 
                             Image(systemName: "text.book.closed.fill")
                                 .font(.appFont(20))
-                                .foregroundColor(MacAppTheme.accent)
+                                .foregroundColor(.yellow)
                         }
 
                         VStack(alignment: .leading, spacing: 4) {

--- a/macOS/Views/Settings/SettingsView+More.swift
+++ b/macOS/Views/Settings/SettingsView+More.swift
@@ -156,12 +156,12 @@ extension SettingsView {
             VStack(alignment: .leading, spacing: 12) {
                 HStack(alignment: .audioHeaderCenter, spacing: 16) {
                     ZStack {
-                        RoundedRectangle(cornerRadius: 12)
+                        Circle()
                             .fill(MacAppTheme.iconFill)
                             .frame(width: 44, height: 44)
                         Image(systemName: "mic.fill")
                             .font(.appFont(20))
-                            .foregroundColor(MacAppTheme.accent)
+                            .foregroundColor(.yellow)
                     }
                     .alignmentGuide(.audioHeaderCenter) { dimensions in
                         dimensions[VerticalAlignment.center]
@@ -202,12 +202,12 @@ extension SettingsView {
         SettingsCard {
             HStack(alignment: .audioHeaderCenter, spacing: 16) {
                 ZStack {
-                    RoundedRectangle(cornerRadius: 12)
+                    Circle()
                         .fill(MacAppTheme.iconFill)
                         .frame(width: 44, height: 44)
                     Image(systemName: "speaker.wave.2.fill")
                         .font(.appFont(20))
-                        .foregroundColor(MacAppTheme.accent)
+                        .foregroundColor(.yellow)
                 }
                 .alignmentGuide(.audioHeaderCenter) { dimensions in
                     dimensions[VerticalAlignment.center]

--- a/macOS/Views/Settings/SettingsView+More.swift
+++ b/macOS/Views/Settings/SettingsView+More.swift
@@ -11,20 +11,31 @@ extension SettingsView {
                     .foregroundColor(.secondary.opacity(0.6))
                     .padding(.leading, 4)
 
-                SettingsCard {
-                    SettingsRow(
-                        icon: "keyboard",
-                        title: "Trigger Key",
-                        subtitle: "Hold this key to start recording. Release to transcribe."
-                    ) {
-                        Picker("", selection: $appSettings.triggerBinding) {
-                            ForEach(KeyboardMonitor.TriggerBinding.allCases) { binding in
-                                Text(binding.displayName).tag(binding)
+                VStack(alignment: .leading, spacing: 10) {
+                    SettingsCard {
+                        SettingsRow(
+                            icon: "keyboard",
+                            title: "Trigger Key",
+                            subtitle: "Hold this key to start recording. Release to transcribe."
+                        ) {
+                            Picker("", selection: $appSettings.triggerBinding) {
+                                ForEach(KeyboardMonitor.TriggerBinding.allCases) { binding in
+                                    Text(binding.displayName).tag(binding)
+                                }
                             }
+                            .pickerStyle(.menu)
+                            .frame(width: 160)
+                            .labelsHidden()
                         }
-                        .pickerStyle(.menu)
-                        .frame(width: 160)
-                        .labelsHidden()
+                    }
+
+                    HStack {
+                        Spacer()
+                        TipItem(
+                            icon: "shift.fill",
+                            text: "Trigger key + Shift = Hands-free mode"
+                        )
+                        Spacer()
                     }
                 }
             }

--- a/macOS/Views/Settings/SettingsView.swift
+++ b/macOS/Views/Settings/SettingsView.swift
@@ -19,6 +19,7 @@ struct SettingsView: View {
     @State internal var showLegal = false
     @State internal var dictionaryEditorMode: DictionaryWordEditorMode?
     @State internal var dictionaryDeleteTarget: DictionaryEntry?
+    @State internal var dictationModelDeleteTarget: DictationModelID?
     @State internal var isVibesAIDeleteConfirmationPresented = false
     @State internal var dictionarySortMode: DictionarySortMode = .alphabetical
     @State private var hasVisitedDictionaryTab = false
@@ -86,6 +87,23 @@ struct SettingsView: View {
                 },
                 onCancel: {
                     dictionaryDeleteTarget = nil
+                }
+            )
+        }
+        .sheet(item: $dictationModelDeleteTarget) { modelID in
+            let displayName = DictationModelCatalog.descriptor(for: modelID).displayName
+
+            ConfirmDeletePromptView(
+                config: ConfirmDeletePromptConfig(
+                    title: "Delete \(displayName)?",
+                    message: "\(displayName) will be removed from this Mac."
+                ),
+                onConfirm: {
+                    downloader.deleteModel(withID: modelID)
+                    dictationModelDeleteTarget = nil
+                },
+                onCancel: {
+                    dictationModelDeleteTarget = nil
                 }
             )
         }

--- a/macOS/Views/UpdatePromptOverlay.swift
+++ b/macOS/Views/UpdatePromptOverlay.swift
@@ -24,7 +24,7 @@ struct UpdatePromptOverlay: View {
         VStack(alignment: .leading, spacing: 16) {
             AnimatedWaveHeader {
                 if let versionBadgeTitle {
-                    StatusBadge(title: versionBadgeTitle, color: MacAppTheme.accent)
+                    StatusBadge(title: versionBadgeTitle, backgroundColor: MacAppTheme.accent)
                 }
             }
 

--- a/macOS/Views/Updates/PostUpdateNoticeView.swift
+++ b/macOS/Views/Updates/PostUpdateNoticeView.swift
@@ -9,7 +9,7 @@ struct PostUpdateNoticeView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             AnimatedWaveHeader {
-                StatusBadge(title: "Updated", color: MacAppTheme.accent)
+                StatusBadge(title: "Updated", backgroundColor: MacAppTheme.accent)
             }
             .padding(.top, 10)
 

--- a/macOS/Views/Updates/UpdateHeaderCard.swift
+++ b/macOS/Views/Updates/UpdateHeaderCard.swift
@@ -6,13 +6,6 @@ struct UpdateHeaderCard: View {
     let statusMessage: String
     let state: AppUpdateState
 
-    private var badgeTitle: String {
-        if let targetVersion, !targetVersion.isEmpty {
-            return "v\(targetVersion)"
-        }
-        return "v\(currentVersion)"
-    }
-
     var body: some View {
         SettingsCard {
             VStack(alignment: .leading, spacing: 12) {
@@ -26,9 +19,6 @@ struct UpdateHeaderCard: View {
                             .foregroundColor(.secondary)
                     }
 
-                    Spacer()
-
-                    StatusBadge(title: badgeTitle, color: MacAppTheme.accent)
                 }
 
                 HStack {
@@ -39,7 +29,7 @@ struct UpdateHeaderCard: View {
                     if let targetVersion, state != .completed {
                         Text("Update: v\(targetVersion)")
                             .font(.appFont(11))
-                            .foregroundColor(MacAppTheme.accent)
+                            .foregroundColor(.yellow)
                     }
                 }
             }

--- a/macOS/Views/Updates/UpdateWindowView.swift
+++ b/macOS/Views/Updates/UpdateWindowView.swift
@@ -49,9 +49,7 @@ struct UpdateWindowView: View {
 
     private var draggableContent: some View {
         VStack(alignment: .leading, spacing: 16) {
-            AnimatedWaveHeader {
-                StatusBadge(title: "Updater", color: MacAppTheme.accent)
-            }
+            AnimatedWaveHeader()
             .padding(.top, 10)
             .background(WindowDragRegion())
 


### PR DESCRIPTION
## Summary

Updates the Mac settings, onboarding, updater, and Vibes-related UI for a more consistent yellow-accented design.

## Changes

- Refined Mac settings cards with circular yellow icon treatments
- Redesigned dictation model management with expandable details and clearer install/delete actions
- Added delete confirmation for dictation models
- Standardized progress/status display across model downloads, Vibes AI, onboarding, and updater views
- Updated onboarding width, title styling, and action button copy
- Removed updater pills and converted updater accent text to yellow
- Improved updater handoff termination to avoid shutdown-time cleanup crashes
- Cleared visible Vibe cycle pills when overlays hide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added confirmation dialog when deleting dictation models
  * Added hands-free mode tip indicator in settings

* **Improvements**
  * Redesigned dictation model management with expandable sections and clearer actions
  * Updated progress bar styling across settings and onboarding views
  * Refined visual design with improved icon styling and consistent yellow accents
  * Adjusted onboarding window layout for better content presentation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/macmixing/keyvox/pull/90)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->