### PR TITLE
fix(text-composition): preserve locale-aware date capitalization

### DIFF
--- a/Packages/KeyVoxTextComposition/CHANGELOG.md
+++ b/Packages/KeyVoxTextComposition/CHANGELOG.md
@@ -6,9 +6,9 @@ The format loosely follows Keep a Changelog, and the package uses semantic versi
 
 ---
 
-## [1.0.3] - 2026-08-22
+## [1.0.3] - 2026-08-23
 
-Composed dictated terminal marks and missing separators with text immediately following an insertion.
+Composed dictated capitalization, terminal marks, and missing separators with surrounding text.
 
 ### Includes
 
@@ -17,12 +17,13 @@ Composed dictated terminal marks and missing separators with text immediately fo
 - Left incoming terminal punctuation unchanged before straight or curly quotation marks.
 - Added one trailing space when dictated text would otherwise run into an existing letter, number, or emoji.
 - Left trailing spacing unchanged before punctuation, symbols, whitespace, or no following text, and when the dictated text already ends in whitespace.
+- Preserved locale-canonical month and weekday capitalization for detected dates and spoken-number dates while allowing relative date labels to follow normal continuation casing.
 - Shared the punctuation-boundary decision across macOS and iOS composition paths.
-- Added regression coverage for model periods, explicit question marks and exclamation points, supported non-quote punctuation, quotation-mark boundaries, and missing trailing separators.
+- Added regression coverage for locale-canonical calendar names, relative date labels, spoken-number dates, model periods, explicit question marks and exclamation points, supported non-quote punctuation, quotation-mark boundaries, and missing trailing separators.
 
 ### Notes
 
-- `1.0.3` bumps the tracked patch version for punctuation-aware composition and missing trailing separators.
+- `1.0.3` bumps the tracked patch version for locale-aware capitalization, punctuation-aware composition, and missing trailing separators.
 
 ## [1.0.2] - 2026-08-08
 

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/LeadingDateCapitalizationPolicy.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/LeadingDateCapitalizationPolicy.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+enum LeadingDateCapitalizationPolicy {
+    private static let detector = try? NSDataDetector(
+        types: NSTextCheckingResult.CheckingType.date.rawValue
+    )
+
+    static func shouldPreserveCapitalization(
+        in text: String,
+        startingAt capitalizationIndex: String.Index,
+        locale: Locale = .current
+    ) -> Bool {
+        let leadingWordEnd = text[capitalizationIndex...]
+            .firstIndex(where: { $0.isLetter == false }) ?? text.endIndex
+        let leadingWord = String(text[capitalizationIndex..<leadingWordEnd])
+        guard canonicalCalendarSymbols(for: locale).contains(leadingWord) else {
+            return false
+        }
+
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        let expectedLocation = NSRange(
+            capitalizationIndex..<capitalizationIndex,
+            in: text
+        ).location
+        if detector?.firstMatch(in: text, range: fullRange)?.range.location == expectedLocation {
+            return true
+        }
+
+        return beginsWithLocalizedSpelledOutNumber(
+            text[leadingWordEnd...],
+            locale: locale
+        )
+    }
+
+    private static func canonicalCalendarSymbols(for locale: Locale) -> Set<String> {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = locale
+        formatter.calendar = calendar
+
+        let symbolGroups = [
+            formatter.monthSymbols,
+            formatter.shortMonthSymbols,
+            formatter.standaloneMonthSymbols,
+            formatter.shortStandaloneMonthSymbols,
+            formatter.weekdaySymbols,
+            formatter.shortWeekdaySymbols,
+            formatter.standaloneWeekdaySymbols,
+            formatter.shortStandaloneWeekdaySymbols,
+        ]
+        let trimmingCharacters = CharacterSet.whitespacesAndNewlines
+            .union(.punctuationCharacters)
+
+        return Set(symbolGroups.compactMap { $0 }.flatMap { $0 }.map {
+            $0.trimmingCharacters(in: trimmingCharacters)
+        })
+    }
+
+    private static func beginsWithLocalizedSpelledOutNumber(
+        _ suffix: Substring,
+        locale: Locale
+    ) -> Bool {
+        guard let numberStart = suffix.firstIndex(where: \.isLetter) else {
+            return false
+        }
+        let numberWord = String(suffix[numberStart...].prefix(while: \.isLetter))
+
+        let formatter = NumberFormatter()
+        formatter.locale = locale
+        formatter.numberStyle = .spellOut
+        return formatter.number(from: numberWord) != nil
+    }
+}

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
@@ -63,6 +63,12 @@ public enum TextCompositionPolicy {
         let leadingWord = text[capitalizationIndex...].prefix(while: \.isLetter)
         guard isDefaultSentenceCase(word: leadingWord) else { return text }
         guard isSentenceStart == false else { return text }
+        guard LeadingDateCapitalizationPolicy.shouldPreserveCapitalization(
+            in: text,
+            startingAt: capitalizationIndex
+        ) == false else {
+            return text
+        }
 
         var output = text
         let firstCharacter = output[capitalizationIndex]

--- a/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TextCompositionPolicyTests.swift
+++ b/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TextCompositionPolicyTests.swift
@@ -259,6 +259,112 @@ final class TextCompositionPolicyTests: XCTestCase {
         )
     }
 
