### PR TITLE
Add eligible App Store review requests

### DIFF
--- a/iOS/KeyVox iOS/App/AppReview/AppReviewRequestCoordinator.swift
+++ b/iOS/KeyVox iOS/App/AppReview/AppReviewRequestCoordinator.swift
@@ -1,0 +1,114 @@
+import Combine
+import Foundation
+
+@MainActor
+final class AppReviewRequestCoordinator: ObservableObject {
+    struct Context: Equatable {
+        let hasResolvedLaunchContext: Bool
+        let isMainInterfacePresented: Bool
+        let hasCompetingPresentation: Bool
+        let isUpdatePromptStateRefreshing: Bool
+        let hasCompletedOnboardingBeforeCurrentLaunch: Bool
+        let currentVersion: String?
+    }
+
+    private let store: AppReviewRequestStore
+    private var latestContext: Context?
+    private var isSuppressedForCurrentActivation = false
+    private var pendingTask: Task<Void, Never>?
+    private var pendingTaskID: UUID?
+
+    init(store: AppReviewRequestStore) {
+        self.store = store
+    }
+
+    func handleAppDidBecomeActive() {
+        isSuppressedForCurrentActivation = false
+        latestContext = nil
+        cancelPendingRequest()
+    }
+
+    func handleAppDidLeaveActive() {
+        latestContext = nil
+        cancelPendingRequest()
+    }
+
+    func evaluate(
+        context: Context,
+        requestReview: @escaping @MainActor () -> Void
+    ) {
+        latestContext = context
+
+        guard context.hasResolvedLaunchContext else {
+            cancelPendingRequest()
+            return
+        }
+
+        if context.isUpdatePromptStateRefreshing {
+            cancelPendingRequest()
+            return
+        }
+
+        guard context.isMainInterfacePresented,
+              context.hasCompetingPresentation == false else {
+            isSuppressedForCurrentActivation = true
+            cancelPendingRequest()
+            return
+        }
+
+        guard isSuppressedForCurrentActivation == false,
+              pendingTask == nil,
+              let currentVersion = context.currentVersion,
+              store.isEligible(
+                  currentVersion: currentVersion,
+                  hasCompletedOnboardingBeforeCurrentLaunch: context.hasCompletedOnboardingBeforeCurrentLaunch
+              ) else {
+            return
+        }
+
+        scheduleRequest(
+            for: currentVersion,
+            context: context,
+            requestReview: requestReview
+        )
+    }
+
+    private func scheduleRequest(
+        for version: String,
+        context: Context,
+        requestReview: @escaping @MainActor () -> Void
+    ) {
+        let taskID = UUID()
+        pendingTaskID = taskID
+        pendingTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.clearPendingRequest(ifMatching: taskID) }
+
+            try? await Task.sleep(for: .seconds(2))
+            guard Task.isCancelled == false,
+                  self.latestContext == context,
+                  self.isSuppressedForCurrentActivation == false,
+                  self.store.isEligible(
+                      currentVersion: version,
+                      hasCompletedOnboardingBeforeCurrentLaunch: context.hasCompletedOnboardingBeforeCurrentLaunch
+                  ) else {
+                return
+            }
+
+            self.store.markRequested(for: version)
+            requestReview()
+        }
+    }
+
+    private func cancelPendingRequest() {
+        pendingTask?.cancel()
+        pendingTask = nil
+        pendingTaskID = nil
+    }
+
+    private func clearPendingRequest(ifMatching taskID: UUID) {
+        guard pendingTaskID == taskID else { return }
+        pendingTask = nil
+        pendingTaskID = nil
+    }
+}

--- a/iOS/KeyVox iOS/App/AppReview/AppReviewRequestPolicy.swift
+++ b/iOS/KeyVox iOS/App/AppReview/AppReviewRequestPolicy.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+nonisolated enum AppReviewRequestPolicy {
+    private static let eligibilityWindow: TimeInterval = 7 * 24 * 60 * 60
+
+    static func isEligible(
+        firstLaunchAt: Date,
+        lastSuccessfulDictationAt: Date?,
+        lastRequestedVersion: String?,
+        currentVersion: String,
+        hasCompletedOnboardingBeforeCurrentLaunch: Bool,
+        now: Date
+    ) -> Bool {
+        guard hasCompletedOnboardingBeforeCurrentLaunch else { return false }
+
+        let installationAge = now.timeIntervalSince(firstLaunchAt)
+        guard installationAge >= eligibilityWindow else { return false }
+
+        guard let lastSuccessfulDictationAt else { return false }
+        let timeSinceSuccessfulDictation = now.timeIntervalSince(lastSuccessfulDictationAt)
+        guard timeSinceSuccessfulDictation >= 0,
+              timeSinceSuccessfulDictation <= eligibilityWindow else {
+            return false
+        }
+
+        return lastRequestedVersion != currentVersion
+    }
+}

