### PR TITLE
fix(text-composition): add missing spaces before existing text during dictation

### DIFF
--- a/Packages/KeyVoxTextComposition/CHANGELOG.md
+++ b/Packages/KeyVoxTextComposition/CHANGELOG.md
@@ -8,19 +8,21 @@ The format loosely follows Keep a Changelog, and the package uses semantic versi
 
 ## [1.0.3] - 2026-08-22
 
-Composed dictated terminal marks with punctuation immediately following replaced text.
+Composed dictated terminal marks and missing separators with text immediately following an insertion.
 
 ### Includes
 
 - Removed an incoming model-added period when supported non-quote punctuation already follows the selected text.
 - Reused a matching question mark or exclamation point and replaced differing supported non-quote punctuation when processed dictation explicitly ends with either mark.
 - Left incoming terminal punctuation unchanged before straight or curly quotation marks.
+- Added one trailing space when dictated text would otherwise run into an existing letter, number, or emoji.
+- Left trailing spacing unchanged before punctuation, symbols, whitespace, or no following text, and when the dictated text already ends in whitespace.
 - Shared the punctuation-boundary decision across macOS and iOS composition paths.
-- Added regression coverage for model periods, explicit question marks and exclamation points, supported non-quote punctuation, and quotation-mark boundaries.
+- Added regression coverage for model periods, explicit question marks and exclamation points, supported non-quote punctuation, quotation-mark boundaries, and missing trailing separators.
 
 ### Notes
 
-- `1.0.3` bumps the tracked patch version for punctuation-aware selected-text composition.
+- `1.0.3` bumps the tracked patch version for punctuation-aware composition and missing trailing separators.
 
 ## [1.0.2] - 2026-08-08
 

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionCharacterClassifier.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionCharacterClassifier.swift
@@ -1,0 +1,12 @@
+enum TextCompositionCharacterClassifier {
+    static func isEmoji(_ character: Character) -> Bool {
+        let scalars = Array(character.unicodeScalars)
+        guard let baseScalar = scalars.first else { return false }
+        if baseScalar.properties.isEmojiPresentation {
+            return true
+        }
+
+        return baseScalar.properties.isEmoji
+            && scalars.dropFirst().first?.value == 0xFE0F
+    }
+}

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
@@ -215,7 +215,7 @@ public enum TextCompositionPolicy {
         _ context: TextCompositionContext
     ) -> Bool {
         guard let previousNonWhitespaceCharacter = context.previousNonWhitespaceCharacter,
-              isEmojiCharacter(previousNonWhitespaceCharacter) else {
+              TextCompositionCharacterClassifier.isEmoji(previousNonWhitespaceCharacter) else {
             return false
         }
 
@@ -312,17 +312,6 @@ public enum TextCompositionPolicy {
         )
         return previousIsWordLike
             || previousIsTriggerPunctuation
-            || isEmojiCharacter(previousCharacter)
-    }
-
-    private static func isEmojiCharacter(_ character: Character) -> Bool {
-        let scalars = Array(character.unicodeScalars)
-        guard let baseScalar = scalars.first else { return false }
-        if baseScalar.properties.isEmojiPresentation {
-            return true
-        }
-
-        return baseScalar.properties.isEmoji
-            && scalars.dropFirst().first?.value == 0xFE0F
+            || TextCompositionCharacterClassifier.isEmoji(previousCharacter)
     }
 }

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TrailingSeparatorCompositionPolicy.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TrailingSeparatorCompositionPolicy.swift
@@ -1,0 +1,17 @@
+public enum TrailingSeparatorCompositionPolicy {
+    public static func applyIfNeeded(
+        to text: String,
+        followingCharacter: Character?
+    ) -> String {
+        guard let followingCharacter,
+              followingCharacter.isLetter
+                || followingCharacter.isNumber
+                || TextCompositionCharacterClassifier.isEmoji(followingCharacter),
+              let incomingLastCharacter = text.last,
+              incomingLastCharacter.isWhitespace == false else {
+            return text
+        }
+
+        return text + " "
+    }
+}

--- a/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TrailingSeparatorCompositionPolicyTests.swift
+++ b/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TrailingSeparatorCompositionPolicyTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import KeyVoxTextComposition
+
+final class TrailingSeparatorCompositionPolicyTests: XCTestCase {
+    func testAddsSeparatorBeforeFollowingWordNumberOrEmoji() {
+        for testCase in [
+            (text: "What's up?", followingCharacter: Character("T"), expected: "What's up? "),
+            (text: "That's awesome.", followingCharacter: Character("Y"), expected: "That's awesome. "),
+            (text: "definitely", followingCharacter: Character("a"), expected: "definitely "),
+            (text: "Version", followingCharacter: Character("2"), expected: "Version "),
+            (text: "Nice", followingCharacter: Character("😎"), expected: "Nice "),
+            (text: "Great", followingCharacter: Character("❤️"), expected: "Great "),
+        ] {
+            XCTAssertEqual(
+                TrailingSeparatorCompositionPolicy.applyIfNeeded(
+                    to: testCase.text,
+                    followingCharacter: testCase.followingCharacter
+                ),
+                testCase.expected
+            )
+        }
+    }
+
+    func testDoesNotAddSeparatorBeforeFollowingPunctuation() {
+        for punctuation in [
+            Character("."), Character(","), Character("?"), Character("!"),
+            Character(":"), Character(";"), Character(")"), Character("—"),
+            Character("…"), Character("\""), Character("”"),
+        ] {
+            XCTAssertEqual(
+                TrailingSeparatorCompositionPolicy.applyIfNeeded(
+                    to: "word",
+                    followingCharacter: punctuation
+                ),
+                "word"
+            )
+        }
+    }
+
+    func testDoesNotAddSeparatorWhenWhitespaceOrNoTextFollows() {
+        for followingCharacter in [Character(" "), Character("\n"), Character("\t")] {
+            XCTAssertEqual(
+                TrailingSeparatorCompositionPolicy.applyIfNeeded(
+                    to: "word",
+                    followingCharacter: followingCharacter
+                ),
+                "word"
+            )
+        }
+
+        XCTAssertEqual(
+            TrailingSeparatorCompositionPolicy.applyIfNeeded(
+                to: "word",
+                followingCharacter: nil
+            ),
+            "word"
+        )
+    }
+
+    func testDoesNotDuplicateExistingTrailingWhitespace() {
+        XCTAssertEqual(
+            TrailingSeparatorCompositionPolicy.applyIfNeeded(
+                to: "word ",
+                followingCharacter: "f"
+            ),
+            "word "
+        )
+    }
+}

