### PR TITLE
fix(text-composition): strip periods before lowercase continuations

### DIFF
--- a/Packages/KeyVoxTextComposition/CHANGELOG.md
+++ b/Packages/KeyVoxTextComposition/CHANGELOG.md
@@ -13,6 +13,7 @@ Composed dictated capitalization, terminal marks, and missing separators with su
 ### Includes
 
 - Removed an incoming model-added period when supported non-quote punctuation already follows the selected text.
+- Removed an incoming model-added period when the next existing non-whitespace character is a lowercase letter.
 - Reused a matching question mark or exclamation point and replaced differing supported non-quote punctuation when processed dictation explicitly ends with either mark.
 - Left incoming terminal punctuation unchanged before straight or curly quotation marks.
 - Added one trailing space when dictated text would otherwise run into an existing letter, number, or emoji.

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TerminalPunctuationCompositionPolicy.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TerminalPunctuationCompositionPolicy.swift
@@ -11,13 +11,30 @@ public struct TerminalPunctuationCompositionResult: Equatable, Sendable {
 public enum TerminalPunctuationCompositionPolicy {
     public static func resolve(
         text: String,
-        followingCharacter: Character?
+        followingCharacter: Character?,
+        followingNonWhitespaceCharacter: Character? = nil
     ) -> TerminalPunctuationCompositionResult {
         guard let followingCharacter,
-              followingCharacter.isPunctuation,
-              isQuotationMark(followingCharacter) == false,
               let incomingPunctuation = text.last,
               TextCompositionPolicy.isSentenceBoundary(incomingPunctuation) else {
+            return TerminalPunctuationCompositionResult(
+                text: text,
+                shouldReplaceFollowingPunctuation: false
+            )
+        }
+
+        let nextContentCharacter = followingCharacter.isWhitespace
+            ? followingNonWhitespaceCharacter
+            : followingCharacter
+        if incomingPunctuation == ".", nextContentCharacter?.isLowercase == true {
+            return TerminalPunctuationCompositionResult(
+                text: String(text.dropLast()),
+                shouldReplaceFollowingPunctuation: false
+            )
+        }
+
+        guard followingCharacter.isPunctuation,
+              isQuotationMark(followingCharacter) == false else {
             return TerminalPunctuationCompositionResult(
                 text: text,
                 shouldReplaceFollowingPunctuation: false

--- a/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TerminalPunctuationCompositionPolicyTests.swift
+++ b/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TerminalPunctuationCompositionPolicyTests.swift
@@ -2,6 +2,35 @@ import XCTest
 @testable import KeyVoxTextComposition
 
 final class TerminalPunctuationCompositionPolicyTests: XCTestCase {
+    func testModelPeriodIsRemovedBeforeFollowingLowercaseLetter() {
+        for testCase in [
+            (followingCharacter: Character("a"), followingNonWhitespaceCharacter: Character("a")),
+            (followingCharacter: Character(" "), followingNonWhitespaceCharacter: Character("m")),
+            (followingCharacter: Character("\t"), followingNonWhitespaceCharacter: Character("é")),
+        ] {
+            let result = TerminalPunctuationCompositionPolicy.resolve(
+                text: "still working.",
+                followingCharacter: testCase.followingCharacter,
+                followingNonWhitespaceCharacter: testCase.followingNonWhitespaceCharacter
+            )
+
+            XCTAssertEqual(result.text, "still working")
+            XCTAssertFalse(result.shouldReplaceFollowingPunctuation)
+        }
+    }
+
+    func testModelPeriodIsPreservedBeforeNonLowercaseContent() {
+        for followingCharacter in [Character("A"), Character("2"), Character("😎")] {
+            let result = TerminalPunctuationCompositionPolicy.resolve(
+                text: "still working.",
+                followingCharacter: followingCharacter
+            )
+
+            XCTAssertEqual(result.text, "still working.")
+            XCTAssertFalse(result.shouldReplaceFollowingPunctuation)
+        }
+    }
+
     func testModelPeriodIsRemovedBeforeExistingPunctuation() {
         for existingPunctuation in [
             Character("."), Character("?"), Character("!"),

--- a/iOS/KeyVox Keyboard/Core/Input/KeyboardTextInputController.swift
+++ b/iOS/KeyVox Keyboard/Core/Input/KeyboardTextInputController.swift
@@ -170,7 +170,11 @@ final class KeyboardTextInputController {
         let compositionContextBeforeInput = contextAfterCorrectingPendingSelectionDeletion(
             contextBeforeInput
         )
-        let followingCharacter = documentProxy.documentContextAfterInput?.first
+        let contextAfterInput = documentProxy.documentContextAfterInput
+        let followingCharacter = contextAfterInput?.first
+        let followingNonWhitespaceCharacter = contextAfterInput?.first(where: {
+            $0.isWhitespace == false
+        })
         pendingSelectionDeletion = nil
         let preparedText = preparedTranscriptionText(
             cleanedText,
@@ -178,7 +182,8 @@ final class KeyboardTextInputController {
         )
         let punctuationResolution = TerminalPunctuationCompositionPolicy.resolve(
             text: preparedText,
-            followingCharacter: followingCharacter
+            followingCharacter: followingCharacter,
+            followingNonWhitespaceCharacter: followingNonWhitespaceCharacter
         )
         let insertionText = TrailingSeparatorCompositionPolicy.applyIfNeeded(
             to: punctuationResolution.text,

--- a/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
+++ b/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
@@ -59,6 +59,7 @@ extension PasteAXInspecting {
 
 final class PasteAXInspector: PasteAXInspecting {
     private let maxPreviousNonWhitespaceScanLength = 100
+    private let maxFollowingNonWhitespaceScanLength = 100
     private let accessibilityWarmupRetryCount = 5
     private let accessibilityWarmupRetryDelay: useconds_t = 50_000
 
@@ -110,6 +111,7 @@ final class PasteAXInspector: PasteAXInspecting {
 
         var previousCharacter: Character?
         var followingCharacter: Character?
+        var followingNonWhitespaceCharacter: Character?
         var characterBeforePreviousCharacter: Character?
         var previousNonWhitespaceCharacter: Character?
         var characterBeforePreviousNonWhitespaceCharacter: Character?
@@ -143,10 +145,19 @@ final class PasteAXInspector: PasteAXInspecting {
         }
         if let caretLocation,
            let selectionLength {
+            let followingLocation = caretLocation + selectionLength
             followingCharacter = stringForRange(
-                CFRange(location: caretLocation + selectionLength, length: 1),
+                CFRange(location: followingLocation, length: 1),
                 element: focusedElement
             )?.first
+            if followingCharacter?.isWhitespace == true {
+                followingNonWhitespaceCharacter = firstNonWhitespaceCharacter(
+                    after: followingLocation,
+                    element: focusedElement
+                )
+            } else {
+                followingNonWhitespaceCharacter = followingCharacter
+            }
         }
 
         let context = PasteInsertionContext(
@@ -155,6 +166,7 @@ final class PasteAXInspector: PasteAXInspecting {
             caretLocation: caretLocation,
             previousCharacter: previousCharacter,
             followingCharacter: followingCharacter,
+            followingNonWhitespaceCharacter: followingNonWhitespaceCharacter,
             characterBeforePreviousCharacter: characterBeforePreviousCharacter,
             previousNonWhitespaceCharacter: previousNonWhitespaceCharacter,
             characterBeforePreviousNonWhitespaceCharacter: characterBeforePreviousNonWhitespaceCharacter,
@@ -170,6 +182,7 @@ final class PasteAXInspector: PasteAXInspecting {
                     + "selectedText=\(String(reflecting: focusedSelectedText)) "
                     + "previous=\(String(reflecting: previousCharacter)) "
                     + "following=\(String(reflecting: followingCharacter)) "
+                    + "followingNonWhitespace=\(String(reflecting: followingNonWhitespaceCharacter)) "
                     + "beforePrevious=\(String(reflecting: characterBeforePreviousCharacter)) "
                     + "previousNonWhitespace=\(String(reflecting: previousNonWhitespaceCharacter)) "
                     + "beforePreviousNonWhitespace=\(String(reflecting: characterBeforePreviousNonWhitespaceCharacter)) "
@@ -178,6 +191,24 @@ final class PasteAXInspector: PasteAXInspecting {
         }
         #endif
         return context
+    }
+
+    private func firstNonWhitespaceCharacter(
+        after location: Int,
+        element: AXUIElement
+    ) -> Character? {
+        for length in 1...maxFollowingNonWhitespaceScanLength {
+            guard let text = stringForRange(
+                CFRange(location: location, length: length),
+                element: element
+            ) else {
+                return nil
+            }
+            if let character = text.first(where: { $0.isWhitespace == false }) {
+                return character
+            }
+        }
+        return nil
     }
 
     func focusedUIElement() -> AXUIElement? {

--- a/macOS/Core/Services/Paste/Composition/PasteTerminalPunctuationCoordinator.swift
+++ b/macOS/Core/Services/Paste/Composition/PasteTerminalPunctuationCoordinator.swift
@@ -43,7 +43,8 @@ final class PasteTerminalPunctuationCoordinator: PasteTerminalPunctuationCoordin
 
         let resolution = TerminalPunctuationCompositionPolicy.resolve(
             text: text,
-            followingCharacter: context.followingCharacter
+            followingCharacter: context.followingCharacter,
+            followingNonWhitespaceCharacter: context.followingNonWhitespaceCharacter
         )
         guard resolution.shouldReplaceFollowingPunctuation else {
             return PasteTerminalPunctuationInsertion(

--- a/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
+++ b/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
@@ -12,6 +12,7 @@ struct PasteInsertionContext {
     let caretLocation: Int?
     let previousCharacter: Character?
     let followingCharacter: Character?
+    let followingNonWhitespaceCharacter: Character?
     let characterBeforePreviousCharacter: Character?
     let previousNonWhitespaceCharacter: Character?
     let characterBeforePreviousNonWhitespaceCharacter: Character?
@@ -23,6 +24,7 @@ struct PasteInsertionContext {
         caretLocation: Int?,
         previousCharacter: Character?,
         followingCharacter: Character? = nil,
+        followingNonWhitespaceCharacter: Character? = nil,
         characterBeforePreviousCharacter: Character? = nil,
         previousNonWhitespaceCharacter: Character? = nil,
         characterBeforePreviousNonWhitespaceCharacter: Character? = nil,
@@ -33,6 +35,7 @@ struct PasteInsertionContext {
         self.caretLocation = caretLocation
         self.previousCharacter = previousCharacter
         self.followingCharacter = followingCharacter
+        self.followingNonWhitespaceCharacter = followingNonWhitespaceCharacter
         self.characterBeforePreviousCharacter = characterBeforePreviousCharacter
         self.previousNonWhitespaceCharacter = previousNonWhitespaceCharacter
         self.characterBeforePreviousNonWhitespaceCharacter = characterBeforePreviousNonWhitespaceCharacter

--- a/macOS/KeyVoxTests/Services/PasteTerminalPunctuationCoordinatorTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteTerminalPunctuationCoordinatorTests.swift
@@ -4,6 +4,27 @@ import XCTest
 
 @MainActor
 final class PasteTerminalPunctuationCoordinatorTests: XCTestCase {
+    func testRemovesModelPeriodBeforeFollowingLowercaseWordAcrossWhitespace() {
+        let element = AXUIElementCreateApplication(getpid())
+        let inspector = TerminalPunctuationAXInspector(
+            context: PasteInsertionContext(
+                selectionLength: 0,
+                caretLocation: 16,
+                previousCharacter: "g",
+                followingCharacter: " ",
+                followingNonWhitespaceCharacter: "m"
+            ),
+            element: element
+        )
+        let coordinator = PasteTerminalPunctuationCoordinator(axInspector: inspector)
+
+        let output = coordinator.resolveAdjacentTerminalPunctuation(in: "really awesome.")
+
+        XCTAssertEqual(output.text, "really awesome")
+        XCTAssertTrue(output.targetElement === element)
+        XCTAssertTrue(inspector.expandedSelections.isEmpty)
+    }
+
     func testRemovesModelPeriodBeforeExistingPunctuation() {
         let element = AXUIElementCreateApplication(getpid())
         for existingPunctuation in [


### PR DESCRIPTION
## Summary

This change removes an incoming model-added period when dictated text is composed before an existing lowercase continuation word.

- Evaluates the next existing non-whitespace character at the insertion boundary.
- Handles both directly adjacent words and words separated from the caret by whitespace.
- Preserves periods before uppercase letters, numbers, emoji, and other non-lowercase content.
- Applies the shared behavior across iOS keyboard insertion and macOS paste composition.

## Root cause

- Multiword dictation can arrive with a model-added terminal period even when the user is inserting it into the middle of existing prose.
- The composition policy previously resolved only immediately adjacent punctuation.
- The first implementation inspected only the immediate following character.
- When the caret appeared before an existing separator, composition saw whitespace instead of the lowercase first letter of the following word and retained the period.

## Composition policy

- Keeps immediate-character context as the source of truth for adjacent punctuation replacement.
- Uses the first following non-whitespace character only for the lowercase-continuation period decision.
- Removes the incoming period without replacing or deleting existing following content.
- Does not add special handling for stylized words or attempt to infer sentence meaning.

## Platform integration

- iOS reads the first non-whitespace character from the existing document context after the input boundary.
- macOS carries the first following non-whitespace accessibility character through the paste insertion context.
- Both platforms route the result through the shared KeyVoxTextComposition policy.

## Regression coverage

- Verifies model-added periods are removed before directly adjacent lowercase letters.
- Verifies whitespace and tab separators do not hide a following lowercase letter.
- Verifies Unicode lowercase letters use the same behavior.
- Verifies periods remain before uppercase letters, numbers, and emoji.
- Verifies the macOS coordinator carries whitespace-separated lowercase context into shared composition.

## Changelog

- Updates the current KeyVoxTextComposition `1.0.3` entry.
- Documents removal of model-added periods before existing lowercase continuation words.

## Validation

- KeyVoxTextComposition package: 30 tests passed.
- `PasteTerminalPunctuationCoordinatorTests`: 4 tests passed.
- iOS tests passed.
- `git diff --check` passed.