--- a/iOS/KeyVox iOS/App/AppReview/AppReviewRequestStore.swift
+++ b/iOS/KeyVox iOS/App/AppReview/AppReviewRequestStore.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+@MainActor
+final class AppReviewRequestStore {
+    private let defaults: UserDefaults
+    private let now: () -> Date
+
+    init(
+        defaults: UserDefaults,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.defaults = defaults
+        self.now = now
+
+        if defaults.object(forKey: UserDefaultsKeys.App.reviewFirstLaunchAt) == nil {
+            defaults.set(now(), forKey: UserDefaultsKeys.App.reviewFirstLaunchAt)
+        }
+    }
+
+    func recordSuccessfulDictation() {
+        defaults.set(now(), forKey: UserDefaultsKeys.App.reviewLastSuccessfulDictationAt)
+    }
+
+    func isEligible(
+        currentVersion: String,
+        hasCompletedOnboardingBeforeCurrentLaunch: Bool
+    ) -> Bool {
+        guard let firstLaunchAt = defaults.object(
+            forKey: UserDefaultsKeys.App.reviewFirstLaunchAt
+        ) as? Date else {
+            return false
+        }
+
+        return AppReviewRequestPolicy.isEligible(
+            firstLaunchAt: firstLaunchAt,
+            lastSuccessfulDictationAt: defaults.object(
+                forKey: UserDefaultsKeys.App.reviewLastSuccessfulDictationAt
+            ) as? Date,
+            lastRequestedVersion: defaults.string(
+                forKey: UserDefaultsKeys.App.reviewLastRequestedVersion
+            ),
+            currentVersion: currentVersion,
+            hasCompletedOnboardingBeforeCurrentLaunch: hasCompletedOnboardingBeforeCurrentLaunch,
+            now: now()
+        )
+    }
+
+    func markRequested(for version: String) {
+        defaults.set(version, forKey: UserDefaultsKeys.App.reviewLastRequestedVersion)
+    }
+}

--- a/iOS/KeyVox iOS/App/AppUpdate/AppUpdateCoordinator.swift
+++ b/iOS/KeyVox iOS/App/AppUpdate/AppUpdateCoordinator.swift
@@ -13,6 +13,7 @@ final class AppUpdateCoordinator: ObservableObject {
     }
 
     @Published var activePrompt: Prompt?
+    @Published private(set) var isRefreshingPromptState = false
 
     private let service: AppUpdateService
     private let defaults: UserDefaults
@@ -39,10 +40,14 @@ final class AppUpdateCoordinator: ObservableObject {
         guard refreshTask == nil else { return }
         guard shouldRefresh else { return }
 
+        isRefreshingPromptState = true
         refreshTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            defer {
+                self.isRefreshingPromptState = false
+                self.refreshTask = nil
+            }
             await self.refreshPromptState()
-            self.refreshTask = nil
         }
     }
 
@@ -95,7 +100,7 @@ final class AppUpdateCoordinator: ObservableObject {
         syncPresentationState()
     }
 