+    func testDateCapitalizationPreservesCanonicalLeadingCalendarName() throws {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "MMMM d, yyyy"
+
+        let components = DateComponents(
+            calendar: formatter.calendar,
+            timeZone: formatter.timeZone,
+            year: 2025,
+            month: 3,
+            day: 15
+        )
+        let date = try XCTUnwrap(components.date)
+        let dateText = formatter.string(from: date)
+        let capitalizationIndex = try XCTUnwrap(dateText.indices.first)
+
+        XCTAssertTrue(
+            LeadingDateCapitalizationPolicy.shouldPreserveCapitalization(
+                in: dateText,
+                startingAt: capitalizationIndex,
+                locale: formatter.locale
+            )
+        )
+    }
+
+    func testDateCapitalizationDoesNotPreserveLocalizedRelativeDateLabel() throws {
+        let locale = Locale(identifier: "en_US_POSIX")
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateStyle = .medium
+        formatter.doesRelativeDateFormatting = true
+
+        let now = Date()
+        for dayOffset in -1...1 {
+            let date = try XCTUnwrap(
+                formatter.calendar.date(byAdding: .day, value: dayOffset, to: now)
+            )
+            let dateText = formatter.string(from: date)
+            let capitalizationIndex = try XCTUnwrap(dateText.firstIndex(where: \.isLetter))
+
+            XCTAssertFalse(
+                LeadingDateCapitalizationPolicy.shouldPreserveCapitalization(
+                    in: dateText,
+                    startingAt: capitalizationIndex,
+                    locale: locale
+                )
+            )
+        }
+    }
+
+    func testDateCapitalizationPreservesLocalizedWeekdayAtStartOfLongerText() throws {
+        let locale = Locale(identifier: "en_US_POSIX")
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateStyle = .full
+
+        let components = DateComponents(
+            calendar: formatter.calendar,
+            timeZone: formatter.timeZone,
+            year: 2025,
+            month: 3,
+            day: 15
+        )
+        let date = try XCTUnwrap(components.date)
+        let dateText = formatter.string(from: date)
+        let capitalizationIndex = try XCTUnwrap(dateText.indices.first)
+
+        XCTAssertTrue(
+            LeadingDateCapitalizationPolicy.shouldPreserveCapitalization(
+                in: dateText,
+                startingAt: capitalizationIndex,
+                locale: locale
+            )
+        )
+    }
+
+    func testDateCapitalizationPreservesCalendarNameBeforeSpelledOutNumber() throws {
+        let locale = Locale(identifier: "en_US_POSIX")
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = locale
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
+        let month = try XCTUnwrap(dateFormatter.monthSymbols.first)
+
+        let numberFormatter = NumberFormatter()
+        numberFormatter.locale = locale
+        numberFormatter.numberStyle = .spellOut
+        let spokenNumber = try XCTUnwrap(numberFormatter.string(from: 25))
+
+        let dateText = month + " " + spokenNumber
+        let capitalizationIndex = try XCTUnwrap(dateText.indices.first)
+
+        XCTAssertTrue(
+            LeadingDateCapitalizationPolicy.shouldPreserveCapitalization(
+                in: dateText,
+                startingAt: capitalizationIndex,
+                locale: locale
+            )
+        )
+    }
+
     func testCapitalizationScopesPreserveExistingPlatformBehavior() {
         let context = TextCompositionContext(
             isAtDocumentStart: false,


### PR DESCRIPTION
## Summary

This change preserves locale-canonical date capitalization when corrected dictation is composed with existing text.

- Preserves leading localized month and weekday casing for detected dates.
- Recognizes calendar names followed by localized spoken-number components when the system date detector does not.
- Keeps relative date labels on the existing continuation-capitalization path.
- Updates the current KeyVoxTextComposition `1.0.3` changelog entry.

## Root cause

- Each standalone transcription can begin with model-added capitalization even when it continues existing text.
- The shared composition policy therefore lowercases ordinary default sentence-case words at continuation boundaries.
- `NSDataDetector` recognizes numeric date forms but does not recognize spoken-number forms such as `March twenty fifth`.
- Treating every detected date as intrinsically capitalized also preserves relative labels such as `Tomorrow`, `Today`, and `Yesterday` unnecessarily.

## Capitalization policy evaluation

- Uses locale-provided month and weekday symbols as the source of canonical calendar casing.
- Preserves a matching calendar name when the system detector identifies a leading date.
- Falls back only when the next localized spoken token parses as a number.
- Leaves stylized words and other proper nouns on the existing user-dictionary casing path.
- Avoids hard-coded month, weekday, relative-date, and spoken-number vocabulary.

## Regression coverage

- Verifies canonical leading calendar names remain capitalized.
- Verifies localized relative date labels do not receive date-specific capitalization preservation.
- Verifies leading weekdays remain canonical when additional date text follows.
- Verifies calendar names followed by localized spelled-out numbers are preserved.

## Changelog

- Updates the KeyVoxTextComposition `1.0.3` date to August 23, 2026.
- Documents locale-aware calendar casing and spoken-number date handling in the current entry.

## Validation

- KeyVoxTextComposition package: 28 tests passed.
- `git diff --check` passed.

