### PR TITLE
fix(dictionary): preserve distinct mixed-case terms

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -6,7 +6,7 @@ The format loosely follows Keep a Changelog and the package uses semantic versio
 
 ---
 
-## [1.2.6] - 2026-08-22
+## [1.2.6] - 2026-08-23
 
 Spoken quantities now preserve complete hundreds-and-thousands values, Parakeet rejects captures without detected speech, and stylized dictionary terms correct reliably before title-cased words.
 
@@ -18,6 +18,7 @@ Spoken quantities now preserve complete hundreds-and-thousands values, Parakeet 
 - Added regression coverage for both partial-grouping failures.
 - Integrated Whisper and Parakeet with the provider-neutral `KeyVoxVoiceActivity` package, preventing captures without detected speech from reaching the Parakeet decoder and producing hallucinated text.
 - Allowed unknown stylized-word phonetic near-misses to match before title-cased words without requiring those following words in the dictionary, while preserving safeguards for known words and names.
+- Preserved distinct model-recognized mixed-case product names when their internal capitalization boundaries conflict with a stylized dictionary candidate, preventing `MacPaste` from being rewritten as `MrBeast` based on coarse phonetic similarity.
 
 ### Notes
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardSingleTokenEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardSingleTokenEvaluation.swift
@@ -124,6 +124,20 @@ extension DictionaryMatcher {
         }
 
         if stylizedSingleTokenEntry,
+           hasConflictingMixedCaseStructure(
+               observed: observedToken.raw,
+               candidate: best.entry.phrase
+           ),
+           !hasStrongStylizedTextEvidence(
+               observed: observedToken.normalized,
+               candidate: candidateToken,
+               textSimilarity: textSimilarity
+           ) {
+            stats.rejectedLowScore += 1
+            return nil
+        }
+
+        if stylizedSingleTokenEntry,
            !hasStylizedLongPrefixTailGuardEvidence(
                 observed: selection.observedNormalized,
                 candidate: candidateToken

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationStylizedHelpers.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationStylizedHelpers.swift
@@ -109,6 +109,16 @@ extension DictionaryMatcher {
         return true
     }
 
+    func hasConflictingMixedCaseStructure(
+        observed: String,
+        candidate: String
+    ) -> Bool {
+        let observedBoundaries = internalUppercaseOffsets(in: observed)
+        let candidateBoundaries = internalUppercaseOffsets(in: candidate)
+        guard !observedBoundaries.isEmpty, !candidateBoundaries.isEmpty else { return false }
+        return observedBoundaries != candidateBoundaries
+    }
+
     func stylizedFallbackPhoneticSimilarity(
         tokenCount: Int,
         observedNormalized: String,
@@ -212,5 +222,19 @@ extension DictionaryMatcher {
 
     private func sharedPrefixLength(lhs: String, rhs: String) -> Int {
         zip(lhs, rhs).prefix { $0 == $1 }.count
+    }
+
+    private func internalUppercaseOffsets(in text: String) -> [Int] {
+        guard text.unicodeScalars.contains(where: { $0.properties.isLowercase }) else {
+            return []
+        }
+
+        return text.enumerated().compactMap { offset, character in
+            guard offset > 0,
+                  character.unicodeScalars.contains(where: { $0.properties.isUppercase }) else {
+                return nil
+            }
+            return offset
+        }
     }
 }

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -957,6 +957,15 @@ final class DictionaryMatcherTests: XCTestCase {
         XCTAssertEqual(result.text, "Is that MrBeast over there?")
     }
 
+    func testDoesNotReplaceUnrelatedMixedCaseTokenWithStylizedDictionaryEntry() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "MrBeast")])
+
+        let input = "Have you ever downloaded MacPaste?"
+
+        XCTAssertEqual(matcher.apply(to: input).text, input)
+    }
+
     func testSplitJoinAllowsShortTokenExactJoinForInitialedBrand() {
         let matcher = makeMatcher()
         matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "MrD")])


### PR DESCRIPTION
## Summary

This change prevents legitimate mixed-case terms from being rewritten as unrelated stylized dictionary entries when only coarse phonetic similarity supports the replacement.

- Preserves model-recognized mixed-case names such as `MacPaste` when their internal word boundary differs from the dictionary candidate.
- Keeps strong surface-spelling corrections available even when capitalization boundaries differ.
- Leaves all-caps pronunciation recovery and exact split-join behavior unchanged.
- Updates the current KeyVoxCore `1.2.6` changelog entry.

## Root cause

- Whisper can legitimately emit `MacPaste` as a recognized software name in product context.
- The dictionary phonetic fallback reduced `MacPaste` and `MrBeast` to `NKBST` and `NRBST`.
- Those coarse signatures received `0.80` phonetic similarity despite the terms having only `0.50` text similarity and sounding distinct.
- Existing stylized-token handling treated internal capitalization as supporting evidence and lowered the acceptance threshold enough to rewrite `MacPaste` as `MrBeast`.

## Dictionary matching

- Detects internal uppercase boundaries only for genuinely mixed-case observed and candidate terms.
- Rejects a stylized single-token candidate when both terms are mixed case, their internal boundaries conflict, and surface spelling is not strongly similar.
- Preserves strong spelling-based near misses so capitalization structure does not block an otherwise well-supported correction.
- Excludes all-caps inputs from this boundary comparison so acronym and spelled-uppercase recovery continues through its existing pronunciation safeguards.

## Regression coverage

- Verifies `Have you ever downloaded MacPaste?` remains unchanged when `MrBeast` is present in the dictionary.
- Retains coverage for exact `Mr. Beast` joining into `MrBeast`.
- Retains stylized possessive recovery from all-caps transcription forms.
- Retains matching-pronunciation acronym correction.

## Changelog

- Updates the current KeyVoxCore `1.2.6` entry date to August 23, 2026.
- Documents preservation of distinct model-recognized mixed-case product names when coarse phonetic similarity conflicts with their capitalization structure.

## Validation

- KeyVoxCore package: 540 tests passed.
- Exact `MacPaste` dictionary regression passed.
- `git diff --check` passed.
