### PR TITLE
fix(core): improve numeric dictionary matching

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -6,9 +6,9 @@ The format loosely follows Keep a Changelog and the package uses semantic versio
 
 ---
 
-## [1.2.2] - 2026-08-03
+## [1.2.2] - 2026-08-04
 
-Thousands-grouping, stylized-capitalization, and emoji-boundary normalization fixes with regression coverage.
+Thousands-grouping, numeric dictionary matching, stylized-capitalization, and emoji-boundary normalization fixes with regression coverage.
 
 ### Includes
 
@@ -18,14 +18,18 @@ Thousands-grouping, stylized-capitalization, and emoji-boundary normalization fi
 - Preserved prepositional and clause-based year forms, including simple references such as `in 2015`, even when the lexical tagger labels a neighboring alphabetic token as an unclassified word.
 - Preserved explicit temporal years beyond the common year range, including `year 3000`, while continuing to group unqualified quantities such as `3000`.
 - Protected nominal identifiers such as PIN numbers from grouping while retaining grouping for noun-based count and total-number quantities.
+- Added number-aware dictionary variants so digit, cardinal, ordinal, and phonetic number forms can resolve to the same custom entry across hyphenated and joined phrase shapes.
+- Updated dictionary phonetic encoding to use canonical cardinal pronunciations for numeric and ordinal tokens.
+- Required number-shaped dictionary candidates to preserve numeric alignment and strong evidence for nonnumeric companion words, preventing unrelated plural or possessive tails from triggering replacements.
 - Preserved model-emitted stylized mixed-case tokens such as `eBay` at sentence and list boundaries while continuing to capitalize ordinary list items.
 - Added emoji-aware sentence and line-boundary capitalization while leaving emoji-following continuation text lowercase when it follows ordinary prose.
 - Added regression coverage for mixed-format inputs with preformatted and unformatted quantities, affected year forms, and nominal identifiers.
+- Added regression coverage for numeric dictionary substitutions, joined and hyphenated entries, cardinal and ordinal forms, and unrelated-tail false positives.
 - Added regression coverage for stylized casing, ordinary list-item capitalization, and emoji sentence boundaries.
 
 ### Notes
 
