### PR TITLE
fix(whisper): filter VAD silence before decoding

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -6,12 +6,13 @@ The format loosely follows Keep a Changelog and the package uses semantic versio
 
 ---
 
-## [1.2.2] - 2026-08-04
+## [1.2.2] - 2026-08-05
 
 Thousands-grouping, numeric dictionary matching, stylized-capitalization, and emoji-boundary normalization fixes with regression coverage.
 
 ### Includes
 
+- Added VAD-aware Whisper speech-range selection that removes trailing and inter-speech silence before decoding while preserving logical paragraph chunk boundaries, reducing hallucinated text from accepted silence.
 - Preserved four-digit year forms with stacked uncertainty qualifiers such as `like at least` across numeric and spoken-number normalization paths.
 - Preserved coordinated year references in noun contexts while continuing to group nearby quantities.
 - Reworked four-digit year-versus-quantity detection around contextual evidence instead of individual sentence-shape branches, preferring ungrouped years when the context is ambiguous while retaining grouping for clear quantities such as standalone values, plural noun complements, partitive phrases, and quantity modifiers.

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Services/Whisper/WhisperService+TranscriptionCore.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Services/Whisper/WhisperService+TranscriptionCore.swift
@@ -48,10 +48,14 @@ extension WhisperService {
         }
 
         #if DEBUG
-        print("Transcribing \(audioFrames.count) raw frames...")
+        print(
+            "Transcribing \(audioFrames.count) raw frames " +
+            "language=\(configuredLanguage.rawValue)..."
+        )
         #endif
 
         let paragraphChunker = self.paragraphChunker
+        let speechRangePlanner = WhisperSpeechRangePlanner()
         let noSpeechSegmentProbabilityThreshold = self.noSpeechSegmentProbabilityThreshold
         let noSpeechAverageProbabilityThreshold = self.noSpeechAverageProbabilityThreshold
         let voiceActivityThreshold = self.voiceActivityThreshold