--- a/iOS/KeyVox Keyboard/Core/Input/KeyboardTextInputController.swift
+++ b/iOS/KeyVox Keyboard/Core/Input/KeyboardTextInputController.swift
@@ -180,7 +180,10 @@ final class KeyboardTextInputController {
             text: preparedText,
             followingCharacter: followingCharacter
         )
-        let insertionText = punctuationResolution.text
+        let insertionText = TrailingSeparatorCompositionPolicy.applyIfNeeded(
+            to: punctuationResolution.text,
+            followingCharacter: followingCharacter
+        )
         documentProxy.insertText(insertionText)
         if punctuationResolution.shouldReplaceFollowingPunctuation {
             documentProxy.adjustTextPosition(byCharacterOffset: 1)

--- a/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardTextInputControllerTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardTextInputControllerTests.swift
@@ -272,6 +272,69 @@ struct KeyboardTextInputControllerTests {
         }
     }
 
+    @Test func transcriptionInsertionAddsTrailingSeparatorBeforeExistingWordText() {
+        let insertionCases = [
+            (
+                original: "That's cool.",
+                followingText: "That's cool.",
+                transcription: "What's up?",
+                expected: "What's up? That's cool."
+            ),
+            (
+                original: "You're good.",
+                followingText: "You're good.",
+                transcription: "That's awesome.",
+                expected: "That's awesome. You're good."
+            ),
+            (
+                original: "That's awesome.",
+                followingText: "awesome.",
+                transcription: "definitely",
+                expected: "That's definitely awesome."
+            ),
+            (
+                original: "😎",
+                followingText: "😎",
+                transcription: "Nice",
+                expected: "Nice 😎"
+            ),
+        ]
+        for testCase in insertionCases {
+            let documentProxy = StatefulSelectionDocumentProxy(
+                text: testCase.original,
+                caretBefore: testCase.followingText
+            )
+            let controller = KeyboardTextInputController(
+                documentProxy: documentProxy,
+                emitKeypress: {}
+            )
+
+            let inserted = controller.insertTranscription(testCase.transcription)
+
+            #expect(inserted == true)
+            #expect(documentProxy.text == testCase.expected)
+        }
+    }
+
+    @Test func transcriptionInsertionDoesNotAddTrailingSeparatorBeforePunctuation() {
+        for punctuation in [".", ",", "?", "!", ":", ";"] {
+            let original = "That's\(punctuation)"
+            let documentProxy = StatefulSelectionDocumentProxy(
+                text: original,
+                caretBefore: punctuation
+            )
+            let controller = KeyboardTextInputController(
+                documentProxy: documentProxy,
+                emitKeypress: {}
+            )
+
+            let inserted = controller.insertTranscription("definitely")
+
+            #expect(inserted == true)
+            #expect(documentProxy.text == "That's definitely\(punctuation)")
+        }
+    }
+
     @Test func transcriptionRepairsStaleSpaceAfterDeletingSelection() {
         let documentProxy = KeyboardTextDocumentProxySpy()
         documentProxy.documentContextBeforeInput = "Previous sentence. "
@@ -626,6 +689,15 @@ private final class StatefulSelectionDocumentProxy: KeyboardTextDocumentProxying
         let upperBound = text.distance(from: text.startIndex, to: selectedRange.upperBound)
         selection = lowerBound..<upperBound
         caretLocation = lowerBound
+    }
+
+    init(text: String, caretBefore followingText: String) {
+        characters = Array(text)
+        guard let followingRange = text.range(of: followingText) else {
+            preconditionFailure("Following test text must exist in the document")
+        }
+        selection = nil
+        caretLocation = text.distance(from: text.startIndex, to: followingRange.lowerBound)
     }
 
     var text: String { String(characters) }

