### PR TITLE
fix(ios-models): normalize provider from complete state snapshots

### DIFF
--- a/iOS/KeyVox iOS/App/Composition/AppServiceRegistry.swift
+++ b/iOS/KeyVox iOS/App/Composition/AppServiceRegistry.swift
@@ -390,8 +390,8 @@ final class AppServiceRegistry {
             .store(in: &cancellables)
 
         modelManager.$modelStates
-            .sink { [weak self] _ in
-                self?.normalizeActiveProviderSelection()
+            .sink { [weak self] modelStates in
+                self?.normalizeActiveProviderSelection(using: modelStates)
             }
             .store(in: &cancellables)
 
@@ -407,7 +407,7 @@ final class AppServiceRegistry {
             }
             .store(in: &cancellables)
 
-        normalizeActiveProviderSelection()
+        normalizeActiveProviderSelection(using: modelManager.modelStates)
         normalizeTTSVoiceSelection()
     }
 
@@ -425,21 +425,22 @@ final class AppServiceRegistry {
         )
     }
 
-    private func normalizeActiveProviderSelection() {
+    private func normalizeActiveProviderSelection(
+        using modelStates: [DictationModelID: ModelInstallState]
+    ) {
         let selectedModelID = settingsStore.activeDictationProvider.modelID
-        if modelManager.activeInstallModelID() == selectedModelID {
+        switch modelStates[selectedModelID] ?? .notInstalled {
+        case .downloading, .installing, .ready:
             return
-        }
-
-        switch modelManager.state(for: selectedModelID) {
-        case .downloading, .installing, .ready, .failed:
-            return
-        case .notInstalled:
+        case .notInstalled, .failed:
             break
         }
 
         let readyProviders = AppSettingsStore.ActiveDictationProvider.allCases.filter {
-            modelManager.isModelReady(for: $0.modelID)
+            if case .ready = modelStates[$0.modelID] ?? .notInstalled {
+                return true
+            }
+            return false
         }
 
         if let fallback = readyProviders.first {

--- a/iOS/KeyVox iOS/Core/ModelDownloader/ModelManager+InstallLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/ModelDownloader/ModelManager+InstallLifecycle.swift
@@ -45,7 +45,10 @@ extension ModelManager {
         backgroundJobStore().load()
     }
 
-    func applyBackgroundJobStatus(_ job: ModelBackgroundDownloadJob) {
+    func applyBackgroundJobStatus(
+        _ job: ModelBackgroundDownloadJob,
+        to modelStates: inout [DictationModelID: ModelInstallState]
+    ) {
         let state: ModelInstallState
         if let message = job.lastErrorMessage, job.finalizationState == .failed {
             state = .failed(message: message)
@@ -68,7 +71,7 @@ extension ModelManager {
             )
         }
 
-        setState(state, for: job.modelID)
+        modelStates[job.modelID] = state
     }
 
     func startOrResumeDownloadJob(for modelID: DictationModelID) async {

--- a/iOS/KeyVox iOS/Core/ModelDownloader/ModelManager.swift
+++ b/iOS/KeyVox iOS/Core/ModelDownloader/ModelManager.swift
@@ -94,14 +94,16 @@ final class ModelManager: ObservableObject {
     }
 
     func refreshStatus() {
+        var refreshedModelStates = modelStates
         for modelID in DictationModelID.allCases {
-            modelStates[modelID] = validatedState(for: modelID)
+            refreshedModelStates[modelID] = validatedState(for: modelID)
         }
 
         if let backgroundJob = persistedBackgroundDownloadJob() {
-            applyBackgroundJobStatus(backgroundJob)
+            applyBackgroundJobStatus(backgroundJob, to: &refreshedModelStates)
         }
 
+        modelStates = refreshedModelStates
         syncLegacyWhisperState()
     }
 


### PR DESCRIPTION
## Summary

- Switch away from an unavailable active dictation model as soon as a complete model-state update arrives.
- Publish disk validation and persisted background-download status as one coherent snapshot.
- Preserve the selected provider while its model is ready, downloading, or installing.

## Problem

The iOS model manager refreshed its published dictionary one model at a time. The active-provider subscriber discarded the snapshot delivered by Combine and immediately read the manager again, which could still expose the previous value during publication.

This made model removal asymmetric. Removing Whisper appeared to fall back correctly because the later Parakeet refresh generated another notification. Removing Parakeet did not have a later model update, so Parakeet could remain selected until another refresh even when Whisper was already installed.

The refresh flow also published validated disk state before applying a persisted background-job overlay, exposing subscribers to a temporary state followed by a second update.

## Changes

- Build refreshed model states in a local dictionary before publishing them.
- Apply any persisted background-job state to that local dictionary before the single publication.
- Normalize the active provider from the exact snapshot supplied by the model-state publisher.
- Keep selections whose model is ready or actively downloading or installing.
- Fall back to an installed provider when the selected model becomes unavailable or fails.

## Result

Deleting the active Parakeet model now immediately selects an installed Whisper model. Subscribers receive one completed view of model availability, including any active background installation, instead of observing partial refresh state.
