### PR TITLE
fix(dictionary): correct stylized near-misses before titlecase words

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -8,7 +8,7 @@ The format loosely follows Keep a Changelog and the package uses semantic versio
 
 ## [1.2.6] - 2026-08-22
 
-Spoken quantities now preserve complete hundreds-and-thousands values, and Parakeet rejects captures without detected speech before decoding through the shared voice activity package.
+Spoken quantities now preserve complete hundreds-and-thousands values, Parakeet rejects captures without detected speech, and stylized dictionary terms correct reliably before title-cased words.
 
 ### Includes
 
@@ -17,6 +17,7 @@ Spoken quantities now preserve complete hundreds-and-thousands values, and Parak
 - Normalized article-led hundreds within larger quantities and retained complete trailing hundreds, tens, and units.
 - Added regression coverage for both partial-grouping failures.
 - Integrated Whisper and Parakeet with the provider-neutral `KeyVoxVoiceActivity` package, preventing captures without detected speech from reaching the Parakeet decoder and producing hallucinated text.
+- Allowed unknown stylized-word phonetic near-misses to match before title-cased words without requiring those following words in the dictionary, while preserving safeguards for known words and names.
 
 ### Notes
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardSingleTokenEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardSingleTokenEvaluation.swift
@@ -67,6 +67,16 @@ extension DictionaryMatcher {
             tokens: tokens,
             text: text
         )
+        let hasUnknownWordStylizedFallbackEvidence =
+            !observedHasRuntimePronunciation
+            && allowStylizedFallbackBySurface
+            && hasStrongStylizedFallbackPhoneticEvidence(
+                observed: observedToken.normalized,
+                candidate: candidateToken,
+                observedPhonetic: observedToken.phonetic,
+                candidatePhonetic: candidatePhonetic,
+                textSimilarity: textSimilarity
+            )
 
         var adjustedThreshold = effectiveThreshold
         var requiresPeerSupport = false
@@ -87,7 +97,8 @@ extension DictionaryMatcher {
                observed: observedToken.normalized,
                candidate: candidateToken,
                textSimilarity: textSimilarity
-           ) {
+           ),
+           !hasUnknownWordStylizedFallbackEvidence {
             if !hasAdjacentTitlecaseListContext {
                 stats.rejectedLowScore += 1
                 return nil

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -250,6 +250,21 @@ final class DictionaryMatcherTests: XCTestCase {
         XCTAssertEqual(result.text, "Yeah, the KeyVox Core package.")
     }
 
+    func testCorrectsStylizedSingleTokenBrandPhoneticNearMissBeforeUnlistedTitlecaseWords() {
+        let matcher = makeRuntimeMatcher()
+        let entries = DictionaryBuiltInEntries.effectiveEntries(merging: [])
+        matcher.rebuildIndex(entries: entries)
+
+        let result = matcher.apply(
+            to: "Kivox speak, the Kivox Core package, and Kivox Whisper."
+        )
+
+        XCTAssertEqual(
+            result.text,
+            "KeyVox Speak, the KeyVox Core package, and KeyVox Whisper."
+        )
+    }
+
     func testRuntimeMatcherDoesNotRewriteOrdinaryMergedTokenPrefixIntoStylizedSingleTokenBrand() {
         let matcher = makeRuntimeMatcher()
         matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "KeyVox")])


### PR DESCRIPTION
## Summary

This change lets KeyVox Core correct strong phonetic near-misses for unknown stylized dictionary terms when a title-cased word follows.

- Corrects standalone `Kivox` transcriptions to `KeyVox` before words such as `Core` and `Whisper`.
- Does not require the following title-cased words to exist in the dictionary.
- Preserves the existing safeguards for known words, names, and title-cased phrases.
- Updates the current KeyVox Core `1.2.6` changelog entry.

## Root cause

- The single-token matcher detects adjacent title-cased words as potentially risky phrase context.
- That guard previously accepted only strong spelling similarity for a stylized dictionary candidate.
- `Kivox` has strong fallback phonetic evidence for `KeyVox`, but its spelling score does not satisfy that title-case guard.
- The candidate was therefore rejected before normal scoring could accept it, while `Kivox speak` succeeded separately through the built-in two-token `KeyVox Speak` entry.

## Matcher evaluation

- Reuses the existing strong stylized fallback phonetic evidence instead of adding phrase-specific aliases or following-word exceptions.
- Applies the fallback only when the observed word has no runtime pronunciation, keeping known words on the stricter path.
- Retains the existing surface-shape requirement before phonetic evidence can bypass the adjacent title-case rejection.
- Leaves title-cased list handling and the remaining common-word safeguards unchanged.

## Regression coverage

- Reproduces the captured sentence with only the built-in dictionary entries.
- Verifies all three occurrences normalize to `KeyVox`, including those before unlisted title-cased words.
- Continues to protect existing cases for known title-cased words and place-name phrases.

## Changelog

- Updates the KeyVox Core `1.2.6` summary to include the matcher correction.
- Documents that following title-cased words do not need their own dictionary entries.

## Validation

- KeyVox Core package: 539 tests passed.
- `git diff --check` passed.
