### PR TITLE
fix(mac-windows): restore draggable window surfaces

### DIFF
--- a/macOS/App/KeyVoxApp.swift
+++ b/macOS/App/KeyVoxApp.swift
@@ -122,26 +122,29 @@ class WindowManager: ObservableObject {
         window.center()
         
         
-        window.contentView = NSHostingView(rootView: OnboardingView(onComplete: {
-            AppSettingsStore.shared.hasCompletedOnboarding = true
-            window.close()
-            self.onboardingWindow = nil
-            self.showFirstDictationOnboarding()
-        }, openSettings: {
-            self.openSettings()
-        }, beginMicrophoneAuthorization: {
-            self.lowerOnboardingWindowForMicrophoneAuthorization()
-        }, beginAccessibilityAuthorization: {
-            self.lowerOnboardingWindowForAccessibilityPrompt()
-        }, endAccessibilityAuthorization: {
-            self.restoreOnboardingWindowAfterAccessibilityGranted()
-        }, onPreferredHeightChange: { [weak window] height in
-            guard let window else { return }
-            let targetSize = CGSize(width: OnboardingView.preferredWindowSize.width, height: height)
-            if window.contentLayoutRect.size != targetSize {
-                window.setContentSize(targetSize)
-            }
-        }))
+        window.contentView = NSHostingView(
+            rootView: OnboardingView(onComplete: {
+                AppSettingsStore.shared.hasCompletedOnboarding = true
+                window.close()
+                self.onboardingWindow = nil
+                self.showFirstDictationOnboarding()
+            }, openSettings: {
+                self.openSettings()
+            }, beginMicrophoneAuthorization: {
+                self.lowerOnboardingWindowForMicrophoneAuthorization()
+            }, beginAccessibilityAuthorization: {
+                self.lowerOnboardingWindowForAccessibilityPrompt()
+            }, endAccessibilityAuthorization: {
+                self.restoreOnboardingWindowAfterAccessibilityGranted()
+            }, onPreferredHeightChange: { [weak window] height in
+                guard let window else { return }
+                let targetSize = CGSize(width: OnboardingView.preferredWindowSize.width, height: height)
+                if window.contentLayoutRect.size != targetSize {
+                    window.setContentSize(targetSize)
+                }
+            })
+            .keyVoxWindowDragGesture(allowsActivationEvents: true)
+        )
 
         window.setContentSize(onboardingSize)
         self.onboardingWindow = window

--- a/macOS/App/WindowManager+FirstDictationOnboarding.swift
+++ b/macOS/App/WindowManager+FirstDictationOnboarding.swift
@@ -30,24 +30,27 @@ extension WindowManager {
         window.level = .floating
         window.hidesOnDeactivate = false
 
-        window.contentView = NSHostingView(rootView: FirstDictationOnboardingFlowView(
-            onWindowSizeChange: { [weak window] newSize, completion in
-                window?.animateFirstDictationContentSize(to: newSize, completion: completion)
-            },
-            onComplete: { completion in
-                switch completion {
-                case .completed:
-                    AppSettingsStore.shared.hasCompletedFirstDictation = true
-                case .skipped:
-                    AppSettingsStore.shared.hasSkippedFirstDictation = true
-                }
+        window.contentView = NSHostingView(
+            rootView: FirstDictationOnboardingFlowView(
+                onWindowSizeChange: { [weak window] newSize, completion in
+                    window?.animateFirstDictationContentSize(to: newSize, completion: completion)
+                },
+                onComplete: { completion in
+                    switch completion {
+                    case .completed:
+                        AppSettingsStore.shared.hasCompletedFirstDictation = true
+                    case .skipped:
+                        AppSettingsStore.shared.hasSkippedFirstDictation = true
+                    }
 
-                window.close()
-                self.firstDictationOnboardingWindow = nil
-                self.openSettings(centered: true)
-                KeyVoxApp.presentVibesIntroIfEligibleAfterUpdateGate()
-            }
-        ))
+                    window.close()
+                    self.firstDictationOnboardingWindow = nil
+                    self.openSettings(centered: true)
+                    KeyVoxApp.presentVibesIntroIfEligibleAfterUpdateGate()
+                }
+            )
+            .keyVoxWindowDragGesture(allowsActivationEvents: true)
+        )
 
         window.setContentSize(windowSize)
         window.center()

--- a/macOS/App/WindowManager+VibesIntro.swift
+++ b/macOS/App/WindowManager+VibesIntro.swift
@@ -57,6 +57,7 @@ extension WindowManager {
                         self.openSettings(tab: .style)
                     }
                 )
+                .keyVoxWindowDragGesture(allowsActivationEvents: true)
             )
 
         window.contentView = hostingView