-    private var currentAppVersion: AppVersion? {
+    var currentAppVersion: AppVersion? {
         guard let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String else {
             return nil
         }

--- a/iOS/KeyVox iOS/App/Composition/AppServiceRegistry.swift
+++ b/iOS/KeyVox iOS/App/Composition/AppServiceRegistry.swift
@@ -13,6 +13,8 @@ final class AppServiceRegistry {
     let settingsStore: AppSettingsStore
     let onboardingStore: OnboardingStore
     let weeklyWordStatsStore: WeeklyWordStatsStore
+    let appReviewRequestStore: AppReviewRequestStore
+    let appReviewRequestCoordinator: AppReviewRequestCoordinator
     let appTabRouter: AppTabRouter
     let appHaptics: AppHaptics
     let ttsPurchaseController: TTSPurchaseController
@@ -68,6 +70,8 @@ final class AppServiceRegistry {
         let runtimeFlags = RuntimeFlags()
         let onboardingStore = OnboardingStore(defaults: settingsDefaults, runtimeFlags: runtimeFlags)
         let weeklyWordStatsStore = WeeklyWordStatsStore(defaults: settingsDefaults)
+        let appReviewRequestStore = AppReviewRequestStore(defaults: settingsDefaults)
+        let appReviewRequestCoordinator = AppReviewRequestCoordinator(store: appReviewRequestStore)
         let appTabRouter = AppTabRouter()
         let appHaptics = AppHaptics()
         let ttsPurchaseController = TTSPurchaseController(
@@ -196,6 +200,9 @@ final class AppServiceRegistry {
             },
             recordPipelineResult: { [weak styleRewritePipelineCoordinator] result, selectedText in
                 styleRewritePipelineCoordinator?.recordLatestArtifact(from: result, selectedText: selectedText)
+            },
+            recordSuccessfulDictation: { [weak appReviewRequestStore] in
+                appReviewRequestStore?.recordSuccessfulDictation()
             },
             prewarmStyleRewriteForUpcomingDictation: { [weak styleRewritePipelineCoordinator] in
                 Task { @MainActor [weak styleRewritePipelineCoordinator] in
@@ -335,6 +342,8 @@ final class AppServiceRegistry {
         self.settingsStore = settingsStore
         self.onboardingStore = onboardingStore
         self.weeklyWordStatsStore = weeklyWordStatsStore
+        self.appReviewRequestStore = appReviewRequestStore
+        self.appReviewRequestCoordinator = appReviewRequestCoordinator
         self.appTabRouter = appTabRouter
         self.appHaptics = appHaptics
         self.ttsPurchaseController = ttsPurchaseController

--- a/iOS/KeyVox iOS/App/Lifecycle/KeyVoxiOSApp.swift
+++ b/iOS/KeyVox iOS/App/Lifecycle/KeyVoxiOSApp.swift
@@ -21,6 +21,7 @@ struct KeyVoxApp: App {
     @StateObject private var settingsStore: AppSettingsStore
     @StateObject private var onboardingStore: OnboardingStore
     @StateObject private var weeklyWordStatsStore: WeeklyWordStatsStore
+    @StateObject private var appReviewRequestCoordinator: AppReviewRequestCoordinator
     @StateObject private var appTabRouter: AppTabRouter
     @StateObject private var appUpdateCoordinator: AppUpdateCoordinator
     private let appHaptics: AppHaptics
@@ -44,6 +45,7 @@ struct KeyVoxApp: App {
         _settingsStore = StateObject(wrappedValue: services.settingsStore)
         _onboardingStore = StateObject(wrappedValue: services.onboardingStore)
         _weeklyWordStatsStore = StateObject(wrappedValue: services.weeklyWordStatsStore)
+        _appReviewRequestCoordinator = StateObject(wrappedValue: services.appReviewRequestCoordinator)
         _appTabRouter = StateObject(wrappedValue: services.appTabRouter)
         _appUpdateCoordinator = StateObject(wrappedValue: services.appUpdateCoordinator)
         appHaptics = services.appHaptics
@@ -88,6 +90,7 @@ struct KeyVoxApp: App {
                 .environmentObject(settingsStore)
                 .environmentObject(onboardingStore)
                 .environmentObject(weeklyWordStatsStore)
+                .environmentObject(appReviewRequestCoordinator)
                 .environmentObject(appTabRouter)
                 .environmentObject(appUpdateCoordinator)
                 .environmentObject(dictionaryStore)

--- a/iOS/KeyVox iOS/App/Presentation/AppReviewRequestBlockingPreference.swift
+++ b/iOS/KeyVox iOS/App/Presentation/AppReviewRequestBlockingPreference.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+private struct AppReviewRequestBlockingPreferenceKey: PreferenceKey {
+    static var defaultValue = false
+
+    static func reduce(value: inout Bool, nextValue: () -> Bool) {
+        value = value || nextValue()
+    }
+}
+
+extension View {
+    func blocksAppReviewRequest(_ isBlocked: Bool) -> some View {
+        preference(key: AppReviewRequestBlockingPreferenceKey.self, value: isBlocked)
+    }
+
+    func onAppReviewRequestBlockingChange(
+        perform action: @escaping (Bool) -> Void
+    ) -> some View {
+        onPreferenceChange(AppReviewRequestBlockingPreferenceKey.self, perform: action)
+    }
+}

--- a/iOS/KeyVox iOS/App/iCloud/UserDefaultsKeys.swift
+++ b/iOS/KeyVox iOS/App/iCloud/UserDefaultsKeys.swift
@@ -41,6 +41,9 @@ nonisolated enum UserDefaultsKeys {
         static let hasSeenKeyVoxVibesIntro = "KeyVox.App.HasSeenKeyVoxVibesIntro"
         static let hasInteractedWithKeyVoxVibes = "KeyVox.App.HasInteractedWithKeyVoxVibes"
         static let shouldShowKeyVoxVibesIntroOnNextEligibleLaunch = "KeyVox.App.ShouldShowKeyVoxVibesIntroOnNextEligibleLaunch"
+        static let reviewFirstLaunchAt = "KeyVox.App.Review.FirstLaunchAt"
+        static let reviewLastSuccessfulDictationAt = "KeyVox.App.Review.LastSuccessfulDictationAt"
+        static let reviewLastRequestedVersion = "KeyVox.App.Review.LastRequestedVersion"
     }
 
     enum iCloud {

--- a/iOS/KeyVox iOS/Core/Transcription/TranscriptionManager.swift
+++ b/iOS/KeyVox iOS/Core/Transcription/TranscriptionManager.swift
@@ -37,6 +37,7 @@ final class TranscriptionManager: ObservableObject {
     private let capsLockEnabledProvider: () -> Bool
     private let processOutputText: (DictationPipelineTextProcessingContext) async -> DictationPipelineTextProcessingResult
     private let recordPipelineResult: (DictationPipelineResult, String) -> Void
+    private let recordSuccessfulDictation: () -> Void
     private let prewarmStyleRewriteForUpcomingDictation: () -> Void
     let releaseStyleRewritePrewarmSession: @MainActor (String) async -> Void
     private let sessionDisableTimingProvider: (() -> SessionDisableTiming)?
@@ -67,6 +68,7 @@ final class TranscriptionManager: ObservableObject {
         listRenderModeProvider: { .multiline },
         recordSpokenWords: { [weak self] text in
             self?.weeklyWordStatsStore.recordSpokenWords(from: text)
+            self?.recordSuccessfulDictation()
         },
         pasteText: { [weak self] text in
             self?.capturePipelineOutput(text)
@@ -94,6 +96,7 @@ final class TranscriptionManager: ObservableObject {
             .unchanged($0.baseText)
         },
         recordPipelineResult: @escaping (DictationPipelineResult, String) -> Void = { _, _ in },
+        recordSuccessfulDictation: @escaping () -> Void = {},
         prewarmStyleRewriteForUpcomingDictation: @escaping () -> Void = {},
         releaseStyleRewritePrewarmSession: @escaping @MainActor (String) async -> Void = { _ in },
         sessionDisableTimingProvider: (() -> SessionDisableTiming)? = nil,
@@ -125,6 +128,7 @@ final class TranscriptionManager: ObservableObject {
         self.capsLockEnabledProvider = capsLockEnabledProvider
         self.processOutputText = processOutputTextWithContext
         self.recordPipelineResult = recordPipelineResult
+        self.recordSuccessfulDictation = recordSuccessfulDictation
         self.prewarmStyleRewriteForUpcomingDictation = prewarmStyleRewriteForUpcomingDictation
         self.releaseStyleRewritePrewarmSession = releaseStyleRewritePrewarmSession
         self.sessionDisableTimingProvider = sessionDisableTimingProvider

--- a/iOS/KeyVox iOS/Views/AppRootView.swift
+++ b/iOS/KeyVox iOS/Views/AppRootView.swift
@@ -1,3 +1,4 @@
+import StoreKit
 import SwiftUI
 
 struct AppRootView: View {
@@ -23,9 +24,13 @@ struct AppRootView: View {
     @EnvironmentObject private var keyVoxVibesPurchaseController: KeyVoxVibesPurchaseController
     @EnvironmentObject private var keyVoxVibesIntroController: KeyVoxVibesIntroController
     @EnvironmentObject private var appUpdateCoordinator: AppUpdateCoordinator
+    @EnvironmentObject private var appReviewRequestCoordinator: AppReviewRequestCoordinator
+    @Environment(\.requestReview) private var requestReview
+    @Environment(\.scenePhase) private var scenePhase
     @State private var previousDestination: RootDestination?
     @State private var onboardingOverlayState: RootOverlayState = .hidden
     @State private var onboardingOverlayOpacity = 1.0
+    @State private var isDescendantBlockingReviewRequest = false
 
     private var destination: RootDestination {
         if !appLaunchRouteStore.hasResolvedInitialLaunchContext {
@@ -119,6 +124,9 @@ struct AppRootView: View {
                 .environmentObject(keyVoxVibesPurchaseController)
         }
         .appUpdatePrompt(activeUpdatePrompt, onUpdate: openUpdate, onLater: dismissOptionalUpdate)
+        .onAppReviewRequestBlockingChange { isBlocked in
+            isDescendantBlockingReviewRequest = isBlocked
+        }
         .onAppear {
             previousDestination = destination
             onboardingOverlayState = destination == .onboarding ? .visible : .hidden
@@ -148,6 +156,10 @@ struct AppRootView: View {
                 onboardingOverlayState = .hidden
                 onboardingOverlayOpacity = 1
             }
+
+            Task { @MainActor in
+                evaluateReviewRequest()
+            }
         }
         .onChange(of: onboardingStore.hasCompletedOnboardingThisLaunch, initial: false) { _, newValue in
             guard newValue else { return }
@@ -158,6 +170,22 @@ struct AppRootView: View {
         }
         .onChange(of: appUpdateCoordinator.activePrompt?.id, initial: false) { _, _ in
             updateKeyVoxSpeakIntroPresentation(for: destination)
+        }
+        .onChange(of: appUpdateCoordinator.isRefreshingPromptState, initial: true) { _, _ in
+            evaluateReviewRequest()
+        }
+        .onChange(of: hasCompetingReviewPresentation, initial: true) { _, _ in
+            evaluateReviewRequest()
+        }
+        .onChange(of: scenePhase, initial: true) { _, newPhase in
+            if newPhase == .active {
+                appReviewRequestCoordinator.handleAppDidBecomeActive()
+                Task { @MainActor in
+                    evaluateReviewRequest()
+                }
+            } else {
+                appReviewRequestCoordinator.handleAppDidLeaveActive()
+            }
         }
         .animation(rootAnimation, value: destination)
     }
@@ -212,6 +240,42 @@ struct AppRootView: View {
         appUpdateCoordinator.dismissOptionalPrompt()
     }
 
+    private var hasCompetingReviewPresentation: Bool {
+        isDescendantBlockingReviewRequest
+            || appUpdateCoordinator.activePrompt != nil
+            || keyVoxSpeakIntroController.isPresented
+            || keyVoxSpeakIntroController.wantsPresentationOnEligibleLaunch
+            || keyVoxVibesIntroController.isPresented
+            || keyVoxVibesIntroController.wantsPresentationOnEligibleLaunch
+            || ttsPurchaseController.isUnlockSheetPresented
+            || keyVoxVibesPurchaseController.sheetPresentation != nil
+            || transcriptionManager.state != .idle
+            || ttsManager.isActive
+    }
+
+    private var hasCompletedOnboardingBeforeCurrentLaunch: Bool {
+        onboardingStore.hasCompletedOnboarding
+            && onboardingStore.hasCompletedOnboardingThisLaunch == false
+    }
+
+    private func evaluateReviewRequest() {
+        guard scenePhase == .active else { return }
+
+        appReviewRequestCoordinator.evaluate(
+            context: AppReviewRequestCoordinator.Context(
+                hasResolvedLaunchContext: appLaunchRouteStore.hasResolvedInitialLaunchContext,
+                isMainInterfacePresented: destination == .main,
+                hasCompetingPresentation: hasCompetingReviewPresentation,
+                isUpdatePromptStateRefreshing: appUpdateCoordinator.isRefreshingPromptState,
+                hasCompletedOnboardingBeforeCurrentLaunch: hasCompletedOnboardingBeforeCurrentLaunch,
+                currentVersion: appUpdateCoordinator.currentAppVersion?.rawValue
+            ),
+            requestReview: {
+                requestReview()
+            }
+        )
+    }
+
 }
 
 #Preview {
@@ -226,6 +290,7 @@ struct AppRootView: View {
         .environmentObject(AppServiceRegistry.shared.keyVoxVibesPurchaseController)
         .environmentObject(AppServiceRegistry.shared.keyVoxVibesIntroController)
         .environmentObject(AppServiceRegistry.shared.appUpdateCoordinator)
+        .environmentObject(AppServiceRegistry.shared.appReviewRequestCoordinator)
         .environmentObject(AppServiceRegistry.shared.modelManager)
         .environmentObject(AppServiceRegistry.shared.localRewriteModelManager)
         .environmentObject(AppServiceRegistry.shared.settingsStore)

--- a/iOS/KeyVox iOS/Views/DictionaryTabView/DictionaryEntryRowView.swift
+++ b/iOS/KeyVox iOS/Views/DictionaryTabView/DictionaryEntryRowView.swift
@@ -70,5 +70,6 @@ struct DictionaryEntryRowView: View {
         } message: {
             Text("This dictionary entry will be removed from KeyVox.")
         }
+        .blocksAppReviewRequest(isDeleteConfirmationPresented)
     }
 }

--- a/iOS/KeyVox iOS/Views/DictionaryTabView/DictionaryTabView.swift
+++ b/iOS/KeyVox iOS/Views/DictionaryTabView/DictionaryTabView.swift
@@ -102,6 +102,7 @@ struct DictionaryTabView: View {
                 }
             )
         }
+        .blocksAppReviewRequest(dictionaryEditorMode != nil)
         .onChange(of: dictionaryEditorMode?.id) { _, newValue in
             if let newValue {
                 lastPresentedEditorID = newValue

--- a/iOS/KeyVox iOS/Views/MainTabView.swift
+++ b/iOS/KeyVox iOS/Views/MainTabView.swift
@@ -56,6 +56,7 @@ struct MainTabView: View {
             onDownload: performModelUpdatePromptDownload,
             onLater: dismissModelUpdatePromptPermanently
         )
+        .blocksAppReviewRequest(hasReviewBlockingPresentation)
         .sheet(
             isPresented: Binding(
                 get: { canPresentFeatureSheets && ttsPurchaseController.isUnlockSheetPresented },
@@ -270,6 +271,12 @@ struct MainTabView: View {
     private var canPresentExplicitVibesSheet: Bool {
         onboardingStore.shouldShowOnboarding == false
             && ttsManager.isPlaybackPreparationViewPresented == false
+    }
+
+    private var hasReviewBlockingPresentation: Bool {
+        pendingDeletionConfirmation != nil
+            || pendingDownloadConfirmation != nil
+            || pendingModelUpdatePrompt != nil
     }
 
 }

--- a/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView+About.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView+About.swift
@@ -1,4 +1,3 @@
-import StoreKit
 import SwiftUI
 
 extension SettingsTabView {
@@ -182,15 +181,15 @@ extension SettingsTabView {
 
     func openAppStoreReview() {
         appHaptics.light()
-        if #available(iOS 18.0, *) {
-            if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-                AppStore.requestReview(in: scene)
-            }
-        } else {
-            if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-                SKStoreReviewController.requestReview(in: scene)
-            }
-        }
+
+        var components = URLComponents(
+            url: AppUpdateConfiguration.fallbackAppStoreURL,
+            resolvingAgainstBaseURL: false
+        )
+        components?.queryItems = [URLQueryItem(name: "action", value: "write-review")]
+
+        guard let writeReviewURL = components?.url else { return }
+        openURL(writeReviewURL)
     }
 
     func openGitHubSponsors() {

--- a/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsTabView: View {
     @Environment(\.appHaptics) var appHaptics
+    @Environment(\.openURL) var openURL
     @EnvironmentObject var modelManager: ModelManager
     @EnvironmentObject var pocketTTSModelManager: PocketTTSModelManager
     @EnvironmentObject var localRewriteModelManager: LocalRewriteModelManager

--- a/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView.swift
@@ -45,6 +45,7 @@ struct SettingsTabView: View {
             .sheet(isPresented: $isThirdPartyNoticesPresented) {
                 ThirdPartyNoticesView()
             }
+            .blocksAppReviewRequest(isThirdPartyNoticesPresented)
             .onDisappear {
                 ttsPreviewPlayer.stop()
             }


### PR DESCRIPTION
## Summary

Adds the iOS App Store review flow for KeyVox 1.2.17.

## What changed

- Requests a StoreKit review after seven days when onboarding is complete and the user has completed a recent successful dictation.
- Defers the automatic request while updates, prompts, sheets, Speak, Vibes, dictation, or other competing experiences are active.
- Records the first containing-app launch for existing users so they receive the same seven-day eligibility window.
- Limits automatic requests to once per app version and lets StoreKit decide whether to display the prompt.
- Opens the manual Rate & Review action directly on the App Store write-review page.

## Impact

Users receive a review request only after meaningful use and only when the main app interface is clear, while the Settings action provides a direct path to leave a review.

## Validation

Reviewed the StoreKit request path, persisted eligibility state, and presentation-blocking conditions across the iOS app integration.