@@ -63,6 +67,7 @@ extension WhisperService {
         transcriptionTask = Task { [weak self] in
             guard let self else { return }
             do {
+                let voiceActivityAnalysis: WhisperVoiceActivityAnalysis?
                 if let voiceActivityDetector = self.voiceActivityDetector,
                    let voiceActivity = await voiceActivityDetector.analyze(
                     audioFrames: audioFrames,
@@ -74,14 +79,14 @@ extension WhisperService {
                     #if DEBUG
                     let maximumProbability = voiceActivity.probabilities.max() ?? 0
                     let speechRanges = voiceActivity.speechSegments.map {
-                        "\(String(format: "%.2f", $0.startTime))-\(String(format: "%.2f", $0.endTime))"
+                        "\(String(format: "%.2f", Double($0.startTime) / 100.0))-\(String(format: "%.2f", Double($0.endTime) / 100.0))s"
                     }
                     print(
                         "WhisperService VAD: frames=\(audioFrames.count) " +
                         "probabilities=\(voiceActivity.probabilities.count) " +
                         "maxProbability=\(String(format: "%.3f", maximumProbability)) " +
                         "speechSegments=\(voiceActivity.speechSegments.count) " +
-                        "speechRanges=\(speechRanges)"
+                        "speechRangesSeconds=\(speechRanges)"
                     )
                     #endif
 
@@ -101,10 +106,12 @@ extension WhisperService {
                         )
                         return
                     }
+                    voiceActivityAnalysis = voiceActivity
                 } else {
                     #if DEBUG
                     print("WhisperService VAD: unavailable; continuing with decoder safeguards.")
                     #endif
+                    voiceActivityAnalysis = nil
                 }
 
                 let chunkResult = paragraphChunker.split(audioFrames)
@@ -127,6 +134,8 @@ extension WhisperService {
                 var detectedLanguageCode: String? = nil
                 var nonEmptyChunkTextCount = 0
                 var precedingChunkText = ""
+                var vadSkippedChunkCount = 0
+                var vadSelectedFrameCount = 0
 
                 for (chunkIndex, chunk) in chunkResult.chunks.enumerated() {
                     if Task.isCancelled {
@@ -137,8 +146,69 @@ extension WhisperService {
                         return
                     }
 
-                    let chunkFrames = Array(audioFrames[chunk.startFrame..<chunk.endFrame])
-                    guard !chunkFrames.isEmpty else { continue }
+                    let sourceChunkFrames = Array(audioFrames[chunk.startFrame..<chunk.endFrame])
+                    guard !sourceChunkFrames.isEmpty else { continue }
+
+                    let trailingBoundaryFrame = chunkIndex < (chunkResult.chunks.count - 1)
+                        ? chunk.endFrame
+                        : nil
+                    let selectedSpeechRanges: [WhisperSpeechRangePlanner.FrameRange]?
+                    let chunkFrames: [Float]
+
+                    if let speechSegments = voiceActivityAnalysis?.speechSegments {
+                        let ranges = speechRangePlanner.ranges(
+                            for: chunk,
+                            speechSegments: speechSegments,
+                            audioFrameCount: audioFrames.count
+                        )
+                        selectedSpeechRanges = ranges
+
+                        guard !ranges.isEmpty else {
+                            vadSkippedChunkCount += 1
+                            transcribedChunks.append(
+                                TranscribedChunk(
+                                    text: "",
+                                    trailingBoundaryFrame: trailingBoundaryFrame
+                                )
+                            )
+                            #if DEBUG
+                            print(
+                                "WhisperService VAD chunk: chunk=\(chunkIndex + 1)/\(chunkResult.chunks.count) " +
+                                "sourceSeconds=\(String(format: "%.2f", Double(sourceChunkFrames.count) / 16_000.0)) " +
+                                "action=skip_no_speech_overlap"
+                            )
+                            #endif
+                            continue
+                        }
+
+                        chunkFrames = speechRangePlanner.compactedFrames(
+                            from: audioFrames,
+                            ranges: ranges,
+                            maximumInterRangeSilenceMilliseconds: Int(voiceActivityMinimumSilenceDurationMilliseconds)
+                        )
+                        vadSelectedFrameCount += chunkFrames.count
+                    } else {
+                        selectedSpeechRanges = nil
+                        chunkFrames = sourceChunkFrames
+                    }
+
+                    guard !chunkFrames.isEmpty else {
+                        vadSkippedChunkCount += 1
+                        transcribedChunks.append(
+                            TranscribedChunk(
+                                text: "",
+                                trailingBoundaryFrame: trailingBoundaryFrame
+                            )
+                        )
+                        #if DEBUG
+                        print(
+                            "WhisperService VAD chunk: chunk=\(chunkIndex + 1)/\(chunkResult.chunks.count) " +
+                            "sourceSeconds=\(String(format: "%.2f", Double(sourceChunkFrames.count) / 16_000.0)) " +
+                            "action=skip_empty_selection"
+                        )
+                        #endif
+                        continue
+                    }
 
                     let result = try await self.transcribeChunkWithLeadingPhraseRetry(
                         chunkFrames: chunkFrames,
@@ -163,9 +233,6 @@ extension WhisperService {
                     if !normalizedChunkText.isEmpty {
                         precedingChunkText = normalizedChunkText
                     }
-                    let trailingBoundaryFrame = chunkIndex < (chunkResult.chunks.count - 1)
-                        ? chunk.endFrame
-                        : nil
                     transcribedChunks.append(
                         TranscribedChunk(
                             text: normalizedChunkText,
@@ -176,13 +243,19 @@ extension WhisperService {
                         nonEmptyChunkTextCount += 1
                     }
                     #if DEBUG
-                    let chunkDurationSeconds = Double(chunk.endFrame - chunk.startFrame) / 16_000.0
+                    let sourceChunkDurationSeconds = Double(sourceChunkFrames.count) / 16_000.0
+                    let decodedChunkDurationSeconds = Double(chunkFrames.count) / 16_000.0
+                    let selectedRangeSummary = selectedSpeechRanges?.map {
+                        "\($0.startFrame)-\($0.endFrame)"
+                    } ?? ["full"]
                     let averageChunkNoSpeechProbability: Float = segments.isEmpty
                         ? 1.0
                         : (segments.reduce(0) { $0 + $1.noSpeechProbability } / Float(segments.count))
                     print(
                         "WhisperService chunk result: chunk=\(chunkIndex + 1)/\(chunkResult.chunks.count) " +
-                        "seconds=\(String(format: "%.2f", chunkDurationSeconds)) " +
+                        "sourceSeconds=\(String(format: "%.2f", sourceChunkDurationSeconds)) " +
+                        "decodedSeconds=\(String(format: "%.2f", decodedChunkDurationSeconds)) " +
+                        "selectedRanges=\(selectedRangeSummary) " +
                         "segments=\(segments.count) " +
                         "avgNoSpeech=\(String(format: "%.3f", averageChunkNoSpeechProbability)) " +
                         "emptyText=\(normalizedChunkText.isEmpty)"
@@ -233,6 +306,8 @@ extension WhisperService {
                 print(
                     "WhisperService final decode: totalChunks=\(chunkResult.chunks.count) " +
                     "nonEmptyChunks=\(nonEmptyChunkTextCount) " +
+                    "vadSkippedChunks=\(vadSkippedChunkCount) " +
+                    "vadSelectedFrames=\(vadSelectedFrameCount) " +
                     "segments=\(transcribedSegments.count) " +
                     "likelyNoSpeech=\(likelyNoSpeechByDecoder) " +
                     "finalChars=\(finalText.count)"

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Services/Whisper/WhisperSpeechRangePlanner.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Services/Whisper/WhisperSpeechRangePlanner.swift
@@ -1,0 +1,136 @@
+import Foundation
+import KeyVoxWhisper
+
+struct WhisperSpeechRangePlanner: Sendable {
+    struct FrameRange: Equatable, Sendable {
+        let startFrame: Int
+        let endFrame: Int
+
+        var isEmpty: Bool {
+            endFrame <= startFrame
+        }
+    }
+
+    private let sampleRate: Double
+
+    init(sampleRate: Double = 16_000) {
+        self.sampleRate = sampleRate
+    }
+
+    func ranges(
+        for chunk: AudioParagraphChunker.Chunk,
+        speechSegments: [WhisperVoiceActivitySegment],
+        audioFrameCount: Int
+    ) -> [FrameRange] {
+        guard audioFrameCount > 0 else { return [] }
+
+        let chunkStartFrame = max(0, min(chunk.startFrame, audioFrameCount))
+        let chunkEndFrame = max(chunkStartFrame, min(chunk.endFrame, audioFrameCount))
+        guard chunkEndFrame > chunkStartFrame else { return [] }
+
+        let clippedRanges = speechSegments.compactMap { segment -> FrameRange? in
+            guard let segmentStartFrame = frameIndex(forCentiseconds: segment.startTime),
+                  let segmentEndFrame = frameIndex(forCentiseconds: segment.endTime) else {
+                return nil
+            }
+
+            let startFrame = max(chunkStartFrame, segmentStartFrame)
+            let endFrame = min(chunkEndFrame, segmentEndFrame)
+            guard endFrame > startFrame else { return nil }
+
+            return FrameRange(startFrame: startFrame, endFrame: endFrame)
+        }
+
+        return mergeOverlappingRanges(clippedRanges)
+    }
+
+    func compactedFrames(
+        from audioFrames: [Float],
+        ranges: [FrameRange],
+        maximumInterRangeSilenceMilliseconds: Int
+    ) -> [Float] {
+        guard !audioFrames.isEmpty else { return [] }
+
+        let validRanges = mergeOverlappingRanges(
+            ranges.compactMap { range in
+                let startFrame = max(0, min(range.startFrame, audioFrames.count))
+                let endFrame = max(startFrame, min(range.endFrame, audioFrames.count))
+                let clippedRange = FrameRange(startFrame: startFrame, endFrame: endFrame)
+                return clippedRange.isEmpty ? nil : clippedRange
+            }
+        )
+        guard !validRanges.isEmpty else { return [] }
+
+        let maximumInterRangeSilenceFrames = max(
+            0,
+            Int(
+                (Double(maximumInterRangeSilenceMilliseconds) / 1_000.0 * sampleRate)
+                    .rounded()
+            )
+        )
+        let totalRangeFrames = validRanges.reduce(0) { $0 + ($1.endFrame - $1.startFrame) }
+        let separatorCount = max(0, validRanges.count - 1) * maximumInterRangeSilenceFrames
+        var compacted = [Float]()
+        compacted.reserveCapacity(totalRangeFrames + separatorCount)
+
+        for (index, range) in validRanges.enumerated() {
+            if index > 0 {
+                let previousRange = validRanges[index - 1]
+                let sourceGapFrames = max(0, range.startFrame - previousRange.endFrame)
+                let separatorFrames = min(sourceGapFrames, maximumInterRangeSilenceFrames)
+                if separatorFrames > 0 {
+                    compacted.append(contentsOf: repeatElement(0, count: separatorFrames))
+                }
+            }
+
+            compacted.append(contentsOf: audioFrames[range.startFrame..<range.endFrame])
+        }
+
+        return compacted
+    }
+
+    private func frameIndex(forCentiseconds timeCentiseconds: Float) -> Int? {
+        let scaledTime = Double(timeCentiseconds) / 100.0 * sampleRate
+        guard timeCentiseconds.isFinite,
+              scaledTime.isFinite,
+              scaledTime >= 0,
+              scaledTime <= Double(Int.max) else {
+            return nil
+        }
+
+        return Int(scaledTime.rounded())
+    }
+
+    private func mergeOverlappingRanges(_ ranges: [FrameRange]) -> [FrameRange] {
+        let sortedRanges = ranges
+            .filter { !$0.isEmpty }
+            .sorted {
+                if $0.startFrame == $1.startFrame {
+                    return $0.endFrame < $1.endFrame
+                }
+                return $0.startFrame < $1.startFrame
+            }
+
+        var merged: [FrameRange] = []
+        merged.reserveCapacity(sortedRanges.count)
+
+        for range in sortedRanges {
+            guard let previous = merged.last else {
+                merged.append(range)
+                continue
+            }
+
+            guard range.startFrame <= previous.endFrame else {
+                merged.append(range)
+                continue
+            }
+
+            merged[merged.count - 1] = FrameRange(
+                startFrame: previous.startFrame,
+                endFrame: max(previous.endFrame, range.endFrame)
+            )
+        }
+
+        return merged
+    }
+}

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Services/WhisperSpeechRangePlannerTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Services/WhisperSpeechRangePlannerTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import KeyVoxWhisper
+@testable import KeyVoxCore
+
+final class WhisperSpeechRangePlannerTests: XCTestCase {
+    private let planner = WhisperSpeechRangePlanner()
+
+    func testRangesClipSpeechToChunkAndDropSpeechOutsideChunk() {
+        let chunk = AudioParagraphChunker.Chunk(
+            startFrame: 16_000,
+            endFrame: 48_000
+        )
+        let speechSegments = [
+            WhisperVoiceActivitySegment(startTime: 50, endTime: 150),
+            WhisperVoiceActivitySegment(startTime: 250, endTime: 350),
+            WhisperVoiceActivitySegment(startTime: 400, endTime: 500)
+        ]
+
+        let ranges = planner.ranges(
+            for: chunk,
+            speechSegments: speechSegments,
+            audioFrameCount: 64_000
+        )
+
+        XCTAssertEqual(
+            ranges,
+            [
+                .init(startFrame: 16_000, endFrame: 24_000),
+                .init(startFrame: 40_000, endFrame: 48_000)
+            ]
+        )
+    }
+
+    func testRangesMergeOverlappingSpeechSegments() {
+        let chunk = AudioParagraphChunker.Chunk(
+            startFrame: 0,
+            endFrame: 32_000
+        )
+        let speechSegments = [
+            WhisperVoiceActivitySegment(startTime: 50, endTime: 100),
+            WhisperVoiceActivitySegment(startTime: 90, endTime: 150)
+        ]
+
+        let ranges = planner.ranges(
+            for: chunk,
+            speechSegments: speechSegments,
+            audioFrameCount: 32_000
+        )
+
+        XCTAssertEqual(
+            ranges,
+            [.init(startFrame: 8_000, endFrame: 24_000)]
+        )
+    }
+
+    func testCompactedFramesRemoveUnboundedSourceGap() {
+        let audioFrames = (0..<6).map(Float.init)
+        let ranges = [
+            WhisperSpeechRangePlanner.FrameRange(startFrame: 0, endFrame: 2),
+            WhisperSpeechRangePlanner.FrameRange(startFrame: 4, endFrame: 6)
+        ]
+
+        let compacted = planner.compactedFrames(
+            from: audioFrames,
+            ranges: ranges,
+            maximumInterRangeSilenceMilliseconds: 0
+        )
+
+        XCTAssertEqual(compacted, [0, 1, 4, 5])
+    }
+
+    func testCompactedFramesPreserveOnlyBoundedInterRangeSilence() {
+        let audioFrames = [Float](repeating: 1, count: 4_000)
+        let ranges = [
+            WhisperSpeechRangePlanner.FrameRange(startFrame: 0, endFrame: 1),
+            WhisperSpeechRangePlanner.FrameRange(startFrame: 3_000, endFrame: 3_001)
+        ]
+
+        let compacted = planner.compactedFrames(
+            from: audioFrames,
+            ranges: ranges,
+            maximumInterRangeSilenceMilliseconds: 100
+        )
+
+        XCTAssertEqual(compacted.count, 1 + 1_600 + 1)
+        XCTAssertEqual(compacted.first, 1)
+        XCTAssertEqual(compacted.last, 1)
+        XCTAssertEqual(compacted.dropFirst().dropLast().allSatisfy { $0 == 0 }, true)
+    }
+
+    func testCompactedFramesReturnEmptyForNoSpeechRanges() {
+        let compacted = planner.compactedFrames(
+            from: [0.1, 0.2],
+            ranges: [],
+            maximumInterRangeSilenceMilliseconds: 100
+        )
+
+        XCTAssertTrue(compacted.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Uses the existing VAD analysis to select speech ranges within each Whisper chunk.
- Converts whisper.cpp VAD centisecond timestamps into 16 kHz frame ranges.
- Removes trailing and inter-speech silence before decoding while preserving logical paragraph boundaries and skipping chunks with no speech overlap.
- Adds planner coverage for range clipping, merging, and bounded compaction.
- Updates the KeyVoxCore changelog date and entry without changing version 1.2.2.

## Root cause

The VAD timestamps were interpreted as seconds and then milliseconds instead of whisper.cpp centiseconds. Valid speech was reduced to a tiny audio slice, which caused Whisper to return hallucinated text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved speech transcription by focusing decoding on detected speech and removing trailing or extended silence.
  * Preserved natural, bounded pauses between speech segments and paragraph boundaries.

* **Bug Fixes**
  * Chunks without detected speech are now skipped, improving transcription efficiency and clarity.

* **Documentation**
  * Updated the 1.2.2 release date to August 5, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->