@@ -73,8 +74,8 @@ extension WindowManager {
     }
 
     @MainActor
-    private func resolvedVibesIntroContentSize(
-        hostingView: NSHostingView<MacVibesIntroWindowView>,
+    private func resolvedVibesIntroContentSize<Content: View>(
+        hostingView: NSHostingView<Content>,
         fallback: CGSize
     ) -> CGSize {
         let fittingSize = hostingView.fittingSize

--- a/macOS/Core/Overlay/OverlayManager.swift
+++ b/macOS/Core/Overlay/OverlayManager.swift
@@ -15,6 +15,13 @@ class OverlayVisibilityManager: ObservableObject {
 class OverlayManager {
     static let shared = OverlayManager()
 
+    private enum OverlayContentMode {
+        case recording
+        case standaloneVibePill
+        case standaloneFormattingPill
+        case vibeCyclePill
+    }
+
     enum VibePillPlacement {
         case savedOverlayOrigin
         case currentOverlayCenter
@@ -33,6 +40,7 @@ class OverlayManager {
     private weak var activeVibeCyclePillPanel: NSPanel?
     private var visibleVibePillTitle: String?
     private var visibleVibePillState: OverlayPillState?
+    private var contentModesByPanel: [ObjectIdentifier: OverlayContentMode] = [:]
     private var moveObserver: NSObjectProtocol?
     private var screenParamsObserver: NSObjectProtocol?
 
@@ -69,22 +77,31 @@ class OverlayManager {
             panel.isMovableByWindowBackground = true
             configurePanelCallbacks(panel)
 
-            let contentView = NSHostingView(rootView: RecordingOverlay(
-                recorder: recorder,
-                isTranscribing: isTranscribing,
-                visibilityManager: visibilityManager
-            ))
-            panel.contentView = contentView
+            setDraggableContentView(
+                rootView: RecordingOverlay(
+                    recorder: recorder,
+                    isTranscribing: isTranscribing,
+                    visibilityManager: visibilityManager
+                ),
+                mode: .recording,
+                on: panel
+            )
             registerMoveObserverIfNeeded(for: panel)
             registerScreenParamsObserverIfNeeded(for: panel)
             window = panel
         }
 
-        window?.contentView = NSHostingView(rootView: RecordingOverlay(
-            recorder: recorder,
-            isTranscribing: isTranscribing,
-            visibilityManager: visibilityManager
-        ))
+        if let panel = window {
+            setDraggableContentView(
+                rootView: RecordingOverlay(
+                    recorder: recorder,
+                    isTranscribing: isTranscribing,
+                    visibilityManager: visibilityManager
+                ),
+                mode: .recording,
+                on: panel
+            )
+        }
         if configuredVibeCyclePillContentPanel === window {
             configuredVibeCyclePillContentPanel = nil
         }
@@ -187,7 +204,11 @@ class OverlayManager {
             hideVibeLabelWindow()
             self.visibleVibePillTitle = visibleVibeTitle
             visibleVibePillState = visibleVibeTitle == nil ? nil : state
-            panel.contentView = NSHostingView(rootView: content)
+            setDraggableContentView(
+                rootView: content,
+                mode: visibleVibeTitle == nil ? .standaloneFormattingPill : .standaloneVibePill,
+                on: panel
+            )
             if configuredVibeCyclePillContentPanel === panel {
                 configuredVibeCyclePillContentPanel = nil
             }
@@ -243,6 +264,7 @@ class OverlayManager {
         if panel === window {
             if let auxiliaryPanel = vibeCyclePillWindow, auxiliaryPanel !== panel {
                 auxiliaryPanel.orderOut(nil)
+                contentModesByPanel.removeValue(forKey: ObjectIdentifier(auxiliaryPanel))
             }
             vibeCyclePillWindow = nil
         } else {
@@ -255,13 +277,17 @@ class OverlayManager {
             )
         }
         if configuredVibeCyclePillContentPanel !== panel {
-            panel.contentView = NSHostingView(rootView: VibeCyclePillOverlay(
-                visibilityController: visibilityController,
-                adoptsVisiblePill: adoptedPillState != nil,
-                onAdoptedAppear: adoptedPillState == nil ? nil : {
-                    visibilityController.present(title: title, state: state)
-                }
-            ))
+            setDraggableContentView(
+                rootView: VibeCyclePillOverlay(
+                    visibilityController: visibilityController,
+                    adoptsVisiblePill: adoptedPillState != nil,
+                    onAdoptedAppear: adoptedPillState == nil ? nil : {
+                        visibilityController.present(title: title, state: state)
+                    }
+                ),
+                mode: .vibeCyclePill,
+                on: panel
+            )
             configuredVibeCyclePillContentPanel = panel
         }
         visibleVibePillTitle = nil
@@ -367,6 +393,10 @@ class OverlayManager {
             panel.orderOut(nil)
         }
 
+        if let panel = vibeCyclePillWindow, panel !== window {
+            contentModesByPanel.removeValue(forKey: ObjectIdentifier(panel))
+        }
+
         activeVibeCyclePillPanel = nil
         vibeCyclePillWindow = nil
         configuredVibeCyclePillContentPanel = nil
@@ -380,7 +410,7 @@ class OverlayManager {
     )? {
         guard let panel = window,
               panel.isVisible,
-              panel.contentView is NSHostingView<OverlayPillOverlay<VibePillView>>,
+              contentMode(for: panel) == .standaloneVibePill,
               let title = visibleVibePillTitle,
               let state = visibleVibePillState else {
             return nil
@@ -391,7 +421,7 @@ class OverlayManager {
     private func visiblePrimaryVibeCyclePillPanel() -> NSPanel? {
         guard let panel = window,
               panel.isVisible,
-              panel.contentView is NSHostingView<VibeCyclePillOverlay> else {
+              contentMode(for: panel) == .vibeCyclePill else {
             return nil
         }
         return panel
@@ -400,7 +430,7 @@ class OverlayManager {
     private func visibleAuxiliaryVibeCyclePillPanel() -> NSPanel? {
         guard let panel = vibeCyclePillWindow,
               panel.isVisible,
-              panel.contentView is NSHostingView<VibeCyclePillOverlay> else {
+              contentMode(for: panel) == .vibeCyclePill else {
             return nil
         }
         return panel
@@ -417,6 +447,25 @@ class OverlayManager {
         panel.onDragReleaseVelocity = { [weak self, weak panel] velocity in
             self?.handleFlingRelease(panel, velocity: velocity)
         }
+    }
+
+    private func makeDraggableHostingView<Content: View>(rootView: Content) -> NSView {
+        NSHostingView(
+            rootView: rootView.keyVoxWindowDragGesture(allowsActivationEvents: false)
+        )
+    }
+
+    private func setDraggableContentView<Content: View>(
+        rootView: Content,
+        mode: OverlayContentMode,
+        on panel: NSPanel
+    ) {
+        panel.contentView = makeDraggableHostingView(rootView: rootView)
+        contentModesByPanel[ObjectIdentifier(panel)] = mode
+    }
+
+    private func contentMode(for panel: NSPanel) -> OverlayContentMode? {
+        contentModesByPanel[ObjectIdentifier(panel)]
     }
 
     private func resizePanel(_ panel: NSPanel, to size: CGSize) {

--- a/macOS/Docs/CODEMAP.md
+++ b/macOS/Docs/CODEMAP.md
@@ -120,6 +120,7 @@ KeyVox/
 │   │   │   ├── SelectedVibeLabel.swift
 │   │   │   ├── UIComponents.swift
 │   │   │   ├── VibePillView.swift
+│   │   │   ├── WindowDragGestureModifier.swift
 │   │   │   └── SettingsLastTranscriptionCard.swift
 │   │   ├── StatusMenuView.swift
 │   │   ├── Onboarding/
@@ -296,6 +297,10 @@ KeyVox/
   - Shared macOS app-window theme tokens for settings, onboarding, updater, and related modal surfaces.
   - Owns the standard main-window background color (`#1A1740` equivalent) plus reusable card/icon/sidebar/stroke accents.
   - Explicitly excludes `StatusMenuView` and warning overlays from the shared theme boundary.
+- `Views/Components/WindowDragGestureModifier.swift`
+  - Shared window-dragging surface used by movable macOS windows and overlays.
+  - Uses `WindowDragGesture` on supported systems and falls back to AppKit `performDrag(with:)` on earlier supported macOS versions.
+  - Lets each caller choose whether dragging can activate a nonactive window.
 - `Views/Components/DictionaryFloatingAddButton.swift`
   - Shared floating circular add action used by the dictionary settings surface.
 - `Views/Components/LogoBarView.swift`

--- a/macOS/KeyVox.xcodeproj/project.pbxproj
+++ b/macOS/KeyVox.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		8E6D05E12F3C5246003BD458 /* KeyboardMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6D05CC2F3C51D6003BD458 /* KeyboardMonitor.swift */; };
 		8E6D05E22F3C5246003BD458 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6D05CB2F3C51D6003BD458 /* AudioRecorder.swift */; };
 		8E6D05E42F3C524B003BD458 /* UIComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E6D05D52F3C51D6003BD458 /* UIComponents.swift */; };
+		A7D9F0012FFF000100AA0001 /* WindowDragGestureModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D9F0022FFF000100AA0001 /* WindowDragGestureModifier.swift */; };
 		8E70C6ED2F623AFA00E9E555 /* updater.sh in Resources */ = {isa = PBXBuildFile; fileRef = 8E70C6EC2F623AFA00E9E555 /* updater.sh */; };
 		8E927F652F3C532800C071B3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8E6D05D02F3C51D6003BD458 /* Assets.xcassets */; };
 		8E927F662F3C532D00C071B3 /* Kanit-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8E6D05D12F3C51D6003BD458 /* Kanit-Medium.ttf */; };
@@ -277,6 +278,7 @@
 		8E6D05D02F3C51D6003BD458 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8E6D05D12F3C51D6003BD458 /* Kanit-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Kanit-Medium.ttf"; sourceTree = "<group>"; };
 		8E6D05D52F3C51D6003BD458 /* UIComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIComponents.swift; sourceTree = "<group>"; };
+		A7D9F0022FFF000100AA0001 /* WindowDragGestureModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragGestureModifier.swift; sourceTree = "<group>"; };
 		8E6D05D72F3C51D6003BD458 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		8E6D05D82F3C51D6003BD458 /* RecordingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingOverlay.swift; sourceTree = "<group>"; };
 		8E6D05DA2F3C51D6003BD458 /* StatusMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusMenuView.swift; sourceTree = "<group>"; };
@@ -616,6 +618,7 @@
 				8E4B08602FD0000100C5DB85 /* MacAppTheme.swift */,
 				E90000162FE1000100AA0001 /* SelectedVibeLabel.swift */,
 				8E6D05D52F3C51D6003BD458 /* UIComponents.swift */,
+				A7D9F0022FFF000100AA0001 /* WindowDragGestureModifier.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1185,6 +1188,7 @@
 				8F2202072F44010000BB2201 /* ConfirmDeletePromptView.swift in Sources */,
 				8E6D05DC2F3C523D003BD458 /* StatusMenuView.swift in Sources */,
 				8E6D05E42F3C524B003BD458 /* UIComponents.swift in Sources */,
+				A7D9F0012FFF000100AA0001 /* WindowDragGestureModifier.swift in Sources */,
 				8E4B085F2F45407E00C5DB85 /* TranscriptionManager.swift in Sources */,
 				8E4B08632FD0000200C5DB85 /* TranscriptionManager+Bindings.swift in Sources */,
 				8E4B08652FD0000300C5DB85 /* DictationTriggerController.swift in Sources */,

--- a/macOS/KeyVoxTests/Core/VibePillPresentationControllerTests.swift
+++ b/macOS/KeyVoxTests/Core/VibePillPresentationControllerTests.swift
@@ -1,5 +1,4 @@
 import AppKit
-import SwiftUI
 import XCTest
 @testable import KeyVox
 
@@ -146,7 +145,7 @@ final class VibePillPresentationControllerTests: XCTestCase {
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.02))
 
         let window = visibleCyclePillWindows.first
-        XCTAssertNotNil(window?.contentView as? NSHostingView<VibeCyclePillOverlay>)
+        XCTAssertNotNil(window?.contentView)
     }
 
     func testStandalonePillClearsVisibleCycleState() {
@@ -274,9 +273,7 @@ final class VibePillPresentationControllerTests: XCTestCase {
     }
 
     private var visibleCyclePillWindows: [NSWindow] {
-        visiblePillWindows.filter { window in
-            window.contentView is NSHostingView<VibeCyclePillOverlay>
-        }
+        OverlayManager.shared.isVibeCyclePillVisible ? visiblePillWindows : []
     }
 
     private var visibleStandalonePillWindowCount: Int {
@@ -284,19 +281,14 @@ final class VibePillPresentationControllerTests: XCTestCase {
     }
 
     private var visibleStandalonePillWindows: [NSWindow] {
-        visiblePillWindows.filter { window in
-            window.contentView is NSHostingView<OverlayPillOverlay<VibePillView>>
-        }
+        OverlayManager.shared.isVibeCyclePillVisible ? [] : visiblePillWindows
     }
 
     private var visiblePillWindows: [NSWindow] {
         NSApp.windows.filter { window in
             window.isVisible &&
-                window.frame.size == OverlayPillMetrics.panelSize &&
-                (
-                    window.contentView is NSHostingView<VibeCyclePillOverlay> ||
-                    window.contentView is NSHostingView<OverlayPillOverlay<VibePillView>>
-                )
+                window is NSPanel &&
+                window.frame.size == OverlayPillMetrics.panelSize
         }
     }
 

--- a/macOS/Views/Components/WindowDragGestureModifier.swift
+++ b/macOS/Views/Components/WindowDragGestureModifier.swift
@@ -1,0 +1,28 @@
+import AppKit
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func keyVoxWindowDragGesture(allowsActivationEvents: Bool) -> some View {
+        if #available(macOS 15.0, *) {
+            gesture(WindowDragGesture())
+                .allowsWindowActivationEvents(allowsActivationEvents)
+        } else {
+            background(LegacyWindowDragRegion())
+        }
+    }
+}
+
+private struct LegacyWindowDragRegion: NSViewRepresentable {
+    func makeNSView(context: Context) -> LegacyWindowDragRegionView {
+        LegacyWindowDragRegionView()
+    }
+
+    func updateNSView(_ nsView: LegacyWindowDragRegionView, context: Context) {}
+}
+
+private final class LegacyWindowDragRegionView: NSView {
+    override func mouseDown(with event: NSEvent) {
+        window?.performDrag(with: event)
+    }
+}

--- a/macOS/Views/Onboarding/OnboardingSetupScreen.swift
+++ b/macOS/Views/Onboarding/OnboardingSetupScreen.swift
@@ -140,7 +140,7 @@ struct OnboardingSetupScreen: View {
             }
             .padding(.leading, 25)
             .padding(.trailing, 30)
-            .padding(.top, 36)
+            .padding(.top, 46)
             .padding(.bottom, 20)
         }
         .fixedSize(horizontal: false, vertical: true)

--- a/macOS/Views/Settings/SettingsView.swift
+++ b/macOS/Views/Settings/SettingsView.swift
@@ -41,6 +41,22 @@ struct SettingsView: View {
                 // Content Area
                 contentView
             }
+
+            // Dedicated drag surface that does not participate in content layout.
+            VStack {
+                HStack(spacing: 0) {
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .keyVoxWindowDragGesture(allowsActivationEvents: true)
+
+                    Color.clear
+                        .frame(width: 64)
+                        .allowsHitTesting(false)
+                }
+                .frame(height: 54)
+
+                Spacer()
+            }
             
             // Close Button (Fixed at top right)
             VStack {

--- a/macOS/Views/Updates/UpdateWindowView.swift
+++ b/macOS/Views/Updates/UpdateWindowView.swift
@@ -1,4 +1,3 @@
-import AppKit
 import SwiftUI
 
 struct UpdateWindowView: View {
@@ -51,7 +50,8 @@ struct UpdateWindowView: View {
         VStack(alignment: .leading, spacing: 16) {
             AnimatedWaveHeader()
             .padding(.top, 10)
-            .background(WindowDragRegion())
+            .contentShape(Rectangle())
+            .keyVoxWindowDragGesture(allowsActivationEvents: true)
 
             UpdateHeaderCard(
                 currentVersion: coordinator.currentVersion,
@@ -107,19 +107,5 @@ struct UpdateWindowView: View {
                 coordinator.primaryAction()
             }
         }
-    }
-}
-
-private struct WindowDragRegion: NSViewRepresentable {
-    func makeNSView(context: Context) -> DragRegionView {
-        DragRegionView()
-    }
-
-    func updateNSView(_ nsView: DragRegionView, context: Context) {}
-}
-
-private final class DragRegionView: NSView {
-    override func mouseDown(with event: NSEvent) {
-        window?.performDrag(with: event)
     }
 }

--- a/macOS/Views/Warnings/WarningManager.swift
+++ b/macOS/Views/Warnings/WarningManager.swift
@@ -104,6 +104,7 @@ final class WarningManager {
         recoveryModel = model
         recoveryWindow?.contentView = NSHostingView(
             rootView: PasteFailureRecoveryOverlayView(model: model)
+                .keyVoxWindowDragGesture(allowsActivationEvents: false)
         )
 
         if let screen = NSScreen.main {


### PR DESCRIPTION
## Summary

Restores draggable windows for macOS 27.

- Add a shared macOS window-dragging modifier with a modern gesture and an earlier-system AppKit fallback.
- Apply draggable surfaces to onboarding, first-dictation onboarding, Vibes intro, settings, updates, warnings, and overlay windows.
- Track overlay content modes explicitly so Vibe pill window detection remains correct after wrapping content in draggable hosting views.
- Adjust the setup back-button placement and register/document the new shared component.
