### PR TITLE
fix(mac-paste): ignore nested placeholder content

### DIFF
--- a/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
+++ b/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
@@ -485,19 +485,36 @@ final class PasteAXInspector: PasteAXInspecting {
         }
 
         let nsValue = value as NSString
-        guard selectedRange?.location == nsValue.length else { return false }
-
-        var classListRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, "AXDOMClassList" as CFString, &classListRef) == .success,
-              let classList = classListRef as? [String] else {
+        guard selectedRange?.location == 0 || selectedRange?.location == nsValue.length else {
             return false
         }
 
-        return Self.containsPlaceholderDOMClass(classList)
+        if let classList = domClassList(for: element),
+           Self.containsPlaceholderDOMClass(classList) {
+            return true
+        }
+
+        return elementsAttribute(element, attribute: kAXChildrenAttribute as String)?
+            .contains { child in
+                guard let classList = domClassList(for: child) else { return false }
+                return Self.containsPlaceholderDOMClass(classList)
+            } == true
     }
 
     static func containsPlaceholderDOMClass(_ classList: [String]) -> Bool {
         classList.contains("placeholder")
+    }
+
+    private func domClassList(for element: AXUIElement) -> [String]? {
+        var classListRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            "AXDOMClassList" as CFString,
+            &classListRef
+        ) == .success else {
+            return nil
+        }
+        return classListRef as? [String]
     }
 
     func valueLengthForMenuVerification(element: AXUIElement) -> Int? {

--- a/macOS/KeyVoxTests/Services/PasteMenuFallbackCoordinatorExecutionTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteMenuFallbackCoordinatorExecutionTests.swift
@@ -148,7 +148,7 @@ final class PasteMenuFallbackCoordinatorExecutionTests: XCTestCase {
         let executor = MockPasteMenuFallbackExecutor()
         executor.pasteResult = .actionSucceeded
         executor.verificationContext = sampleVerificationContext()
-        executor.verifyInsertionOutcomeResult = .none
+        executor.verifyInsertionOutcomeResult = PasteMenuFallbackVerificationOutcome.none
         var trailingSpaceCounts: [Int] = []
 
         let result = coordinator.executeMenuFallback(


### PR DESCRIPTION
## Summary

This change prevents empty browser editors from contributing placeholder text to macOS dictation composition.

- Recognizes semantic placeholder markers exposed on direct accessibility children.
- Treats placeholder-backed editors with a zero-position caret as empty.
- Prevents placeholder text from triggering an unwanted trailing separator on the first dictation.
- Preserves existing handling when genuine text follows the caret.

## Root cause

- Some browser editors expose visible placeholder copy through `AXValue` as though it were editable content.
- The focused text area reports a zero-position caret while its first placeholder character is returned as the following character.
- The existing empty-editor check only inspected the focused element for a placeholder class.
- The trailing-separator policy therefore treated the placeholder character as real adjacent text.

## Placeholder handling

- Keeps the existing semantic placeholder-class detection.
- Reads DOM class metadata through one accessibility helper.
- Accepts the placeholder marker on either the focused editor or one of its direct accessibility children.
- Supports placeholder-backed caret positions at both the beginning and end of the exposed value.
- Normalizes confirmed placeholder-backed editors to an empty insertion context before text composition.

## Fallback verification cleanup

- Qualifies `PasteMenuFallbackVerificationOutcome.none` explicitly in the fallback execution setup.
- Removes the optional `.none` ambiguity while preserving the intended no-verification outcome.

## Validation

- `PasteMenuFallbackCoordinatorExecutionTests`: 17 tests passed.
- macOS build succeeded.
- `git diff --check` passed.