### PR TITLE
Refine stylized dictionary context matching

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -22,6 +22,8 @@ Shared Whisper Base language selection and voice-activity gating for dictation c
 - Added diagnostic output for voice-activity probabilities, detected speech ranges, audio-to-ambient measurements, and primary-versus-retry decode selection.
 - Prevented normalized compact times from being processed twice when the minute component is also a valid hour, avoiding output such as `8:10:00 PM` for `810 PM`.
 - Allowed whitespace-delimited single-letter split pronunciations to match single dictionary terms when the remaining tail matches exactly and spelling and phonetic evidence are strong, while retaining the existing short-token and common-word safeguards.
+- Prevented unanchored plural split/join matches from collapsing unrelated phrases such as `main goes` into stylized dictionary entries.
+- Improved stylized dictionary matching across titlecase, list, noun, and particle contexts while preserving common-word protection and ranking only eligible stylized short-token candidates.
 - Preserved sentence periods after normalized spoken email addresses when the following sentence is initially overcaptured as part of the domain.
 - Expanded year-context detection across numeric and spoken-number paths to preserve four-digit years with leading or trailing uncertainty and stacked qualifiers, including `in 2012 maybe`, `in maybe 2015`, and `since at least 2012`, while continuing to add thousands separators to similarly phrased quantities such as `I need at least 2000`.
 - Corrected incidental title casing at Whisper continuation-segment boundaries while preserving proper names and dictionary-defined casing.

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
@@ -75,11 +75,27 @@ extension DictionaryMatcher {
         let leftIsVerb = leftToken.lexicalClass == .verb
         let rightIsVerbLike = rightToken.lexicalClass == .verb || rightToken.lexicalClass == .adjective
 
-        return left.count <= StandardEvaluationConstants.structuralLeftContextMaximumLength
-            && leftIsVerb
-            && rightIsLowerAlphabetic
-            && right.count >= StandardEvaluationConstants.structuralRightContextMinimumLength
-            && rightIsVerbLike
+        return hasNounIntroducedTitlecaseContext(
+            tokenStart: tokenStart,
+            tokenEndExclusive: tokenEndExclusive,
+            tokens: tokens
+        )
+            || (left.count <= StandardEvaluationConstants.structuralLeftContextMaximumLength
+                && leftIsVerb
+                && rightIsLowerAlphabetic
+                && right.count >= StandardEvaluationConstants.structuralRightContextMinimumLength
+                && rightIsVerbLike)
+    }
+
+    private func hasNounIntroducedTitlecaseContext(
+        tokenStart: Int,
+        tokenEndExclusive: Int,
+        tokens: [Token]
+    ) -> Bool {
+        guard tokenStart > 0, tokenEndExclusive < tokens.count else { return false }
+        return tokens[tokenStart - 1].lexicalClass == .noun
+            && isTitlecaseToken(tokens[tokenStart])
+            && tokens[tokenEndExclusive].lexicalClass == .adverb
     }
 
     func proposeStandardReplacement(
@@ -260,6 +276,11 @@ extension DictionaryMatcher {
                 tokenEndExclusive: end,
                 tokens: tokens
             )
+            let hasNounIntroducedTitlecaseContext = hasNounIntroducedTitlecaseContext(
+                tokenStart: start,
+                tokenEndExclusive: end,
+                tokens: tokens
+            )
             let hasAttributionPrepositionContext = hasAttributionLikePrepositionContext(
                 tokenStart: start,
                 tokens: tokens
@@ -271,6 +292,12 @@ extension DictionaryMatcher {
                     totalTokens: tokens.count
                 )
             let hasAdjacentTitlecaseContext = hasAdjacentTitlecasePhraseContext(
+                tokenIndex: start,
+                totalTokens: tokens.count,
+                tokens: tokens,
+                text: text
+            )
+            let hasAdjacentTitlecaseListContext = hasAdjacentTitlecaseListContext(
                 tokenIndex: start,
                 totalTokens: tokens.count,
                 tokens: tokens,
@@ -293,13 +320,17 @@ extension DictionaryMatcher {
                    candidate: candidateToken,
                    textSimilarity: textSimilarity
                ) {
-                stats.rejectedLowScore += 1
-                return nil
+                if !hasAdjacentTitlecaseListContext {
+                    stats.rejectedLowScore += 1
+                    return nil
+                }
             }
 
             if observedHasRuntimePronunciation,
                isTitlecaseToken(observedToken),
                observedToken.normalized.count >= candidateToken.count,
+               !hasNounIntroducedTitlecaseContext,
+               !hasAdjacentTitlecaseListContext,
                textSimilarity < StandardEvaluationConstants.titlecaseKnownWordSurfaceMinimum {
                 requiresPeerSupport = true
                 requiresPeerSupportForTitlecaseKnownWord = true

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationStylizedHelpers.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationStylizedHelpers.swift
@@ -48,6 +48,26 @@ extension DictionaryMatcher {
         return previousIsTitlecase || nextIsTitlecase
     }
 
+    func hasAdjacentTitlecaseListContext(
+        tokenIndex: Int,
+        totalTokens: Int,
+        tokens: [Token],
+        text: String
+    ) -> Bool {
+        guard isTitlecaseToken(tokens[tokenIndex]) else { return false }
+
+        let previousIsListItem =
+            tokenIndex > 0
+            && isTitlecaseToken(tokens[tokenIndex - 1])
+            && hasListSeparatorBetween(tokens[tokenIndex - 1], tokens[tokenIndex], in: text)
+        let nextIsListItem =
+            tokenIndex + 1 < totalTokens
+            && isTitlecaseToken(tokens[tokenIndex + 1])
+            && hasListSeparatorBetween(tokens[tokenIndex], tokens[tokenIndex + 1], in: text)
+
+        return previousIsListItem || nextIsListItem
+    }
+
     private func hasSentenceBoundaryBetween(_ left: Token, _ right: Token, in text: String) -> Bool {
         let leftEnd = left.range.location + left.range.length
         let rightStart = right.range.location
@@ -56,6 +76,16 @@ extension DictionaryMatcher {
         let bridge = text as NSString
         let gap = bridge.substring(with: NSRange(location: leftEnd, length: rightStart - leftEnd))
         return gap.contains(".") || gap.contains("?") || gap.contains("!") || gap.contains("\n")
+    }
+
+    private func hasListSeparatorBetween(_ left: Token, _ right: Token, in text: String) -> Bool {
+        let leftEnd = left.range.location + left.range.length
+        let rightStart = right.range.location
+        guard rightStart > leftEnd else { return false }
+
+        let bridge = text as NSString
+        let gap = bridge.substring(with: NSRange(location: leftEnd, length: rightStart - leftEnd))
+        return gap.contains(",") || gap.contains(";")
     }
 
     func isStylizedSingleTokenEntry(_ entry: CompiledEntry) -> Bool {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinGuards.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinGuards.swift
@@ -77,4 +77,11 @@ extension DictionaryMatcher {
         return !between.isEmpty
             && between.unicodeScalars.allSatisfy { CharacterSet.whitespacesAndNewlines.contains($0) }
     }
+
+    func hasShortTokenSplitContext(start: Int, end: Int, tokens: [Token]) -> Bool {
+        guard start > 0, end < tokens.count else { return false }
+        let precedingClass = tokens[start - 1].lexicalClass
+        return (precedingClass == .noun || precedingClass == .particle)
+            && tokens[end].lexicalClass == .adverb
+    }
 }

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinScoring.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinScoring.swift
@@ -65,14 +65,18 @@ extension DictionaryMatcher {
         let containsShortToken =
             window[0].normalized.count < minimumSplitTokenLength
             || window[1].normalized.count < minimumSplitTokenLength
+        var requiresContextualShortTokenEvidence = false
         if containsShortToken {
             let exactJoinedCandidates = Set(oneTokenCandidates.map(\.normalizedPhrase))
             let hasExactJoinCandidate = forms.contains { form in
                 exactJoinedCandidates.contains(form.normalized)
             }
-            guard hasExactJoinCandidate || isDelimitedSingleLetterTailLane else {
-                stats.rejectedShortToken += 1
-                return nil
+            if !hasExactJoinCandidate, !isDelimitedSingleLetterTailLane {
+                guard hasShortTokenSplitContext(start: start, end: end, tokens: tokens) else {
+                    stats.rejectedShortToken += 1
+                    return nil
+                }
+                requiresContextualShortTokenEvidence = true
             }
         }
 
@@ -80,6 +84,11 @@ extension DictionaryMatcher {
         var secondBestScore = 0.0
 
         for candidate in oneTokenCandidates {
+            if requiresContextualShortTokenEvidence,
+               !isStylizedSingleTokenEntry(candidate) {
+                continue
+            }
+
             let candidateToken = candidate.tokens[0]
             let candidateIsCommonWord = lexicon.isCommonWord(candidateToken)
 
@@ -169,6 +178,12 @@ extension DictionaryMatcher {
             return nil
         }
 
+        let hasCommonObservedShortToken =
+            requiresContextualShortTokenEvidence
+            && window.contains(where: {
+                lexicon.isCommonWord(baseTokenForCommonWordGuard($0.normalized))
+            })
+
         let threshold = max(scorer.threshold(for: 2), splitJoinMinimumScore)
         var effectiveThreshold = threshold
         if isDelimitedSingleLetterTailLane {
@@ -241,7 +256,7 @@ extension DictionaryMatcher {
             return nil
         }
 
-        if lexicon.isCommonWord(best.entry.tokens[0]),
+        if (hasCommonObservedShortToken || lexicon.isCommonWord(best.entry.tokens[0])),
            best.score.final < scorer.commonWordOverrideThreshold {
             stats.rejectedCommonWord += 1
             return nil

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -426,6 +426,90 @@ final class DictionaryMatcherTests: XCTestCase {
         XCTAssertEqual(result.text, "Everything on main goes through another.")
     }
 
+    func testCorrectsStylizedEntryInNounIntroducedTitlecaseContext() {
+        let matcher = DictionaryMatcher(
+            lexicon: PronunciationLexicon.shared,
+            encoder: PhoneticEncoder(),
+            scorer: .balanced
+        )
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "MiGo")])
+
+        let result = matcher.apply(to: "Have you checked out my app Mego lately? It's pretty cool.")
+
+        XCTAssertEqual(result.text, "Have you checked out my app MiGo lately? It's pretty cool.")
+    }
+
+    func testCorrectsStylizedEntrySplitIntoShortTokensInNounIntroducedContext() {
+        let matcher = DictionaryMatcher(
+            lexicon: PronunciationLexicon.shared,
+            encoder: PhoneticEncoder(),
+            scorer: .balanced
+        )
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "MiGo")])
+
+        let result = matcher.apply(to: "Have you checked out my app me go lately? It's pretty cool.")
+
+        XCTAssertEqual(result.text, "Have you checked out my app MiGo lately? It's pretty cool.")
+    }
+
+    func testCorrectsStylizedEntrySplitIntoShortTokensAfterParticle() {
+        let matcher = DictionaryMatcher(
+            lexicon: PronunciationLexicon.shared,
+            encoder: PhoneticEncoder(),
+            scorer: .balanced
+        )
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "MiGo")])
+
+        let result = matcher.apply(to: "Have you checked out me go lately?")
+
+        XCTAssertEqual(result.text, "Have you checked out MiGo lately?")
+    }
+
+    func testContextualShortTokenSplitRejectsCommonObservedWords() {
+        let lexicon = FakeLexicon(
+            pronunciations: [
+                "me": "M",
+                "go": "K",
+                "mego": "MK",
+                "migo": "MK",
+            ],
+            commonWords: ["me", "go"]
+        )
+        let matcher = DictionaryMatcher(
+            lexicon: lexicon,
+            encoder: PhoneticEncoder(),
+            scorer: .balanced
+        )
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "MiGo")])
+
+        let input = "Have you checked out my app me go lately?"
+        let result = matcher.apply(to: input)
+
+        XCTAssertEqual(result.text, input)
+    }
+
+    func testCorrectsStylizedTitlecaseListItemWithIndependentPeerSupport() {
+        let matcher = DictionaryMatcher(
+            lexicon: PronunciationLexicon.shared,
+            encoder: PhoneticEncoder(),
+            scorer: .balanced
+        )
+        matcher.rebuildIndex(entries: [
+            DictionaryEntry(phrase: "KeyVox"),
+            DictionaryEntry(phrase: "MiGo"),
+            DictionaryEntry(phrase: "Cueboard"),
+        ])
+
+        let result = matcher.apply(
+            to: "I have three apps available right now. Keybox, Mego, and Cueboard."
+        )
+
+        XCTAssertEqual(
+            result.text,
+            "I have three apps available right now. KeyVox, MiGo, and Cueboard."
+        )
+    }
+
     func testTitlecaseKnownWordsResistRandomStylizedDictionaryEntries() {
         let matcher = DictionaryMatcher(
             lexicon: PronunciationLexicon.shared,


### PR DESCRIPTION
## Summary

- improves guarded stylized dictionary matching across titlecase, list, noun, and particle contexts
- preserves common-word protection and eligible-candidate ranking for contextual short-token matches
- documents the matcher refinements in the current package changelog

## Package version

- KeyVoxCore 1.2.0

## Validation

- KeyVoxCore package suite: 484 tests passed