-- `1.2.2` tracks the thousands-grouping, quantity-protection, stylized-capitalization, and emoji-boundary behavior used by shared dictation clients.
+- `1.2.2` tracks the thousands-grouping, quantity-protection, numeric dictionary matching, stylized-capitalization, and emoji-boundary behavior used by shared dictation clients.
 
 ---
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryMatcher+Models.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryMatcher+Models.swift
@@ -29,6 +29,7 @@ extension DictionaryMatcher {
         let normalizedPhrase: String
         let matchingNormalizedPhrases: [String]
         let tokens: [String]
+        let numericSourceTokens: [String?]
         let phoneticPhrase: String
     }
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryMatcher+Models.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryMatcher+Models.swift
@@ -27,6 +27,7 @@ extension DictionaryMatcher {
     struct CompiledEntry {
         let phrase: String
         let normalizedPhrase: String
+        let matchingNormalizedPhrases: [String]
         let tokens: [String]
         let phoneticPhrase: String
     }

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryMatcher.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryMatcher.swift
@@ -97,6 +97,7 @@ public final class DictionaryMatcher {
             let compiled = CompiledEntry(
                 phrase: entry.phrase,
                 normalizedPhrase: normalizedPhrase,
+                matchingNormalizedPhrases: DictionaryNumericMatching.phraseVariants(for: tokens),
                 tokens: tokens,
                 phoneticPhrase: phoneticPhrase
             )
@@ -114,6 +115,7 @@ public final class DictionaryMatcher {
                 let compiledAlias = CompiledEntry(
                     phrase: entry.phrase,
                     normalizedPhrase: normalizedAlias,
+                    matchingNormalizedPhrases: DictionaryNumericMatching.phraseVariants(for: aliasTokens),
                     tokens: aliasTokens,
                     phoneticPhrase: aliasPhoneticPhrase
                 )

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryMatcher.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryMatcher.swift
@@ -93,16 +93,13 @@ public final class DictionaryMatcher {
             let tokens = normalizedPhrase.split(separator: " ").map(String.init)
             guard !tokens.isEmpty, tokens.count <= 4 else { continue }
 
-            let phoneticPhrase = encoder.scoringPhraseSignature(for: tokens, lexicon: lexicon)
-            let compiled = CompiledEntry(
+            for compiled in compiledEntries(
                 phrase: entry.phrase,
                 normalizedPhrase: normalizedPhrase,
-                matchingNormalizedPhrases: DictionaryNumericMatching.phraseVariants(for: tokens),
-                tokens: tokens,
-                phoneticPhrase: phoneticPhrase
-            )
-
-            grouped[tokens.count, default: []].append(compiled)
+                tokens: tokens
+            ) {
+                grouped[compiled.tokens.count, default: []].append(compiled)
+            }
 
             for alias in DictionaryBuiltInEntries.aliases(for: entry) {
                 let normalizedAlias = DictionaryTextNormalization.normalizedPhrase(alias)
@@ -111,21 +108,46 @@ public final class DictionaryMatcher {
                 let aliasTokens = normalizedAlias.split(separator: " ").map(String.init)
                 guard !aliasTokens.isEmpty, aliasTokens.count <= 4 else { continue }
 
-                let aliasPhoneticPhrase = encoder.scoringPhraseSignature(for: aliasTokens, lexicon: lexicon)
-                let compiledAlias = CompiledEntry(
+                for compiledAlias in compiledEntries(
                     phrase: entry.phrase,
                     normalizedPhrase: normalizedAlias,
-                    matchingNormalizedPhrases: DictionaryNumericMatching.phraseVariants(for: aliasTokens),
-                    tokens: aliasTokens,
-                    phoneticPhrase: aliasPhoneticPhrase
-                )
-
-                grouped[aliasTokens.count, default: []].append(compiledAlias)
+                    tokens: aliasTokens
+                ) {
+                    grouped[compiledAlias.tokens.count, default: []].append(compiledAlias)
+                }
             }
         }
 
         entriesByTokenCount = grouped
         emailEntriesByDomain = emailGrouped
+    }
+
+    private func compiledEntries(
+        phrase: String,
+        normalizedPhrase: String,
+        tokens: [String]
+    ) -> [CompiledEntry] {
+        var variantsByTokenCount: [Int: [DictionaryNumericMatching.PhraseVariant]] = [:]
+        for variant in DictionaryNumericMatching.phraseVariants(for: tokens)
+        where !variant.tokens.isEmpty && variant.tokens.count <= 4 {
+            variantsByTokenCount[variant.tokens.count, default: []].append(variant)
+        }
+
+        return variantsByTokenCount.keys.sorted().compactMap { tokenCount in
+            guard let variants = variantsByTokenCount[tokenCount], !variants.isEmpty else {
+                return nil
+            }
+
+            let activeVariant = variants.first(where: { $0.normalized == normalizedPhrase }) ?? variants[0]
+            return CompiledEntry(
+                phrase: phrase,
+                normalizedPhrase: activeVariant.normalized,
+                matchingNormalizedPhrases: variants.map(\.normalized),
+                tokens: activeVariant.tokens,
+                numericSourceTokens: activeVariant.numericSourceTokens,
+                phoneticPhrase: encoder.scoringPhraseSignature(for: activeVariant.tokens, lexicon: lexicon)
+            )
+        }
     }
 
     public func apply(to text: String) -> DictionaryMatchResult {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryNumericMatching.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryNumericMatching.swift
@@ -12,6 +12,19 @@ enum DictionaryNumericMatching {
         options: []
     )
 
+    private static let cardinalNumericLookup: [String: String] = {
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.numberStyle = .spellOut
+
+        var lookup: [String: String] = [:]
+        for value in 0...999 {
+            guard let spelledOut = formatter.string(from: NSNumber(value: value)) else { continue }
+            lookup[DictionaryTextNormalization.normalizedPhrase(spelledOut)] = String(value)
+        }
+        return lookup
+    }()
+
     static func isNumericToken(_ normalizedToken: String) -> Bool {
         let range = NSRange(location: 0, length: (normalizedToken as NSString).length)
         return numericTokenRegex.firstMatch(in: normalizedToken, options: [], range: range) != nil
@@ -48,7 +61,90 @@ enum DictionaryNumericMatching {
             }
         }
 
-        return unique(variants)
+        return unique(variants.flatMap(variantsWithCardinalAliases))
+    }
+
+    private static func variantsWithCardinalAliases(_ variant: PhraseVariant) -> [PhraseVariant] {
+        let spans = cardinalSpans(for: variant)
+        guard !spans.isEmpty else { return [variant] }
+
+        func build(
+            spanIndex: Int,
+            tokenIndex: Int,
+            tokens: [String],
+            numericSourceTokens: [String?]
+        ) -> [PhraseVariant] {
+            guard tokenIndex < variant.tokens.count else {
+                return [PhraseVariant(
+                    normalized: tokens.joined(separator: " "),
+                    tokens: tokens,
+                    numericSourceTokens: numericSourceTokens
+                )]
+            }
+
+            guard spanIndex < spans.count, spans[spanIndex].start == tokenIndex else {
+                return build(
+                    spanIndex: spanIndex,
+                    tokenIndex: tokenIndex + 1,
+                    tokens: tokens + [variant.tokens[tokenIndex]],
+                    numericSourceTokens: numericSourceTokens + [variant.numericSourceTokens[tokenIndex]]
+                )
+            }
+
+            let span = spans[spanIndex]
+            let originalTokens = Array(variant.tokens[span.start..<span.end])
+            let originalSources = Array(variant.numericSourceTokens[span.start..<span.end])
+            let kept = build(
+                spanIndex: spanIndex + 1,
+                tokenIndex: span.end,
+                tokens: tokens + originalTokens,
+                numericSourceTokens: numericSourceTokens + originalSources
+            )
+            let collapsed = build(
+                spanIndex: spanIndex + 1,
+                tokenIndex: span.end,
+                tokens: tokens + [span.source],
+                numericSourceTokens: numericSourceTokens + [span.source]
+            )
+            return kept + collapsed
+        }
+
+        return build(spanIndex: 0, tokenIndex: 0, tokens: [], numericSourceTokens: [])
+    }
+
+    private static func cardinalSpans(
+        for variant: PhraseVariant
+    ) -> [(start: Int, end: Int, source: String)] {
+        var spans: [(start: Int, end: Int, source: String)] = []
+        var index = 0
+
+        while index < variant.tokens.count {
+            guard variant.numericSourceTokens[index] == nil else {
+                index += 1
+                continue
+            }
+
+            var phrase = ""
+            var best: (start: Int, end: Int, source: String)?
+            for end in index..<variant.tokens.count {
+                phrase = phrase.isEmpty
+                    ? variant.tokens[end]
+                    : "\(phrase) \(variant.tokens[end])"
+                if let source = cardinalNumericLookup[phrase] {
+                    best = (start: index, end: end + 1, source: source)
+                }
+            }
+
+            guard let best else {
+                index += 1
+                continue
+            }
+
+            spans.append(best)
+            index = best.end
+        }
+
+        return spans
     }
 
     private static func cardinalSpelling(for normalizedToken: String) -> String? {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryNumericMatching.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryNumericMatching.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 enum DictionaryNumericMatching {
+    struct PhraseVariant {
+        let normalized: String
+        let tokens: [String]
+        let numericSourceTokens: [String?]
+    }
+
     private static let numericTokenRegex = try! NSRegularExpression(
         pattern: #"^(\d+)(?:st|nd|rd|th)?$"#,
         options: []
@@ -21,17 +27,23 @@ enum DictionaryNumericMatching {
             : [normalizedToken, spelledOut]
     }
 
-    static func phraseVariants(for normalizedTokens: [String]) -> [String] {
+    static func phraseVariants(for normalizedTokens: [String]) -> [PhraseVariant] {
         guard !normalizedTokens.isEmpty else { return [] }
 
-        var variants = [""]
+        var variants = [PhraseVariant(normalized: "", tokens: [], numericSourceTokens: [])]
         for token in normalizedTokens {
             let tokenVariants = tokenVariants(for: token)
+            let numericSourceToken = numericSourceToken(for: token)
             variants = variants.flatMap { prefix in
                 tokenVariants.map { tokenVariant in
-                    [prefix, tokenVariant]
-                        .filter { !$0.isEmpty }
-                        .joined(separator: " ")
+                    let variantTokens = tokenVariant.split(separator: " ").map(String.init)
+                    let variantSourceTokens = variantTokens.map { _ in numericSourceToken }
+                    let combinedTokens = prefix.tokens + variantTokens
+                    return PhraseVariant(
+                        normalized: combinedTokens.joined(separator: " "),
+                        tokens: combinedTokens,
+                        numericSourceTokens: prefix.numericSourceTokens + variantSourceTokens
+                    )
                 }
             }
         }
@@ -40,14 +52,10 @@ enum DictionaryNumericMatching {
     }
 
     private static func cardinalSpelling(for normalizedToken: String) -> String? {
-        let nsToken = normalizedToken as NSString
-        let range = NSRange(location: 0, length: nsToken.length)
-        guard let match = numericTokenRegex.firstMatch(in: normalizedToken, options: [], range: range) else {
+        guard let digits = numericToken(for: normalizedToken),
+              let value = Int(digits) else {
             return nil
         }
-
-        let digits = nsToken.substring(with: match.range(at: 1))
-        guard let value = Int(digits) else { return nil }
 
         let formatter = NumberFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
@@ -59,8 +67,22 @@ enum DictionaryNumericMatching {
         return DictionaryTextNormalization.normalizedPhrase(spelledOut)
     }
 
-    private static func unique(_ values: [String]) -> [String] {
+    private static func numericSourceToken(for normalizedToken: String) -> String? {
+        numericToken(for: normalizedToken)
+    }
+
+    private static func numericToken(for normalizedToken: String) -> String? {
+        let nsToken = normalizedToken as NSString
+        let range = NSRange(location: 0, length: nsToken.length)
+        guard let match = numericTokenRegex.firstMatch(in: normalizedToken, options: [], range: range) else {
+            return nil
+        }
+
+        return nsToken.substring(with: match.range(at: 1))
+    }
+
+    private static func unique(_ values: [PhraseVariant]) -> [PhraseVariant] {
         var seen = Set<String>()
-        return values.filter { seen.insert($0).inserted }
+        return values.filter { seen.insert($0.normalized).inserted }
     }
 }

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryNumericMatching.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/DictionaryNumericMatching.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+enum DictionaryNumericMatching {
+    private static let numericTokenRegex = try! NSRegularExpression(
+        pattern: #"^(\d+)(?:st|nd|rd|th)?$"#,
+        options: []
+    )
+
+    static func isNumericToken(_ normalizedToken: String) -> Bool {
+        let range = NSRange(location: 0, length: (normalizedToken as NSString).length)
+        return numericTokenRegex.firstMatch(in: normalizedToken, options: [], range: range) != nil
+    }
+
+    static func tokenVariants(for normalizedToken: String) -> [String] {
+        guard let spelledOut = cardinalSpelling(for: normalizedToken) else {
+            return [normalizedToken]
+        }
+
+        return normalizedToken == spelledOut
+            ? [normalizedToken]
+            : [normalizedToken, spelledOut]
+    }
+
+    static func phraseVariants(for normalizedTokens: [String]) -> [String] {
+        guard !normalizedTokens.isEmpty else { return [] }
+
+        var variants = [""]
+        for token in normalizedTokens {
+            let tokenVariants = tokenVariants(for: token)
+            variants = variants.flatMap { prefix in
+                tokenVariants.map { tokenVariant in
+                    [prefix, tokenVariant]
+                        .filter { !$0.isEmpty }
+                        .joined(separator: " ")
+                }
+            }
+        }
+
+        return unique(variants)
+    }
+
+    private static func cardinalSpelling(for normalizedToken: String) -> String? {
+        let nsToken = normalizedToken as NSString
+        let range = NSRange(location: 0, length: nsToken.length)
+        guard let match = numericTokenRegex.firstMatch(in: normalizedToken, options: [], range: range) else {
+            return nil
+        }
+
+        let digits = nsToken.substring(with: match.range(at: 1))
+        guard let value = Int(digits) else { return nil }
+
+        let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.numberStyle = .spellOut
+        guard let spelledOut = formatter.string(from: NSNumber(value: value)) else {
+            return nil
+        }
+
+        return DictionaryTextNormalization.normalizedPhrase(spelledOut)
+    }
+
+    private static func unique(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.filter { seen.insert($0).inserted }
+    }
+}

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+NumericEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+NumericEvaluation.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+private enum NumericEvaluationConstants {
+    static let minimumNonNumericTokenSimilarity = 0.72
+}
+
+extension DictionaryMatcher {
+    func hasSufficientNumericAlignment(
+        observedNormalized: String,
+        candidate: CompiledEntry
+    ) -> Bool {
+        guard candidate.tokens.contains(where: DictionaryNumericMatching.isNumericToken) else {
+            return true
+        }
+
+        let observedTokens = observedNormalized.split(separator: " ").map(String.init)
+        guard observedTokens.count == candidate.tokens.count else {
+            return true
+        }
+
+        for index in candidate.tokens.indices {
+            let observedToken = observedTokens[index]
+            let candidateToken = candidate.tokens[index]
+            let observedIsNumeric = DictionaryNumericMatching.isNumericToken(observedToken)
+            let candidateIsNumeric = DictionaryNumericMatching.isNumericToken(candidateToken)
+
+            if observedIsNumeric || candidateIsNumeric {
+                guard numericTokenVariantsOverlap(observedToken, candidateToken) else {
+                    return false
+                }
+                continue
+            }
+
+            let textSimilarity = scorer.similarity(lhs: observedToken, rhs: candidateToken)
+            let observedPhonetic = encoder.scoringSignature(for: observedToken, lexicon: lexicon)
+            let candidatePhonetic = encoder.scoringSignature(for: candidateToken, lexicon: lexicon)
+            let phoneticSimilarity = scorer.similarity(lhs: observedPhonetic, rhs: candidatePhonetic)
+
+            guard max(textSimilarity, phoneticSimilarity)
+                >= NumericEvaluationConstants.minimumNonNumericTokenSimilarity else {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private func numericTokenVariantsOverlap(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsVariants = Set(DictionaryNumericMatching.tokenVariants(for: lhs))
+        let rhsVariants = Set(DictionaryNumericMatching.tokenVariants(for: rhs))
+        return !lhsVariants.isDisjoint(with: rhsVariants)
+    }
+}

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+NumericEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+NumericEvaluation.swift
@@ -7,27 +7,54 @@ private enum NumericEvaluationConstants {
 extension DictionaryMatcher {
     func hasSufficientNumericAlignment(
         observedNormalized: String,
+        observedNumericSourceTokens: [String?],
         candidate: CompiledEntry
     ) -> Bool {
-        guard candidate.tokens.contains(where: DictionaryNumericMatching.isNumericToken) else {
+        guard candidate.numericSourceTokens.contains(where: { $0 != nil }) else {
             return true
         }
 
         let observedTokens = observedNormalized.split(separator: " ").map(String.init)
-        guard observedTokens.count == candidate.tokens.count else {
-            return true
+        guard observedTokens.count == candidate.tokens.count,
+              observedNumericSourceTokens.count == candidate.tokens.count,
+              candidate.numericSourceTokens.count == candidate.tokens.count else {
+            return false
         }
 
-        for index in candidate.tokens.indices {
+        var index = 0
+        while index < candidate.tokens.count {
             let observedToken = observedTokens[index]
             let candidateToken = candidate.tokens[index]
-            let observedIsNumeric = DictionaryNumericMatching.isNumericToken(observedToken)
-            let candidateIsNumeric = DictionaryNumericMatching.isNumericToken(candidateToken)
 
-            if observedIsNumeric || candidateIsNumeric {
+            if let candidateNumericSource = candidate.numericSourceTokens[index] {
+                var numericGroupEnd = index + 1
+                while numericGroupEnd < candidate.numericSourceTokens.count,
+                      candidate.numericSourceTokens[numericGroupEnd] == candidateNumericSource {
+                    numericGroupEnd += 1
+                }
+
+                let observedGroupSources = observedNumericSourceTokens[index..<numericGroupEnd]
+                if observedGroupSources.contains(where: { $0 != nil }) {
+                    guard observedGroupSources.allSatisfy({ $0 == candidateNumericSource }) else {
+                        return false
+                    }
+                } else {
+                    let observedGroup = observedTokens[index..<numericGroupEnd].joined(separator: " ")
+                    guard DictionaryNumericMatching.tokenVariants(for: candidateNumericSource)
+                        .contains(observedGroup) else {
+                        return false
+                    }
+                }
+
+                index = numericGroupEnd
+                continue
+            }
+
+            if observedNumericSourceTokens[index] != nil {
                 guard numericTokenVariantsOverlap(observedToken, candidateToken) else {
                     return false
                 }
+                index += 1
                 continue
             }
 
@@ -40,6 +67,8 @@ extension DictionaryMatcher {
                 >= NumericEvaluationConstants.minimumNonNumericTokenSimilarity else {
                 return false
             }
+
+            index += 1
         }
 
         return true

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+NumericEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+NumericEvaluation.swift
@@ -58,6 +58,13 @@ extension DictionaryMatcher {
                 continue
             }
 
+            guard !hasSingularPluralMismatch(
+                observedToken: observedToken,
+                candidateToken: candidateToken
+            ) else {
+                return false
+            }
+
             let textSimilarity = scorer.similarity(lhs: observedToken, rhs: candidateToken)
             let observedPhonetic = encoder.scoringSignature(for: observedToken, lexicon: lexicon)
             let candidatePhonetic = encoder.scoringSignature(for: candidateToken, lexicon: lexicon)
@@ -72,6 +79,21 @@ extension DictionaryMatcher {
         }
 
         return true
+    }
+
+    private func hasSingularPluralMismatch(observedToken: String, candidateToken: String) -> Bool {
+        func singularStem(of token: String) -> String? {
+            guard token.count > 3,
+                  token.hasSuffix("s"),
+                  !token.hasSuffix("ss"),
+                  !token.hasSuffix("s'") else {
+                return nil
+            }
+            return String(token.dropLast())
+        }
+
+        return singularStem(of: observedToken) == candidateToken
+            || singularStem(of: candidateToken) == observedToken
     }
 
     private func numericTokenVariantsOverlap(_ lhs: String, _ rhs: String) -> Bool {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
@@ -126,80 +126,89 @@ extension DictionaryMatcher {
         for candidate in candidates {
             var bestForCandidate: Candidate?
             var bestObservedNormalizedForCandidate: String?
-            for form in observedForms {
-                let baseScore = scorer.score(
-                    observedText: form.normalized,
-                    observedPhonetic: form.phonetic,
-                    candidateText: candidate.normalizedPhrase,
-                    candidatePhonetic: candidate.phoneticPhrase,
-                    previousToken: start > 0 ? tokens[start - 1].normalized : nil,
-                    nextToken: end < tokens.count ? tokens[end].normalized : nil
-                )
+            for candidateText in candidate.matchingNormalizedPhrases {
+                for form in observedForms {
+                    guard hasSufficientNumericAlignment(
+                        observedNormalized: form.normalized,
+                        candidate: candidate
+                    ) else {
+                        continue
+                    }
 
-                let fallbackPhoneticSimilarity = stylizedFallbackPhoneticSimilarity(
-                    tokenCount: tokenCount,
-                    observedNormalized: form.normalized,
-                    observedPhonetic: form.phonetic,
-                    candidate: candidate
-                )
-                let allowStylizedFallbackBySurface =
-                    tokenCount != 1
-                    || !isStylizedSingleTokenEntry(candidate)
-                    || allowStylizedFallbackForCommonObservedToken(
-                        token: window[0],
-                        tokenIndex: start,
-                        totalTokens: tokens.count
+                    let baseScore = scorer.score(
+                        observedText: form.normalized,
+                        observedPhonetic: form.phonetic,
+                        candidateText: candidateText,
+                        candidatePhonetic: candidate.phoneticPhrase,
+                        previousToken: start > 0 ? tokens[start - 1].normalized : nil,
+                        nextToken: end < tokens.count ? tokens[end].normalized : nil
                     )
-                let gatedFallbackPhoneticSimilarity =
-                    allowStylizedFallbackBySurface ? fallbackPhoneticSimilarity : 0
-                let phoneticDelta = max(0, gatedFallbackPhoneticSimilarity - baseScore.phonetic)
-                let adjustedBaseFinal = min(1.0, baseScore.final + (scorer.phoneticWeight * phoneticDelta))
-                let adjustedPhoneticScore = max(baseScore.phonetic, gatedFallbackPhoneticSimilarity)
-                let pluralHomophoneBonus: Double
-                if tokenCount == 1,
-                   form.replacementSuffix == "s",
-                   candidate.tokens.count == 1,
-                   !lexicon.isCommonWord(baseTokenForCommonWordGuard(candidate.tokens[0])),
-                   adjustedPhoneticScore >= StandardEvaluationConstants.pluralHomophonePhoneticMinimum,
-                   baseScore.text >= StandardEvaluationConstants.pluralHomophoneTextMinimum,
-                   hasPluralHomophonePronunciationEvidence(
-                       observed: form.normalized,
-                       candidate: candidate.tokens[0]
-                   ) {
-                    // Deterministic lane for plural homophone near-misses such as
-                    // "queues" -> "cues" when the dictionary term is singular.
-                    pluralHomophoneBonus = StandardEvaluationConstants.pluralHomophoneBonus
-                } else {
-                    pluralHomophoneBonus = 0
-                }
 
-                let boostedFinalScore = min(
-                    1.0,
-                    adjustedBaseFinal
-                        + tokenAlignmentBoost(window: window, candidate: candidate)
-                        + possessiveBonus(for: form.replacementSuffix)
-                        + pluralHomophoneBonus
-                )
-                let score = ReplacementScore(
-                    text: baseScore.text,
-                    phonetic: adjustedPhoneticScore,
-                    context: baseScore.context,
-                    final: boostedFinalScore
-                )
+                    let fallbackPhoneticSimilarity = stylizedFallbackPhoneticSimilarity(
+                        tokenCount: tokenCount,
+                        observedNormalized: form.normalized,
+                        observedPhonetic: form.phonetic,
+                        candidate: candidate
+                    )
+                    let allowStylizedFallbackBySurface =
+                        tokenCount != 1
+                        || !isStylizedSingleTokenEntry(candidate)
+                        || allowStylizedFallbackForCommonObservedToken(
+                            token: window[0],
+                            tokenIndex: start,
+                            totalTokens: tokens.count
+                        )
+                    let gatedFallbackPhoneticSimilarity =
+                        allowStylizedFallbackBySurface ? fallbackPhoneticSimilarity : 0
+                    let phoneticDelta = max(0, gatedFallbackPhoneticSimilarity - baseScore.phonetic)
+                    let adjustedBaseFinal = min(1.0, baseScore.final + (scorer.phoneticWeight * phoneticDelta))
+                    let adjustedPhoneticScore = max(baseScore.phonetic, gatedFallbackPhoneticSimilarity)
+                    let pluralHomophoneBonus: Double
+                    if tokenCount == 1,
+                       form.replacementSuffix == "s",
+                       candidate.tokens.count == 1,
+                       !lexicon.isCommonWord(baseTokenForCommonWordGuard(candidate.tokens[0])),
+                       adjustedPhoneticScore >= StandardEvaluationConstants.pluralHomophonePhoneticMinimum,
+                       baseScore.text >= StandardEvaluationConstants.pluralHomophoneTextMinimum,
+                       hasPluralHomophonePronunciationEvidence(
+                           observed: form.normalized,
+                           candidate: candidate.tokens[0]
+                       ) {
+                        // Deterministic lane for plural homophone near-misses such as
+                        // "queues" -> "cues" when the dictionary term is singular.
+                        pluralHomophoneBonus = StandardEvaluationConstants.pluralHomophoneBonus
+                    } else {
+                        pluralHomophoneBonus = 0
+                    }
 
-                let candidateScore = Candidate(
-                    entry: candidate,
-                    score: score,
-                    replacementSuffix: form.replacementSuffix
-                )
-                if let currentBestForCandidate = bestForCandidate {
-                    if candidateScore.score.final > currentBestForCandidate.score.final {
+                    let boostedFinalScore = min(
+                        1.0,
+                        adjustedBaseFinal
+                            + tokenAlignmentBoost(window: window, candidate: candidate)
+                            + possessiveBonus(for: form.replacementSuffix)
+                            + pluralHomophoneBonus
+                    )
+                    let score = ReplacementScore(
+                        text: baseScore.text,
+                        phonetic: adjustedPhoneticScore,
+                        context: baseScore.context,
+                        final: boostedFinalScore
+                    )
+
+                    let candidateScore = Candidate(
+                        entry: candidate,
+                        score: score,
+                        replacementSuffix: form.replacementSuffix
+                    )
+                    if let currentBestForCandidate = bestForCandidate {
+                        if candidateScore.score.final > currentBestForCandidate.score.final {
+                            bestForCandidate = candidateScore
+                            bestObservedNormalizedForCandidate = form.normalized
+                        }
+                    } else {
                         bestForCandidate = candidateScore
                         bestObservedNormalizedForCandidate = form.normalized
                     }
-                } else {
-                    bestForCandidate = candidateScore
-                    bestObservedNormalizedForCandidate = form.normalized
                 }
             }
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
@@ -130,6 +130,7 @@ extension DictionaryMatcher {
                 for form in observedForms {
                     guard hasSufficientNumericAlignment(
                         observedNormalized: form.normalized,
+                        observedNumericSourceTokens: form.numericSourceTokens,
                         candidate: candidate
                     ) else {
                         continue

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationSuffixHelpers.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationSuffixHelpers.swift
@@ -16,25 +16,41 @@ extension DictionaryMatcher {
             return [(normalized: observedNormalized, phonetic: observedPhonetic, replacementSuffix: "")]
         }
 
-        var forms: [(normalized: String, phonetic: String, replacementSuffix: String)] = [
-            (normalized: observedNormalized, phonetic: observedPhonetic, replacementSuffix: "")
-        ]
         var seen = Set<String>()
-        seen.insert("\(observedNormalized)|")
+        var forms: [(normalized: String, phonetic: String, replacementSuffix: String)] = []
+
+        func appendForm(normalized: String, phonetic: String, replacementSuffix: String) {
+            let key = "\(normalized)|\(replacementSuffix)"
+            guard seen.insert(key).inserted else { return }
+            forms.append((normalized: normalized, phonetic: phonetic, replacementSuffix: replacementSuffix))
+        }
+
+        appendForm(
+            normalized: observedNormalized,
+            phonetic: observedPhonetic,
+            replacementSuffix: ""
+        )
+
+        for numericVariant in DictionaryNumericMatching.phraseVariants(for: window.map(\.normalized))
+        where numericVariant != observedNormalized {
+            let variantTokens = numericVariant.split(separator: " ").map(String.init)
+            appendForm(
+                normalized: numericVariant,
+                phonetic: encoder.scoringPhraseSignature(for: variantTokens, lexicon: lexicon),
+                replacementSuffix: ""
+            )
+        }
 
         if tokenCount == 1 {
             let observedRawToken = window.first?.raw ?? observedNormalized
             if observedNormalized.hasSuffix("'s"), observedNormalized.count > 3 {
                 let stem = String(observedNormalized.dropLast(2))
                 if stem.count >= EvaluationSuffixConstants.minimumStemLength {
-                    let key = "\(stem)|'s"
-                    if seen.insert(key).inserted {
-                        forms.append((
-                            normalized: stem,
-                            phonetic: encoder.scoringSignature(for: stem, lexicon: lexicon),
-                            replacementSuffix: "'s"
-                        ))
-                    }
+                    appendForm(
+                        normalized: stem,
+                        phonetic: encoder.scoringSignature(for: stem, lexicon: lexicon),
+                        replacementSuffix: "'s"
+                    )
                 }
             } else if observedNormalized.hasSuffix("s"),
                       !observedNormalized.hasSuffix("ss"),
@@ -42,26 +58,20 @@ extension DictionaryMatcher {
                       observedNormalized.count > 3 {
                 let stem = String(observedNormalized.dropLast())
                 if stem.count >= EvaluationSuffixConstants.minimumStemLength {
-                    let pluralKey = "\(stem)|s"
-                    if seen.insert(pluralKey).inserted {
-                        forms.append((
-                            normalized: stem,
-                            phonetic: encoder.scoringSignature(for: stem, lexicon: lexicon),
-                            replacementSuffix: "s"
-                        ))
-                    }
+                    appendForm(
+                        normalized: stem,
+                        phonetic: encoder.scoringSignature(for: stem, lexicon: lexicon),
+                        replacementSuffix: "s"
+                    )
 
                     // Preserve implicit possessive recovery for proper-name-like tokens.
                     let startsUppercase = observedRawToken.unicodeScalars.first?.properties.isUppercase == true
                     if startsUppercase {
-                        let possessiveKey = "\(stem)|'s"
-                        if seen.insert(possessiveKey).inserted {
-                            forms.append((
-                                normalized: stem,
-                                phonetic: encoder.scoringSignature(for: stem, lexicon: lexicon),
-                                replacementSuffix: "'s"
-                            ))
-                        }
+                        appendForm(
+                            normalized: stem,
+                            phonetic: encoder.scoringSignature(for: stem, lexicon: lexicon),
+                            replacementSuffix: "'s"
+                        )
                     }
                 }
             }
@@ -76,14 +86,11 @@ extension DictionaryMatcher {
             let stem = String(second.dropLast(2))
             if stem.count >= minimumSplitTokenLength {
                 let normalized = "\(first) \(stem)"
-                let key = "\(normalized)|'s"
-                if seen.insert(key).inserted {
-                    forms.append((
-                        normalized: normalized,
-                        phonetic: encoder.scoringPhraseSignature(for: [first, stem], lexicon: lexicon),
-                        replacementSuffix: "'s"
-                    ))
-                }
+                appendForm(
+                    normalized: normalized,
+                    phonetic: encoder.scoringPhraseSignature(for: [first, stem], lexicon: lexicon),
+                    replacementSuffix: "'s"
+                )
             }
         } else if second.hasSuffix("s"),
                   !second.hasSuffix("ss"),
@@ -93,14 +100,11 @@ extension DictionaryMatcher {
             let stem = String(second.dropLast())
             if stem.count >= minimumSplitTokenLength {
                 let normalized = "\(first) \(stem)"
-                let key = "\(normalized)|'s"
-                if seen.insert(key).inserted {
-                    forms.append((
-                        normalized: normalized,
-                        phonetic: encoder.scoringPhraseSignature(for: [first, stem], lexicon: lexicon),
-                        replacementSuffix: "'s"
-                    ))
-                }
+                appendForm(
+                    normalized: normalized,
+                    phonetic: encoder.scoringPhraseSignature(for: [first, stem], lexicon: lexicon),
+                    replacementSuffix: "'s"
+                )
             }
         }
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationSuffixHelpers.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationSuffixHelpers.swift
@@ -11,33 +11,58 @@ extension DictionaryMatcher {
         window: [Token],
         observedNormalized: String,
         observedPhonetic: String
-    ) -> [(normalized: String, phonetic: String, replacementSuffix: String)] {
+    ) -> [(normalized: String, phonetic: String, replacementSuffix: String, numericSourceTokens: [String?])] {
+        func numericSourceTokens(for normalized: String) -> [String?] {
+            let tokens = normalized.split(separator: " ").map(String.init)
+            return DictionaryNumericMatching.phraseVariants(for: tokens)
+                .first(where: { $0.normalized == normalized })?
+                .numericSourceTokens
+                ?? Array(repeating: nil, count: tokens.count)
+        }
+
         guard tokenCount == 1 || tokenCount == 2 else {
-            return [(normalized: observedNormalized, phonetic: observedPhonetic, replacementSuffix: "")]
+            return [(
+                normalized: observedNormalized,
+                phonetic: observedPhonetic,
+                replacementSuffix: "",
+                numericSourceTokens: numericSourceTokens(for: observedNormalized)
+            )]
         }
 
         var seen = Set<String>()
-        var forms: [(normalized: String, phonetic: String, replacementSuffix: String)] = []
+        var forms: [(normalized: String, phonetic: String, replacementSuffix: String, numericSourceTokens: [String?])] = []
 
-        func appendForm(normalized: String, phonetic: String, replacementSuffix: String) {
+        func appendForm(
+            normalized: String,
+            phonetic: String,
+            replacementSuffix: String,
+            numericSourceTokens: [String?]
+        ) {
             let key = "\(normalized)|\(replacementSuffix)"
             guard seen.insert(key).inserted else { return }
-            forms.append((normalized: normalized, phonetic: phonetic, replacementSuffix: replacementSuffix))
+            forms.append((
+                normalized: normalized,
+                phonetic: phonetic,
+                replacementSuffix: replacementSuffix,
+                numericSourceTokens: numericSourceTokens
+            ))
         }
 
         appendForm(
             normalized: observedNormalized,
             phonetic: observedPhonetic,
-            replacementSuffix: ""
+            replacementSuffix: "",
+            numericSourceTokens: numericSourceTokens(for: observedNormalized)
         )
 
         for numericVariant in DictionaryNumericMatching.phraseVariants(for: window.map(\.normalized))
-        where numericVariant != observedNormalized {
-            let variantTokens = numericVariant.split(separator: " ").map(String.init)
+        where numericVariant.normalized != observedNormalized
+            && numericVariant.tokens.count == tokenCount {
             appendForm(
-                normalized: numericVariant,
-                phonetic: encoder.scoringPhraseSignature(for: variantTokens, lexicon: lexicon),
-                replacementSuffix: ""
+                normalized: numericVariant.normalized,
+                phonetic: encoder.scoringPhraseSignature(for: numericVariant.tokens, lexicon: lexicon),
+                replacementSuffix: "",
+                numericSourceTokens: numericVariant.numericSourceTokens
             )
         }
 
@@ -49,7 +74,8 @@ extension DictionaryMatcher {
                     appendForm(
                         normalized: stem,
                         phonetic: encoder.scoringSignature(for: stem, lexicon: lexicon),
-                        replacementSuffix: "'s"
+                        replacementSuffix: "'s",
+                        numericSourceTokens: numericSourceTokens(for: stem)
                     )
                 }
             } else if observedNormalized.hasSuffix("s"),
@@ -61,7 +87,8 @@ extension DictionaryMatcher {
                     appendForm(
                         normalized: stem,
                         phonetic: encoder.scoringSignature(for: stem, lexicon: lexicon),
-                        replacementSuffix: "s"
+                        replacementSuffix: "s",
+                        numericSourceTokens: numericSourceTokens(for: stem)
                     )
 
                     // Preserve implicit possessive recovery for proper-name-like tokens.
@@ -70,7 +97,8 @@ extension DictionaryMatcher {
                         appendForm(
                             normalized: stem,
                             phonetic: encoder.scoringSignature(for: stem, lexicon: lexicon),
-                            replacementSuffix: "'s"
+                            replacementSuffix: "'s",
+                            numericSourceTokens: numericSourceTokens(for: stem)
                         )
                     }
                 }
@@ -89,7 +117,8 @@ extension DictionaryMatcher {
                 appendForm(
                     normalized: normalized,
                     phonetic: encoder.scoringPhraseSignature(for: [first, stem], lexicon: lexicon),
-                    replacementSuffix: "'s"
+                    replacementSuffix: "'s",
+                    numericSourceTokens: numericSourceTokens(for: normalized)
                 )
             }
         } else if second.hasSuffix("s"),
@@ -103,7 +132,8 @@ extension DictionaryMatcher {
                 appendForm(
                     normalized: normalized,
                     phonetic: encoder.scoringPhraseSignature(for: [first, stem], lexicon: lexicon),
-                    replacementSuffix: "'s"
+                    replacementSuffix: "'s",
+                    numericSourceTokens: numericSourceTokens(for: normalized)
                 )
             }
         }

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinForms.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinForms.swift
@@ -10,15 +10,20 @@ extension DictionaryMatcher {
         var forms: [JoinedObservedForm] = []
         var seen = Set<String>()
 
-        let direct = first + second
-        if !direct.isEmpty, seen.insert(direct).inserted {
-            forms.append(
-                JoinedObservedForm(
-                    normalized: direct,
-                    singularizedSecondToken: false,
-                    replacementSuffix: ""
-                )
-            )
+        for firstVariant in DictionaryNumericMatching.tokenVariants(for: first) {
+            for secondVariant in DictionaryNumericMatching.tokenVariants(for: second) {
+                let direct = firstVariant.replacingOccurrences(of: " ", with: "")
+                    + secondVariant.replacingOccurrences(of: " ", with: "")
+                if !direct.isEmpty, seen.insert(direct).inserted {
+                    forms.append(
+                        JoinedObservedForm(
+                            normalized: direct,
+                            singularizedSecondToken: false,
+                            replacementSuffix: ""
+                        )
+                    )
+                }
+            }
         }
 
         if second.hasSuffix("'s"), second.count > minimumSplitTokenLength {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinScoring.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/SplitJoin/DictionaryMatcher+SplitJoinScoring.swift
@@ -28,6 +28,8 @@ private enum SplitJoinScoringConstants {
     static let stylizedAnchoredThreshold = 0.44
     static let stylizedAnchoredTailGuardMinimumSecondTokenLength = 4
     static let stylizedAnchoredTailGuardMinimumSimilarity = 0.55
+    static let numericShortTokenTextMinimum = 0.80
+    static let numericShortTokenPhoneticMinimum = 0.70
 
     static let blendedTextWeight = 0.6
     static let blendedPhoneticWeight = 0.4
@@ -67,11 +69,20 @@ extension DictionaryMatcher {
             || window[1].normalized.count < minimumSplitTokenLength
         var requiresContextualShortTokenEvidence = false
         if containsShortToken {
-            let exactJoinedCandidates = Set(oneTokenCandidates.map(\.normalizedPhrase))
+            let exactJoinedCandidates = Set(oneTokenCandidates.flatMap(\.matchingNormalizedPhrases))
             let hasExactJoinCandidate = forms.contains { form in
                 exactJoinedCandidates.contains(form.normalized)
             }
-            if !hasExactJoinCandidate, !isDelimitedSingleLetterTailLane {
+            let hasNumericShortToken = window.contains {
+                DictionaryNumericMatching.isNumericToken($0.normalized)
+            }
+            let hasNumericShortTokenMatchEvidence = hasNumericShortToken
+                && hasNumericShortTokenEvidence(
+                    window: window,
+                    forms: forms,
+                    candidates: oneTokenCandidates
+                )
+            if !hasExactJoinCandidate, !isDelimitedSingleLetterTailLane, !hasNumericShortTokenMatchEvidence {
                 guard hasShortTokenSplitContext(start: start, end: end, tokens: tokens) else {
                     stats.rejectedShortToken += 1
                     return nil
@@ -99,76 +110,78 @@ extension DictionaryMatcher {
                 continue
             }
 
-            for form in forms {
-                // Only non-common dictionary entries can use plural-tail singularization.
-                if form.singularizedSecondToken && candidateIsCommonWord {
-                    continue
-                }
-                if shouldRejectFuzzyStylizedSplitJoinPluralForm(window: window, candidate: candidate) {
-                    continue
-                }
+            for candidateText in candidate.matchingNormalizedPhrases {
+                for form in forms {
+                    // Only non-common dictionary entries can use plural-tail singularization.
+                    if form.singularizedSecondToken && candidateIsCommonWord {
+                        continue
+                    }
+                    if shouldRejectFuzzyStylizedSplitJoinPluralForm(window: window, candidate: candidate) {
+                        continue
+                    }
 
-                let observedPhonetic = encoder.scoringSignature(for: form.normalized, lexicon: lexicon)
-                let score = scorer.score(
-                    observedText: form.normalized,
-                    observedPhonetic: observedPhonetic,
-                    candidateText: candidate.normalizedPhrase,
-                    candidatePhonetic: candidate.phoneticPhrase,
-                    previousToken: start > 0 ? tokens[start - 1].normalized : nil,
-                    nextToken: end < tokens.count ? tokens[end].normalized : nil
-                )
-                let fallbackPhoneticSimilarity = splitJoinStylizedFallbackPhoneticSimilarity(
-                    observedNormalized: form.normalized,
-                    observedPhonetic: observedPhonetic,
-                    candidate: candidate
-                )
-                let phoneticDelta = max(0, fallbackPhoneticSimilarity - score.phonetic)
-                let adjustedBaseFinal = min(1.0, score.final + (scorer.phoneticWeight * phoneticDelta))
-                let possessiveStylizedBonus =
-                    (form.replacementSuffix == "'s" && isStylizedSingleTokenEntry(candidate))
-                    ? SplitJoinScoringConstants.possessiveStylizedBonus
-                    : 0.0
-                let pluralSplitJoinBonus =
-                    (form.singularizedSecondToken && form.replacementSuffix == "s" && !candidateIsCommonWord)
-                    ? SplitJoinScoringConstants.pluralSplitJoinBonus
-                    : 0.0
-                let anchoredStylizedBonus: Double
-                if isStylizedSingleTokenEntry(candidate), candidateToken.hasPrefix(window[0].normalized) {
-                    anchoredStylizedBonus = SplitJoinScoringConstants.anchoredStylizedBonus
-                } else {
-                    anchoredStylizedBonus = 0
-                }
-                let adjustedScore = ReplacementScore(
-                    text: score.text,
-                    phonetic: max(score.phonetic, fallbackPhoneticSimilarity),
-                    context: score.context,
-                    final: min(
-                        1.0,
-                        adjustedBaseFinal
-                            + possessiveBonus(for: form.replacementSuffix)
-                            + possessiveStylizedBonus
-                            + pluralSplitJoinBonus
-                            + anchoredStylizedBonus
+                    let observedPhonetic = encoder.scoringSignature(for: form.normalized, lexicon: lexicon)
+                    let score = scorer.score(
+                        observedText: form.normalized,
+                        observedPhonetic: observedPhonetic,
+                        candidateText: candidateText,
+                        candidatePhonetic: candidate.phoneticPhrase,
+                        previousToken: start > 0 ? tokens[start - 1].normalized : nil,
+                        nextToken: end < tokens.count ? tokens[end].normalized : nil
                     )
-                )
+                    let fallbackPhoneticSimilarity = splitJoinStylizedFallbackPhoneticSimilarity(
+                        observedNormalized: form.normalized,
+                        observedPhonetic: observedPhonetic,
+                        candidate: candidate
+                    )
+                    let phoneticDelta = max(0, fallbackPhoneticSimilarity - score.phonetic)
+                    let adjustedBaseFinal = min(1.0, score.final + (scorer.phoneticWeight * phoneticDelta))
+                    let possessiveStylizedBonus =
+                        (form.replacementSuffix == "'s" && isStylizedSingleTokenEntry(candidate))
+                        ? SplitJoinScoringConstants.possessiveStylizedBonus
+                        : 0.0
+                    let pluralSplitJoinBonus =
+                        (form.singularizedSecondToken && form.replacementSuffix == "s" && !candidateIsCommonWord)
+                        ? SplitJoinScoringConstants.pluralSplitJoinBonus
+                        : 0.0
+                    let anchoredStylizedBonus: Double
+                    if isStylizedSingleTokenEntry(candidate), candidateToken.hasPrefix(window[0].normalized) {
+                        anchoredStylizedBonus = SplitJoinScoringConstants.anchoredStylizedBonus
+                    } else {
+                        anchoredStylizedBonus = 0
+                    }
+                    let adjustedScore = ReplacementScore(
+                        text: score.text,
+                        phonetic: max(score.phonetic, fallbackPhoneticSimilarity),
+                        context: score.context,
+                        final: min(
+                            1.0,
+                            adjustedBaseFinal
+                                + possessiveBonus(for: form.replacementSuffix)
+                                + possessiveStylizedBonus
+                                + pluralSplitJoinBonus
+                                + anchoredStylizedBonus
+                        )
+                    )
 
-                if let currentBest = best {
-                    if adjustedScore.final > currentBest.score.final {
-                        secondBestScore = currentBest.score.final
+                    if let currentBest = best {
+                        if adjustedScore.final > currentBest.score.final {
+                            secondBestScore = currentBest.score.final
+                            best = Candidate(
+                                entry: candidate,
+                                score: adjustedScore,
+                                replacementSuffix: form.replacementSuffix
+                            )
+                        } else if adjustedScore.final > secondBestScore {
+                            secondBestScore = adjustedScore.final
+                        }
+                    } else {
                         best = Candidate(
                             entry: candidate,
                             score: adjustedScore,
                             replacementSuffix: form.replacementSuffix
                         )
-                    } else if adjustedScore.final > secondBestScore {
-                        secondBestScore = adjustedScore.final
                     }
-                } else {
-                    best = Candidate(
-                        entry: candidate,
-                        score: adjustedScore,
-                        replacementSuffix: form.replacementSuffix
-                    )
                 }
             }
         }
@@ -326,6 +339,36 @@ extension DictionaryMatcher {
         let fallbackSimilarity = scorer.similarity(lhs: observedFallback, rhs: candidateFallback)
         let runtimeSimilarity = scorer.similarity(lhs: observedPhonetic, rhs: candidate.phoneticPhrase)
         return max(fallbackSimilarity, runtimeSimilarity)
+    }
+
+    private func hasNumericShortTokenEvidence(
+        window: [Token],
+        forms: [JoinedObservedForm],
+        candidates: [CompiledEntry]
+    ) -> Bool {
+        let originalJoined = window.map(\.normalized).joined()
+
+        for form in forms where form.normalized != originalJoined {
+            let observedPhonetic = encoder.scoringSignature(for: form.normalized, lexicon: lexicon)
+            for candidate in candidates {
+                let textSimilarity = candidate.matchingNormalizedPhrases
+                    .map { scorer.similarity(lhs: form.normalized, rhs: $0) }
+                    .max() ?? 0
+                guard textSimilarity >= SplitJoinScoringConstants.numericShortTokenTextMinimum else {
+                    continue
+                }
+
+                let phoneticSimilarity = scorer.similarity(
+                    lhs: observedPhonetic,
+                    rhs: candidate.phoneticPhrase
+                )
+                if phoneticSimilarity >= SplitJoinScoringConstants.numericShortTokenPhoneticMinimum {
+                    return true
+                }
+            }
+        }
+
+        return false
     }
 
     private func splitJoinStylizedSimilarity(window: [Token], candidateToken: String) -> (text: Double, phonetic: Double, blended: Double) {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/PhoneticEncoder.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/PhoneticEncoder.swift
@@ -5,8 +5,21 @@ public struct PhoneticEncoder {
 
     @MainActor
     public func signature(for normalizedToken: String, lexicon: PronunciationLexiconProviding) -> String {
+        let tokenVariants = DictionaryNumericMatching.tokenVariants(for: normalizedToken)
+        if let numericSpelling = tokenVariants.last,
+           numericSpelling != normalizedToken {
+            if let knownNumericSpelling = lexicon.pronunciation(for: numericSpelling) {
+                return knownNumericSpelling
+            }
+        }
+
         if let known = lexicon.pronunciation(for: normalizedToken) {
             return known
+        }
+
+        if let numericSpelling = tokenVariants.last,
+           numericSpelling != normalizedToken {
+            return fallbackSignature(for: numericSpelling)
         }
 
         return fallbackSignature(for: normalizedToken)

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -69,6 +69,50 @@ final class DictionaryMatcherTests: XCTestCase {
         XCTAssertEqual(matcher.apply(to: input).text, input)
     }
 
+    func testDoesNotMatchOrdinalSingularToNumericPluralDictionaryEntry() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "21 Pilots")])
+
+        let input = "That's the 21st pilot."
+
+        XCTAssertEqual(matcher.apply(to: input).text, input)
+    }
+
+    func testMatchesNumericPluralToSpelledOutDictionaryEntry() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "Twenty One Pilots")])
+
+        XCTAssertEqual(
+            matcher.apply(to: "Yeah, that's 21 pilots.").text,
+            "Yeah, that's Twenty One Pilots."
+        )
+    }
+
+    func testDoesNotMatchOrdinalSingularToNumericPluralDictionaryEntryWithSyntheticPhrase() {
+        let cases = [
+            (entry: "42 Comets", input: "The 42nd comet passed overhead."),
+            (entry: "53 Runners", input: "The 53rd runner crossed the finish line."),
+            (entry: "44 Climbers", input: "The 44th climber reached the summit.")
+        ]
+
+        for testCase in cases {
+            let matcher = makeRuntimeMatcher()
+            matcher.rebuildIndex(entries: [DictionaryEntry(phrase: testCase.entry)])
+
+            XCTAssertEqual(matcher.apply(to: testCase.input).text, testCase.input)
+        }
+    }
+
+    func testMatchesCardinalPluralToNumericPluralDictionaryEntryWithSyntheticPhrase() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "42 Comets")])
+
+        XCTAssertEqual(
+            matcher.apply(to: "The forty two comets passed overhead.").text,
+            "The 42 Comets passed overhead."
+        )
+    }
+
     func testExactPhraseIsPreserved() {
         let matcher = makeMatcher()
         matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "Dom Esposito")])

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -50,6 +50,25 @@ final class DictionaryMatcherTests: XCTestCase {
         )
     }
 
+    func testMatchesMultiwordCardinalForNumericDictionaryEntry() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "21 Time")])
+
+        XCTAssertEqual(
+            matcher.apply(to: "The schedule says twenty one time today.").text,
+            "The schedule says 21 Time today."
+        )
+    }
+
+    func testDoesNotMatchDifferentMultiwordCardinalForNumericDictionaryEntry() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "21 Time")])
+
+        let input = "The schedule says twenty two time today."
+
+        XCTAssertEqual(matcher.apply(to: input).text, input)
+    }
+
     func testExactPhraseIsPreserved() {
         let matcher = makeMatcher()
         matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "Dom Esposito")])

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -4,6 +4,52 @@ import XCTest
 
 @MainActor
 final class DictionaryMatcherTests: XCTestCase {
+    func testDoesNotMatchNumericDictionaryEntryToUnrelatedPluralTail() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "7-Eleven")])
+
+        let input = "The team logged seven moves during rehearsal."
+
+        XCTAssertEqual(matcher.apply(to: input).text, input)
+    }
+
+    func testMatchesNumericShapeForHyphenatedDictionaryEntry() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "7-Eleven")])
+
+        let result = matcher.apply(to: "The storefront is next to 7-11.")
+
+        XCTAssertEqual(result.text, "The storefront is next to 7-Eleven.")
+    }
+
+    func testMatchesCardinalAndOrdinalNumericShapesForSpokenDictionaryPhrase() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "Leven Time")])
+
+        XCTAssertEqual(
+            matcher.apply(to: "I think 11 time will be great.").text,
+            "I think Leven Time will be great."
+        )
+        XCTAssertEqual(
+            matcher.apply(to: "We built 11th time for the demo.").text,
+            "We built Leven Time for the demo."
+        )
+    }
+
+    func testMatchesNumericShapeWhenDictionaryEntryIsJoined() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "LevenTime")])
+
+        XCTAssertEqual(
+            matcher.apply(to: "The prototype uses 11 time.").text,
+            "The prototype uses LevenTime."
+        )
+        XCTAssertEqual(
+            matcher.apply(to: "I tested 11th time today.").text,
+            "I tested LevenTime today."
+        )
+    }
+
     func testExactPhraseIsPreserved() {
         let matcher = makeMatcher()
         matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "Dom Esposito")])

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/PhoneticEncoderTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/PhoneticEncoderTests.swift
@@ -30,4 +30,12 @@ final class PhoneticEncoderTests: XCTestCase {
         let signature = encoder.phraseSignature(for: ["migo", "platform"], lexicon: lexicon)
         XCTAssertTrue(signature == "MGO PLTRM")
     }
+
+    func testNumericAndOrdinalTokensUseCardinalPronunciation() {
+        let lexicon = FakeLexicon(pronunciations: ["eleven": "IH-L-EH-V-AH-N"])
+        let encoder = PhoneticEncoder()
+
+        XCTAssertEqual(encoder.signature(for: "11", lexicon: lexicon), "IH-L-EH-V-AH-N")
+        XCTAssertEqual(encoder.signature(for: "11th", lexicon: lexicon), "IH-L-EH-V-AH-N")
+    }
 }


### PR DESCRIPTION
## Summary

- Add digit, cardinal, ordinal, and phonetic variants for custom dictionary matching across hyphenated and joined phrase shapes.
- Require aligned numeric evidence and strong companion-word evidence so unrelated plural or possessive tails do not trigger replacements.
- Document the changes under the current KeyVoxCore `1.2.2` release.

## Validation

- KeyVoxCore package suite: 512 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dictionary matching for numeric and ordinal expressions, including equivalent cardinal-word forms.
  * Recognizes numeric variations in phrases, aliases, split words, and joined words.
  * Supports more accurate phonetic matching when numbers have known pronunciations.
* **Bug Fixes**
  * Prevents unrelated quantities from being incorrectly matched to dictionary entries.
  * Improves handling of numeric substitutions while preserving accurate phrase and pronunciation matching.
  * Reduces false positives in split and joined phrase recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->