--- a/macOS/Core/Services/Paste/Composition/PasteTerminalPunctuationCoordinator.swift
+++ b/macOS/Core/Services/Paste/Composition/PasteTerminalPunctuationCoordinator.swift
@@ -4,6 +4,7 @@ import KeyVoxTextComposition
 struct PasteTerminalPunctuationInsertion {
     let text: String
     let targetElement: AXUIElement?
+    let followingCharacter: Character?
 }
 
 protocol PasteTerminalPunctuationCoordinating {
@@ -19,11 +20,25 @@ final class PasteTerminalPunctuationCoordinator: PasteTerminalPunctuationCoordin
 
     func resolveAdjacentTerminalPunctuation(in text: String) -> PasteTerminalPunctuationInsertion {
         guard let targetElement = axInspector.focusedUIElement() else {
-            return PasteTerminalPunctuationInsertion(text: text, targetElement: nil)
+            return PasteTerminalPunctuationInsertion(
+                text: text,
+                targetElement: nil,
+                followingCharacter: nil
+            )
         }
-        guard let context = axInspector.insertionContext(for: targetElement),
-              let selectionLength = context.selectionLength else {
-            return PasteTerminalPunctuationInsertion(text: text, targetElement: targetElement)
+        guard let context = axInspector.insertionContext(for: targetElement) else {
+            return PasteTerminalPunctuationInsertion(
+                text: text,
+                targetElement: targetElement,
+                followingCharacter: nil
+            )
+        }
+        guard let selectionLength = context.selectionLength else {
+            return PasteTerminalPunctuationInsertion(
+                text: text,
+                targetElement: targetElement,
+                followingCharacter: context.followingCharacter
+            )
         }
 
         let resolution = TerminalPunctuationCompositionPolicy.resolve(
@@ -33,7 +48,8 @@ final class PasteTerminalPunctuationCoordinator: PasteTerminalPunctuationCoordin
         guard resolution.shouldReplaceFollowingPunctuation else {
             return PasteTerminalPunctuationInsertion(
                 text: resolution.text,
-                targetElement: targetElement
+                targetElement: targetElement,
+                followingCharacter: context.followingCharacter
             )
         }
         guard let selectionLocation = context.caretLocation,
@@ -43,12 +59,14 @@ final class PasteTerminalPunctuationCoordinator: PasteTerminalPunctuationCoordin
               ) else {
             return PasteTerminalPunctuationInsertion(
                 text: String(resolution.text.dropLast()),
-                targetElement: targetElement
+                targetElement: targetElement,
+                followingCharacter: context.followingCharacter
             )
         }
         return PasteTerminalPunctuationInsertion(
             text: resolution.text,
-            targetElement: targetElement
+            targetElement: targetElement,
+            followingCharacter: context.followingCharacter
         )
     }
 }

--- a/macOS/Core/Services/Paste/MenuFallback/PasteMenuFallbackCoordinator.swift
+++ b/macOS/Core/Services/Paste/MenuFallback/PasteMenuFallbackCoordinator.swift
@@ -2,17 +2,20 @@ import Cocoa
 
 struct PasteMenuFallbackExecutionResult {
     let didMenuFallbackInsert: Bool
+    let didCompleteInsertion: Bool
     let menuAttempt: PasteMenuFallbackAttemptResult?
     let completionEvidence: PasteMenuFallbackCompletionEvidence
     let suppressFirstWarmupFailureWarning: Bool
 
     init(
         didMenuFallbackInsert: Bool,
+        didCompleteInsertion: Bool? = nil,
         menuAttempt: PasteMenuFallbackAttemptResult?,
         completionEvidence: PasteMenuFallbackCompletionEvidence = .none,
         suppressFirstWarmupFailureWarning: Bool
     ) {
         self.didMenuFallbackInsert = didMenuFallbackInsert
+        self.didCompleteInsertion = didCompleteInsertion ?? didMenuFallbackInsert
         self.menuAttempt = menuAttempt
         self.completionEvidence = completionEvidence
         self.suppressFirstWarmupFailureWarning = suppressFirstWarmupFailureWarning
@@ -201,12 +204,11 @@ final class PasteMenuFallbackCoordinator {
             )
         }
 
-        if didMenuFallbackInsert,
-           completionEvidence != .trustedWithoutVerification,
-           transport.trailingSpacesToType > 0 {
-            _ = typeTrailingSpacesOnMainThread(
-                transport.trailingSpacesToType
-            )
+        var didCompleteInsertion = didMenuFallbackInsert
+        if didMenuFallbackInsert, transport.trailingSpacesToType > 0 {
+            didCompleteInsertion = completionEvidence != .trustedWithoutVerification
+                && (typeTrailingSpacesOnMainThread(transport.trailingSpacesToType)
+                    || typeTrailingSpacesOnMainThread(transport.trailingSpacesToType))
         }
 
         let suppressFirstWarmupFailureWarning = Self.shouldSuppressFailureWarningForFirstMenuSuccessAttempt(
@@ -218,6 +220,7 @@ final class PasteMenuFallbackCoordinator {
 
         return PasteMenuFallbackExecutionResult(
             didMenuFallbackInsert: didMenuFallbackInsert,
+            didCompleteInsertion: didCompleteInsertion,
             menuAttempt: menuAttempt,
             completionEvidence: completionEvidence,
             suppressFirstWarmupFailureWarning: suppressFirstWarmupFailureWarning

--- a/macOS/Core/Services/Paste/MenuFallback/PasteMenuFallbackCoordinator.swift
+++ b/macOS/Core/Services/Paste/MenuFallback/PasteMenuFallbackCoordinator.swift
@@ -27,7 +27,8 @@ protocol PasteMenuFallbackCoordinating {
         menuFallbackExecutor: PasteMenuFallbackExecuting,
         shouldTrustMenuSuccessWithoutAXVerification: () -> Bool,
         setClipboardStringOnMainThread: (String) -> Void,
-        executeLeadingSpacePasteOnMainThread: (Int) -> Bool
+        executeLeadingSpacePasteOnMainThread: (Int) -> Bool,
+        typeTrailingSpacesOnMainThread: (Int) -> Bool
     ) -> PasteMenuFallbackExecutionResult
 }
 
@@ -58,7 +59,8 @@ final class PasteMenuFallbackCoordinator {
         menuFallbackExecutor: PasteMenuFallbackExecuting,
         shouldTrustMenuSuccessWithoutAXVerification: () -> Bool,
         setClipboardStringOnMainThread: (String) -> Void,
-        executeLeadingSpacePasteOnMainThread: (Int) -> Bool
+        executeLeadingSpacePasteOnMainThread: (Int) -> Bool,
+        typeTrailingSpacesOnMainThread: (Int) -> Bool
     ) -> PasteMenuFallbackExecutionResult {
         #if DEBUG
         print("Accessibility injection failed/skipped. Triggering paste fallback...")
@@ -70,7 +72,11 @@ final class PasteMenuFallbackCoordinator {
         var isFirstMenuSuccessAttemptForProcess = false
 
         let transport = didAccessibilityInsertText
-            ? PasteMenuFallbackTransport(leadingSpacesToType: 0, textToPaste: insertionText)
+            ? PasteMenuFallbackTransport(
+                leadingSpacesToType: 0,
+                textToPaste: insertionText,
+                trailingSpacesToType: 0
+            )
             : menuFallbackTransport(for: insertionText)
         let textForMenuPaste = transport.textToPaste
         var didTypeLeadingSpaces = false
@@ -192,6 +198,14 @@ final class PasteMenuFallbackCoordinator {
                 trustMenuSuccessWithoutAXVerification: trustWithoutAXVerification,
                 verificationOutcome: verificationOutcome,
                 didObservePostMenuLiveValueChange: didObservePostMenuLiveValueChange
+            )
+        }
+
+        if didMenuFallbackInsert,
+           completionEvidence != .trustedWithoutVerification,
+           transport.trailingSpacesToType > 0 {
+            _ = typeTrailingSpacesOnMainThread(
+                transport.trailingSpacesToType
             )
         }
 
@@ -341,12 +355,14 @@ final class PasteMenuFallbackCoordinator {
 
     private func menuFallbackTransport(for text: String) -> PasteMenuFallbackTransport {
         let leadingSpaces = text.prefix { $0 == " " }.count
-        guard leadingSpaces > 0 else {
-            return PasteMenuFallbackTransport(leadingSpacesToType: 0, textToPaste: text)
-        }
-
-        let remainingText = String(text.dropFirst(leadingSpaces))
-        return PasteMenuFallbackTransport(leadingSpacesToType: leadingSpaces, textToPaste: remainingText)
+        let textAfterLeadingSpaces = text.dropFirst(leadingSpaces)
+        let trailingSpaces = textAfterLeadingSpaces.reversed().prefix { $0 == " " }.count
+        let textToPaste = textAfterLeadingSpaces.dropLast(trailingSpaces)
+        return PasteMenuFallbackTransport(
+            leadingSpacesToType: leadingSpaces,
+            textToPaste: String(textToPaste),
+            trailingSpacesToType: trailingSpaces
+        )
     }
 }
 

--- a/macOS/Core/Services/Paste/PasteService.swift
+++ b/macOS/Core/Services/Paste/PasteService.swift
@@ -178,6 +178,7 @@ class PasteService {
             #endif
 
             var didMenuFallbackInsert = false
+            var didCompleteInsertion = true
             var suppressFirstWarmupFailureWarning = false
             var menuFallbackCompletionEvidence: PasteMenuFallbackCompletionEvidence = .none
             if accessibilityDecision.needsMenuFallback {
@@ -196,6 +197,7 @@ class PasteService {
                     }
                 )
                 didMenuFallbackInsert = menuFallbackExecution.didMenuFallbackInsert
+                didCompleteInsertion = menuFallbackExecution.didCompleteInsertion
                 suppressFirstWarmupFailureWarning = menuFallbackExecution.suppressFirstWarmupFailureWarning
                 menuFallbackCompletionEvidence = menuFallbackExecution.completionEvidence
                 #if DEBUG
@@ -216,7 +218,7 @@ class PasteService {
                 restoreDelayAfterMenuFallback: self.restoreDelayAfterMenuFallback
             )
 
-            if executionPlan.shouldRememberInsertion {
+            if executionPlan.shouldRememberInsertion, didCompleteInsertion {
                 self.rememberSuccessfulInsertion(of: insertionText, in: targetAppIdentity)
             }
 

--- a/macOS/Core/Services/Paste/PasteService.swift
+++ b/macOS/Core/Services/Paste/PasteService.swift
@@ -1,6 +1,7 @@
 import Cocoa
 import Carbon.HIToolbox
 import KeyVoxCore
+import KeyVoxTextComposition
 
 class PasteService {
     static let shared = PasteService()
@@ -138,11 +139,22 @@ class PasteService {
         pasteQueue.async {
             let punctuationInsertion = self.terminalPunctuationCoordinator
                 .resolveAdjacentTerminalPunctuation(in: spacingNormalizedText)
-            let insertionText = punctuationInsertion.text
+            let punctuationNormalizedText = punctuationInsertion.text
             #if DEBUG
             self.logNormalizationStage(
                 "terminalPunctuationNormalized",
                 input: spacingNormalizedText,
+                output: punctuationNormalizedText
+            )
+            #endif
+            let insertionText = TrailingSeparatorCompositionPolicy.applyIfNeeded(
+                to: punctuationNormalizedText,
+                followingCharacter: punctuationInsertion.followingCharacter
+            )
+            #if DEBUG
+            self.logNormalizationStage(
+                "trailingSeparatorNormalized",
+                input: punctuationNormalizedText,
                 output: insertionText
             )
             #endif
@@ -178,6 +190,9 @@ class PasteService {
                     setClipboardStringOnMainThread: { self.setClipboardStringOnMainThread($0) },
                     executeLeadingSpacePasteOnMainThread: {
                         self.executeLeadingSpacePasteOnMainThread(count: $0)
+                    },
+                    typeTrailingSpacesOnMainThread: {
+                        self.typeTrailingSpacesOnMainThread(count: $0)
                     }
                 )
                 didMenuFallbackInsert = menuFallbackExecution.didMenuFallbackInsert
@@ -352,6 +367,9 @@ class PasteService {
             setClipboardStringOnMainThread: { self.setClipboardStringOnMainThread($0) },
             executeLeadingSpacePasteOnMainThread: {
                 self.executeLeadingSpacePasteOnMainThread(count: $0)
+            },
+            typeTrailingSpacesOnMainThread: {
+                self.typeTrailingSpacesOnMainThread(count: $0)
             }
         )
 
@@ -523,24 +541,7 @@ class PasteService {
     private func executeLeadingSpacePaste(count: Int) -> Bool {
         guard count > 0 else { return true }
         guard let source = CGEventSource(stateID: .combinedSessionState) else { return false }
-
-        var events: [CGEvent] = []
-
-        for _ in 0..<count {
-            guard let keyDown = CGEvent(
-                keyboardEventSource: source,
-                virtualKey: CGKeyCode(kVK_Space),
-                keyDown: true
-            ),
-                  let keyUp = CGEvent(
-                    keyboardEventSource: source,
-                    virtualKey: CGKeyCode(kVK_Space),
-                    keyDown: false
-                  ) else {
-                return false
-            }
-            events.append(contentsOf: [keyDown, keyUp])
-        }
+        guard var events = spaceEvents(count: count, source: source) else { return false }
 
         guard let commandDown = CGEvent(
             keyboardEventSource: source,
@@ -572,5 +573,47 @@ class PasteService {
         events.forEach { $0.post(tap: .cghidEventTap) }
 
         return true
+    }
+
+    private func typeTrailingSpacesOnMainThread(count: Int) -> Bool {
+        if Thread.isMainThread {
+            return typeSpaces(count: count)
+        }
+
+        var didSucceed = false
+        DispatchQueue.main.sync {
+            didSucceed = typeSpaces(count: count)
+        }
+        return didSucceed
+    }
+
+    private func typeSpaces(count: Int) -> Bool {
+        guard count > 0 else { return true }
+        guard let source = CGEventSource(stateID: .combinedSessionState),
+              let events = spaceEvents(count: count, source: source) else {
+            return false
+        }
+        events.forEach { $0.post(tap: .cghidEventTap) }
+        return true
+    }
+
+    private func spaceEvents(count: Int, source: CGEventSource) -> [CGEvent]? {
+        var events: [CGEvent] = []
+        for _ in 0..<count {
+            guard let keyDown = CGEvent(
+                keyboardEventSource: source,
+                virtualKey: CGKeyCode(kVK_Space),
+                keyDown: true
+            ),
+                  let keyUp = CGEvent(
+                    keyboardEventSource: source,
+                    virtualKey: CGKeyCode(kVK_Space),
+                    keyDown: false
+                  ) else {
+                return nil
+            }
+            events.append(contentsOf: [keyDown, keyUp])
+        }
+        return events
     }
 }

--- a/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
+++ b/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
@@ -49,6 +49,7 @@ enum PasteAccessibilityInjectionOutcome {
 struct PasteMenuFallbackTransport {
     let leadingSpacesToType: Int
     let textToPaste: String
+    let trailingSpacesToType: Int
 }
 
 enum PasteMenuFallbackAttemptResult {

--- a/macOS/KeyVoxTests/Services/DictationPipelineSmokeTests.swift
+++ b/macOS/KeyVoxTests/Services/DictationPipelineSmokeTests.swift
@@ -510,7 +510,8 @@ private final class StubMenuFallbackCoordinator: PasteMenuFallbackCoordinating {
         menuFallbackExecutor: PasteMenuFallbackExecuting,
         shouldTrustMenuSuccessWithoutAXVerification: () -> Bool,
         setClipboardStringOnMainThread: (String) -> Void,
-        executeLeadingSpacePasteOnMainThread: (Int) -> Bool
+        executeLeadingSpacePasteOnMainThread: (Int) -> Bool,
+        typeTrailingSpacesOnMainThread: (Int) -> Bool
     ) -> PasteMenuFallbackExecutionResult {
         _ = insertionText
         _ = didAccessibilityInsertText
@@ -519,6 +520,7 @@ private final class StubMenuFallbackCoordinator: PasteMenuFallbackCoordinating {
         _ = shouldTrustMenuSuccessWithoutAXVerification
         _ = setClipboardStringOnMainThread
         _ = executeLeadingSpacePasteOnMainThread
+        _ = typeTrailingSpacesOnMainThread
         executeCalls += 1
         return result
     }

--- a/macOS/KeyVoxTests/Services/PasteMenuFallbackCoordinatorExecutionTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteMenuFallbackCoordinatorExecutionTests.swift
@@ -16,7 +16,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: executor,
             shouldTrustMenuSuccessWithoutAXVerification: { false },
             setClipboardStringOnMainThread: { clipboardWrites.append($0) },
-            executeLeadingSpacePasteOnMainThread: { _ in true }
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         XCTAssertTrue(result.didMenuFallbackInsert)
@@ -37,7 +38,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: executor,
             shouldTrustMenuSuccessWithoutAXVerification: { false },
             setClipboardStringOnMainThread: { _ in },
-            executeLeadingSpacePasteOnMainThread: { _ in false }
+            executeLeadingSpacePasteOnMainThread: { _ in false },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         XCTAssertFalse(result.didMenuFallbackInsert)
@@ -61,16 +63,140 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
                 operations.append("clipboard:\($0)")
             },
             executeLeadingSpacePasteOnMainThread: { count in
-                operations.append("keyboard:\(count)")
+                operations.append("leadingPaste:\(count)")
+                return true
+            },
+            typeTrailingSpacesOnMainThread: { count in
+                operations.append("trailing:\(count)")
                 return true
             }
         )
 
         XCTAssertTrue(result.didMenuFallbackInsert)
         XCTAssertEqual(result.completionEvidence, .expectedPayloadObserved)
-        XCTAssertEqual(operations, ["clipboard:hello", "keyboard:1"])
+        XCTAssertEqual(operations, ["clipboard:hello", "leadingPaste:1"])
         XCTAssertEqual(executor.pasteViaMenuBarCalls, 0)
         XCTAssertEqual(executor.verifyInsertionCalls, 1)
+    }
+
+    func testTrailingSpacesWaitForVerifiedPasteBeforeTyping() {
+        let coordinator = PasteMenuFallbackCoordinator()
+        let executor = MockPasteMenuFallbackExecutor()
+        executor.pasteResult = .actionSucceeded
+        executor.verificationContext = sampleVerificationContext()
+        executor.verifyInsertionOutcomeResult = .expectedPayloadObserved
+        var operations: [String] = []
+        executor.onPaste = { operations.append("menuPaste") }
+        executor.onVerifyInsertion = { operations.append("verify") }
+
+        let result = coordinator.executeMenuFallback(
+            insertionText: "hello ",
+            didAccessibilityInsertText: false,
+            targetAppIdentity: identity("com.example.app", 1),
+            menuFallbackExecutor: executor,
+            shouldTrustMenuSuccessWithoutAXVerification: { false },
+            setClipboardStringOnMainThread: {
+                operations.append("clipboard:\($0)")
+            },
+            executeLeadingSpacePasteOnMainThread: { count in
+                operations.append("leadingPaste:\(count)")
+                return true
+            },
+            typeTrailingSpacesOnMainThread: { count in
+                operations.append("trailing:\(count)")
+                return true
+            }
+        )
+
+        XCTAssertTrue(result.didMenuFallbackInsert)
+        XCTAssertEqual(result.completionEvidence, .expectedPayloadObserved)
+        XCTAssertEqual(operations, ["clipboard:hello", "menuPaste", "verify", "trailing:1"])
+        XCTAssertEqual(executor.pasteViaMenuBarCalls, 1)
+        XCTAssertEqual(executor.verifyInsertionCalls, 1)
+    }
+
+    func testTrailingSpacesAreNotTypedWhenPasteIsNotObserved() {
+        let coordinator = PasteMenuFallbackCoordinator()
+        let executor = MockPasteMenuFallbackExecutor()
+        executor.pasteResult = .actionSucceeded
+        executor.verificationContext = sampleVerificationContext()
+        executor.verifyInsertionOutcomeResult = .none
+        var trailingSpaceCounts: [Int] = []
+
+        let result = coordinator.executeMenuFallback(
+            insertionText: "hello ",
+            didAccessibilityInsertText: false,
+            targetAppIdentity: identity("com.example.app", 1),
+            menuFallbackExecutor: executor,
+            shouldTrustMenuSuccessWithoutAXVerification: { false },
+            setClipboardStringOnMainThread: { _ in },
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: {
+                trailingSpaceCounts.append($0)
+                return true
+            }
+        )
+
+        XCTAssertFalse(result.didMenuFallbackInsert)
+        XCTAssertEqual(result.completionEvidence, .none)
+        XCTAssertTrue(trailingSpaceCounts.isEmpty)
+    }
+
+    func testTrailingSpacesAreNotTypedWithoutPasteCompletionEvidence() {
+        let coordinator = PasteMenuFallbackCoordinator()
+        let executor = MockPasteMenuFallbackExecutor()
+        executor.pasteResult = .actionSucceeded
+        var trailingSpaceCounts: [Int] = []
+
+        let result = coordinator.executeMenuFallback(
+            insertionText: "hello ",
+            didAccessibilityInsertText: false,
+            targetAppIdentity: identity("com.example.app", 1),
+            menuFallbackExecutor: executor,
+            shouldTrustMenuSuccessWithoutAXVerification: { true },
+            setClipboardStringOnMainThread: { _ in },
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: {
+                trailingSpaceCounts.append($0)
+                return true
+            }
+        )
+
+        XCTAssertTrue(result.didMenuFallbackInsert)
+        XCTAssertEqual(result.completionEvidence, .trustedWithoutVerification)
+        XCTAssertTrue(trailingSpaceCounts.isEmpty)
+    }
+
+    func testLeadingAndTrailingSpacesPreserveVerifiedInsertionOrder() {
+        let coordinator = PasteMenuFallbackCoordinator()
+        let executor = MockPasteMenuFallbackExecutor()
+        executor.verificationContext = sampleVerificationContext()
+        executor.verifyInsertionOutcomeResult = .expectedPayloadObserved
+        var operations: [String] = []
+        executor.onVerifyInsertion = { operations.append("verify") }
+
+        let result = coordinator.executeMenuFallback(
+            insertionText: " hello ",
+            didAccessibilityInsertText: false,
+            targetAppIdentity: identity("com.example.app", 1),
+            menuFallbackExecutor: executor,
+            shouldTrustMenuSuccessWithoutAXVerification: { false },
+            setClipboardStringOnMainThread: {
+                operations.append("clipboard:\($0)")
+            },
+            executeLeadingSpacePasteOnMainThread: { count in
+                operations.append("leadingPaste:\(count)")
+                return true
+            },
+            typeTrailingSpacesOnMainThread: { count in
+                operations.append("trailing:\(count)")
+                return true
+            }
+        )
+
+        XCTAssertTrue(result.didMenuFallbackInsert)
+        XCTAssertEqual(operations, ["clipboard:hello", "leadingPaste:1", "verify", "trailing:1"])
+        XCTAssertEqual(executor.pasteViaMenuBarCalls, 0)
     }
 
     func testUnavailableMenuAttemptReturnsNoInsertion() {
@@ -85,7 +211,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: executor,
             shouldTrustMenuSuccessWithoutAXVerification: { false },
             setClipboardStringOnMainThread: { _ in },
-            executeLeadingSpacePasteOnMainThread: { _ in true }
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         XCTAssertFalse(result.didMenuFallbackInsert)
@@ -105,7 +232,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: executor,
             shouldTrustMenuSuccessWithoutAXVerification: { true },
             setClipboardStringOnMainThread: { _ in },
-            executeLeadingSpacePasteOnMainThread: { _ in true }
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         XCTAssertTrue(result.didMenuFallbackInsert)
@@ -129,7 +257,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: executor,
             shouldTrustMenuSuccessWithoutAXVerification: { false },
             setClipboardStringOnMainThread: { _ in },
-            executeLeadingSpacePasteOnMainThread: { _ in true }
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         XCTAssertTrue(result.didMenuFallbackInsert)
@@ -152,7 +281,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: executor,
             shouldTrustMenuSuccessWithoutAXVerification: { false },
             setClipboardStringOnMainThread: { _ in },
-            executeLeadingSpacePasteOnMainThread: { _ in true }
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         XCTAssertTrue(result.didMenuFallbackInsert)
@@ -177,7 +307,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: executor,
             shouldTrustMenuSuccessWithoutAXVerification: { false },
             setClipboardStringOnMainThread: { _ in },
-            executeLeadingSpacePasteOnMainThread: { _ in true }
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         XCTAssertTrue(result.didMenuFallbackInsert)
@@ -202,7 +333,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: executor,
             shouldTrustMenuSuccessWithoutAXVerification: { false },
             setClipboardStringOnMainThread: { _ in },
-            executeLeadingSpacePasteOnMainThread: { _ in true }
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         XCTAssertTrue(result.didMenuFallbackInsert)
@@ -224,7 +356,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: executor,
             shouldTrustMenuSuccessWithoutAXVerification: { false },
             setClipboardStringOnMainThread: { _ in },
-            executeLeadingSpacePasteOnMainThread: { _ in true }
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         XCTAssertFalse(result.didMenuFallbackInsert)
@@ -247,7 +380,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: executor,
             shouldTrustMenuSuccessWithoutAXVerification: { false },
             setClipboardStringOnMainThread: { _ in },
-            executeLeadingSpacePasteOnMainThread: { _ in true }
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         XCTAssertTrue(result.didMenuFallbackInsert)
@@ -272,7 +406,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: firstExecutor,
             shouldTrustMenuSuccessWithoutAXVerification: { false },
             setClipboardStringOnMainThread: { _ in },
-            executeLeadingSpacePasteOnMainThread: { _ in true }
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         let secondExecutor = MockPasteMenuFallbackExecutor()
@@ -288,7 +423,8 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
             menuFallbackExecutor: secondExecutor,
             shouldTrustMenuSuccessWithoutAXVerification: { false },
             setClipboardStringOnMainThread: { _ in },
-            executeLeadingSpacePasteOnMainThread: { _ in true }
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: { _ in true }
         )
 
         XCTAssertFalse(first.didMenuFallbackInsert)
@@ -342,6 +478,8 @@ private final class MockPasteMenuFallbackExecutor: PasteMenuFallbackExecuting {
     var verifyLiveResult = false
     var liveSessions: [PasteAXLiveSessioning] = []
     var liveVerificationProcessIDs: [pid_t] = []
+    var onPaste: (() -> Void)?
+    var onVerifyInsertion: (() -> Void)?
     private(set) var lastLiveSessionProcessIDs: [pid_t] = []
 
     private(set) var pasteViaMenuBarCalls = 0
@@ -351,6 +489,7 @@ private final class MockPasteMenuFallbackExecutor: PasteMenuFallbackExecuting {
 
     func pasteViaMenuBarOnMainThread() -> PasteMenuFallbackAttemptResult {
         pasteViaMenuBarCalls += 1
+        onPaste?()
         return pasteResult
     }
 
@@ -376,6 +515,7 @@ private final class MockPasteMenuFallbackExecutor: PasteMenuFallbackExecuting {
         _ = context
         _ = expectedText
         verifyInsertionCalls += 1
+        onVerifyInsertion?()
         if let verifyInsertionOutcomeResult {
             return verifyInsertionOutcomeResult
         }

--- a/macOS/KeyVoxTests/Services/PasteMenuFallbackCoordinatorExecutionTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteMenuFallbackCoordinatorExecutionTests.swift
@@ -115,6 +115,34 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
         XCTAssertEqual(executor.verifyInsertionCalls, 1)
     }
 
+    func testTrailingSpaceFailureRetriesOnlyTrailingSpacesAndReportsIncompleteInsertion() {
+        let coordinator = PasteMenuFallbackCoordinator()
+        let executor = MockPasteMenuFallbackExecutor()
+        executor.pasteResult = .actionSucceeded
+        executor.verificationContext = sampleVerificationContext()
+        executor.verifyInsertionOutcomeResult = .expectedPayloadObserved
+        var trailingSpaceCounts: [Int] = []
+
+        let result = coordinator.executeMenuFallback(
+            insertionText: "hello ",
+            didAccessibilityInsertText: false,
+            targetAppIdentity: identity("com.example.app", 1),
+            menuFallbackExecutor: executor,
+            shouldTrustMenuSuccessWithoutAXVerification: { false },
+            setClipboardStringOnMainThread: { _ in },
+            executeLeadingSpacePasteOnMainThread: { _ in true },
+            typeTrailingSpacesOnMainThread: {
+                trailingSpaceCounts.append($0)
+                return false
+            }
+        )
+
+        XCTAssertTrue(result.didMenuFallbackInsert)
+        XCTAssertFalse(result.didCompleteInsertion)
+        XCTAssertEqual(trailingSpaceCounts, [1, 1])
+        XCTAssertEqual(executor.pasteViaMenuBarCalls, 1)
+    }
+
     func testTrailingSpacesAreNotTypedWhenPasteIsNotObserved() {
         let coordinator = PasteMenuFallbackCoordinator()
         let executor = MockPasteMenuFallbackExecutor()

--- a/macOS/KeyVoxTests/Services/PasteServiceExecutionMocks.swift
+++ b/macOS/KeyVoxTests/Services/PasteServiceExecutionMocks.swift
@@ -150,7 +150,8 @@ final class MockMenuFallbackCoordinator: PasteMenuFallbackCoordinating {
         menuFallbackExecutor: PasteMenuFallbackExecuting,
         shouldTrustMenuSuccessWithoutAXVerification: () -> Bool,
         setClipboardStringOnMainThread: (String) -> Void,
-        executeLeadingSpacePasteOnMainThread: (Int) -> Bool
+        executeLeadingSpacePasteOnMainThread: (Int) -> Bool,
+        typeTrailingSpacesOnMainThread: (Int) -> Bool
     ) -> PasteMenuFallbackExecutionResult {
         _ = insertionText
         _ = didAccessibilityInsertText
@@ -158,6 +159,7 @@ final class MockMenuFallbackCoordinator: PasteMenuFallbackCoordinating {
         _ = shouldTrustMenuSuccessWithoutAXVerification
         _ = setClipboardStringOnMainThread
         _ = executeLeadingSpacePasteOnMainThread
+        _ = typeTrailingSpacesOnMainThread
         executeCalls += 1
         executionThreadWasMain.append(Thread.isMainThread)
         targetAppIdentities.append(targetAppIdentity)
@@ -280,10 +282,15 @@ final class PasteServiceNoopFallbackExecutor: PasteMenuFallbackExecuting {
 final class MockAXInspector: PasteAXInspecting {
     private let stateLock = NSLock()
     private let focusedElement: AXUIElement?
+    private let insertionContextValue: PasteInsertionContext?
     private var selectedRangeValue = CFRange(location: 0, length: 0)
 
-    init(focusedElement: AXUIElement? = nil) {
+    init(
+        focusedElement: AXUIElement? = nil,
+        insertionContext: PasteInsertionContext? = nil
+    ) {
         self.focusedElement = focusedElement
+        insertionContextValue = insertionContext
     }
 
     func updateSelectedRange(_ range: CFRange) {
@@ -293,6 +300,10 @@ final class MockAXInspector: PasteAXInspecting {
     }
 
     func focusedInsertionContext() -> PasteInsertionContext? { nil }
+    func insertionContext(for element: AXUIElement) -> PasteInsertionContext? {
+        guard element === focusedElement else { return nil }
+        return insertionContextValue
+    }
     func focusedUIElement() -> AXUIElement? { focusedElement }
     func roleString(for element: AXUIElement) -> String? {
         _ = element

--- a/macOS/KeyVoxTests/Services/PasteServiceExecutionTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteServiceExecutionTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import KeyVox
 import Foundation
+import ApplicationServices
 
 @MainActor
 final class PasteServiceExecutionTests: XCTestCase {
@@ -70,6 +71,51 @@ final class PasteServiceExecutionTests: XCTestCase {
         XCTAssertEqual(capitalization.inputs.map(\.text), ["Hello"])
         XCTAssertEqual(spacing.inputs.map(\.text), ["hello"])
         XCTAssertEqual(clipboard.writes, ["hello"])
+    }
+
+    func testTrailingSeparatorCompositionFeedsInsertionTransport() async throws {
+        let insertionCases = [
+            (text: "What's up?", followingCharacter: Character("T"), expected: "What's up? "),
+            (text: "That's awesome.", followingCharacter: Character("Y"), expected: "That's awesome. "),
+            (text: "definitely", followingCharacter: Character("a"), expected: "definitely "),
+            (text: "Nice", followingCharacter: Character("😎"), expected: "Nice "),
+            (text: "definitely", followingCharacter: Character(";"), expected: "definitely"),
+        ]
+
+        for testCase in insertionCases {
+            let clipboard = MockClipboardAdapter(snapshot: [[:]])
+            let element = AXUIElementCreateApplication(getpid())
+            let inspector = MockAXInspector(
+                focusedElement: element,
+                insertionContext: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 0,
+                    previousCharacter: nil,
+                    followingCharacter: testCase.followingCharacter
+                )
+            )
+            let service = try makeService(
+                clipboard: clipboard,
+                recovery: MockFailureRecoveryController(),
+                capitalization: MockCapitalizationHeuristics(outputText: testCase.text),
+                spacing: MockSpacingHeuristics(),
+                injector: MockAccessibilityInjector(outcome: .verifiedSuccess),
+                coordinator: MockMenuFallbackCoordinator(result: .init(
+                    didMenuFallbackInsert: false,
+                    menuAttempt: nil,
+                    suppressFirstWarmupFailureWarning: false
+                )),
+                restoreDelayAfterMenuFallback: 0.5,
+                axInspector: inspector
+            )
+
+            service.pasteText(testCase.text)
+
+            try await waitForCondition {
+                clipboard.restoreCalls == 1
+            }
+            XCTAssertEqual(clipboard.writes, [testCase.expected])
+        }
     }
 
     func testVerifiedMenuFallbackKeepsGraceDelayBeforeRestoringClipboard() async throws {

--- a/macOS/KeyVoxTests/Services/PasteServiceExecutionTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteServiceExecutionTests.swift
@@ -376,6 +376,38 @@ final class PasteServiceExecutionTests: XCTestCase {
         XCTAssertEqual(second.lastInsertedTrailingCharacter, ".")
     }
 
+    func testIncompleteMenuFallbackInsertionDoesNotFeedNextSpacingDecision() async throws {
+        let clipboard = MockClipboardAdapter(snapshot: [[:]])
+        let spacing = MockSpacingHeuristics()
+        let coordinator = MockMenuFallbackCoordinator(result: .init(
+            didMenuFallbackInsert: true,
+            didCompleteInsertion: false,
+            menuAttempt: .actionSucceeded,
+            completionEvidence: .expectedPayloadObserved,
+            suppressFirstWarmupFailureWarning: false
+        ))
+        let service = try makeService(
+            clipboard: clipboard,
+            recovery: MockFailureRecoveryController(),
+            capitalization: MockCapitalizationHeuristics(outputText: "hello."),
+            spacing: spacing,
+            injector: MockAccessibilityInjector(outcome: .failureNeedsFallback),
+            coordinator: coordinator,
+            restoreDelayAfterMenuFallback: 0
+        )
+
+        service.pasteText("hello.")
+        try await waitForCondition { clipboard.restoreCalls == 1 }
+
+        service.pasteText("next")
+        try await waitForCondition { clipboard.restoreCalls == 2 }
+
+        XCTAssertEqual(spacing.inputs.count, 2)
+        XCTAssertNil(spacing.inputs[1].lastInsertionAppIdentity)
+        XCTAssertEqual(spacing.inputs[1].lastInsertionAt, .distantPast)
+        XCTAssertNil(spacing.inputs[1].lastInsertedTrailingCharacter)
+    }
+
     func testUntouchedInsertionTargetAndReplacementRunOffMainThread() async throws {
         let clipboard = MockClipboardAdapter(snapshot: [[:]])
         let coordinator = MockMenuFallbackCoordinator(result: .init(


### PR DESCRIPTION
## Summary

This change restores a missing separator when dictated text is inserted immediately before existing word-like text.

- Adds one trailing space before an existing letter, number, or Unicode emoji when the dictated text does not already end in whitespace.
- Emits nothing extra when punctuation, a symbol, whitespace, or no text follows the insertion point.
- Applies the same shared composition decision across the iOS keyboard and macOS paste paths.
- Preserves correct insertion order in Electron editors by waiting for verified paste completion before emitting the trailing space.

## Shared composition policy

- Adds `TrailingSeparatorCompositionPolicy` to `KeyVoxTextComposition` as the single source of truth for missing trailing separators.
- Uses semantic Unicode character properties for letters, numbers, punctuation, symbols, whitespace, and emoji rather than phrase-specific rules.
- Extracts the existing emoji classification into a shared package-owned classifier so leading and trailing composition use the same definition.
- Recognizes emoji-presentation characters and emoji sequences that use a variation selector.
- Avoids duplicating whitespace when the incoming dictation already supplies a trailing separator.

## iOS keyboard integration

- Applies trailing-separator composition after capitalization, leading spacing, and adjacent terminal-punctuation resolution.
- Uses the first character following the insertion point or selected span as the shared policy input.
- Preserves punctuation replacement behavior from the preceding composition change.
- Covers sentence insertion, single-word insertion, numeric boundaries, emoji boundaries, existing whitespace, and punctuation boundaries.

## macOS paste integration

- Carries the following character from the retained Accessibility insertion context into the shared composition policy.
- Applies the missing separator after adjacent terminal-punctuation resolution and before insertion transport begins.
- Keeps Accessibility context collection and insertion mechanics platform-owned while the separator decision remains package-owned.
- Covers complete insertion payloads before following word text, punctuation, and emoji.

## Electron paste ordering

- Preserves the existing leading-space paste sequence used by editors that normalize clipboard-edge whitespace.
- Removes a required trailing space from the clipboard payload before fallback paste so Electron cannot discard it.
- Waits until the existing paste verifier observes insertion completion before emitting the trailing-space keystroke.
- Does not emit a separate trailing space when paste completion cannot be observed or is only trusted without verification.
- Prevents asynchronous Electron paste handling from placing the separator before the dictated text.

## Documentation

- Updates the current unreleased composition changelog with the new trailing-separator behavior and preserved boundaries.

## Version

- `KeyVoxTextComposition 1.0.3`

## Validation

- KeyVoxTextComposition: 24 tests passed.
- macOS: 383 tests passed.
- macOS build succeeded.
- iOS build succeeded.
- All iOS tests passed.
- Live insertion in monday.com produced the expected space after verified fallback paste completion.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text composition by adding missing spaces before following words, numbers, and emoji.
  * Preserved existing whitespace and avoided adding spaces before punctuation or when no following text exists.
  * Enhanced paste fallback handling to preserve trailing spaces after verified insertions.

* **Bug Fixes**
  * Fixed missing trailing separators after punctuation during transcription and paste operations.

* **Tests**
  * Added coverage for spacing behavior across iOS, macOS, words, numbers, emoji, punctuation, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->