### PR TITLE
fix(dictionary): require phonetic similarity for replacements

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -19,6 +19,7 @@ Spoken quantities now preserve complete hundreds-and-thousands values, Parakeet 
 - Integrated Whisper and Parakeet with the provider-neutral `KeyVoxVoiceActivity` package, preventing captures without detected speech from reaching the Parakeet decoder and producing hallucinated text.
 - Allowed unknown stylized-word phonetic near-misses to match before title-cased words without requiring those following words in the dictionary, while preserving safeguards for known words and names.
 - Preserved distinct model-recognized mixed-case product names when their internal capitalization boundaries conflict with a stylized dictionary candidate, preventing `MacPaste` from being rewritten as `MrBeast` based on coarse phonetic similarity.
+- Required non-exact dictionary replacements to pass a shared phonetic similarity gate before spelling and context can approve them, preventing unrelated-sounding words from matching.
 
 ### Notes
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardCandidateScoring.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardCandidateScoring.swift
@@ -94,11 +94,23 @@ extension DictionaryMatcher {
                             tokenIndex: start,
                             totalTokens: tokens.count
                         )
+                        || hasStrongStylizedTextEvidence(
+                            observed: form.normalized,
+                            candidate: candidateText,
+                            textSimilarity: baseScore.text
+                        )
                     let gatedFallbackPhoneticSimilarity =
                         allowStylizedFallbackBySurface ? fallbackPhoneticSimilarity : 0
                     let phoneticDelta = max(0, gatedFallbackPhoneticSimilarity - baseScore.phonetic)
                     let adjustedBaseFinal = min(1.0, baseScore.final + (scorer.phoneticWeight * phoneticDelta))
                     let adjustedPhoneticScore = max(baseScore.phonetic, gatedFallbackPhoneticSimilarity)
+                    guard scorer.hasRequiredPhoneticSimilarity(
+                        observedText: form.normalized,
+                        candidateText: candidateText,
+                        phoneticSimilarity: adjustedPhoneticScore
+                    ) else {
+                        continue
+                    }
                     let pluralHomophoneBonus: Double
                     if tokenCount == 1,
                        form.replacementSuffix == "s",

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardCandidateScoring.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardCandidateScoring.swift
@@ -216,7 +216,11 @@ extension DictionaryMatcher {
             scorer.similarity(lhs: observedPhonetic, rhs: candidatePhonetic),
             scorer.similarity(lhs: observedFallback, rhs: candidateFallback)
         )
-        guard phoneticSimilarity >= StandardEvaluationPolicy.properNounSimilarityMinimum else {
+        let minimumPhoneticSimilarity = max(
+            StandardEvaluationPolicy.properNounSimilarityMinimum,
+            scorer.minimumPhoneticSimilarity
+        )
+        guard phoneticSimilarity >= minimumPhoneticSimilarity else {
             return nil
         }
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
@@ -34,6 +34,14 @@ extension DictionaryMatcher {
         }
 
         let exactMatch = observedNormalized == best.entry.normalizedPhrase
+        guard scorer.hasRequiredPhoneticSimilarity(
+            observedText: selection.observedNormalized,
+            candidateText: best.entry.normalizedPhrase,
+            phoneticSimilarity: best.score.phonetic
+        ) else {
+            stats.rejectedLowScore += 1
+            return nil
+        }
         if tokenCount == 1,
            window[0].normalized.count < StandardEvaluationPolicy.minimumSingleTokenLength,
            !exactMatch {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
@@ -34,14 +34,6 @@ extension DictionaryMatcher {
         }
 
         let exactMatch = observedNormalized == best.entry.normalizedPhrase
-        guard scorer.hasRequiredPhoneticSimilarity(
-            observedText: selection.observedNormalized,
-            candidateText: best.entry.normalizedPhrase,
-            phoneticSimilarity: best.score.phonetic
-        ) else {
-            stats.rejectedLowScore += 1
-            return nil
-        }
         if tokenCount == 1,
            window[0].normalized.count < StandardEvaluationPolicy.minimumSingleTokenLength,
            !exactMatch {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/ReplacementScorer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/ReplacementScorer.swift
@@ -13,7 +13,8 @@ public struct ReplacementScorer {
         phoneticWeight: 0.40,
         contextWeight: 0.10,
         ambiguityMargin: 0.05,
-        commonWordOverrideThreshold: 0.94
+        commonWordOverrideThreshold: 0.94,
+        minimumPhoneticSimilarity: 0.65
     )
 
     public let textWeight: Double
@@ -21,19 +22,22 @@ public struct ReplacementScorer {
     public let contextWeight: Double
     public let ambiguityMargin: Double
     public let commonWordOverrideThreshold: Double
+    public let minimumPhoneticSimilarity: Double
 
     public init(
         textWeight: Double,
         phoneticWeight: Double,
         contextWeight: Double,
         ambiguityMargin: Double,
-        commonWordOverrideThreshold: Double
+        commonWordOverrideThreshold: Double,
+        minimumPhoneticSimilarity: Double = 0.65
     ) {
         self.textWeight = textWeight
         self.phoneticWeight = phoneticWeight
         self.contextWeight = contextWeight
         self.ambiguityMargin = ambiguityMargin
         self.commonWordOverrideThreshold = commonWordOverrideThreshold
+        self.minimumPhoneticSimilarity = minimumPhoneticSimilarity
     }
 
     public func threshold(for tokenCount: Int) -> Double {
@@ -69,6 +73,14 @@ public struct ReplacementScorer {
             context: contextScore,
             final: finalScore
         )
+    }
+
+    public func hasRequiredPhoneticSimilarity(
+        observedText: String,
+        candidateText: String,
+        phoneticSimilarity: Double
+    ) -> Bool {
+        observedText == candidateText || phoneticSimilarity >= minimumPhoneticSimilarity
     }
 
     private func contextScore(previousToken: String?, nextToken: String?) -> Double {

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherCoreLogicTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherCoreLogicTests.swift
@@ -62,6 +62,40 @@ final class DictionaryMatcherCoreLogicTests: XCTestCase {
         XCTAssertTrue(forms.contains(where: { $0.normalized == "cueboard" && $0.replacementSuffix == "'s" }))
     }
 
+    func testStandardCandidateSelectionRanksOnlyPhoneticallyEligibleCandidates() throws {
+        let observed = "abcdefghij"
+        let ineligibleCandidate = "abcdefzhij"
+        let eligibleCandidate = "abcdzzzzij"
+        let matcher = DictionaryMatcher(
+            lexicon: FakeLexicon(pronunciations: [
+                observed: "BKTFR",
+                ineligibleCandidate: "BKNSR",
+                eligibleCandidate: "BKTFS",
+            ]),
+            encoder: PhoneticEncoder(),
+            scorer: .balanced
+        )
+        matcher.rebuildIndex(entries: [
+            DictionaryEntry(phrase: ineligibleCandidate),
+            DictionaryEntry(phrase: eligibleCandidate),
+        ])
+
+        let tokens = matcher.tokenize(observed)
+        let token = try XCTUnwrap(tokens.first)
+        let candidates = try XCTUnwrap(matcher.entriesByTokenCount[1])
+        let selection = matcher.selectBestStandardCandidate(
+            start: 0,
+            tokenCount: 1,
+            tokens: tokens,
+            candidates: candidates,
+            window: [token],
+            observedNormalized: token.normalized,
+            observedPhonetic: token.phonetic
+        )
+
+        XCTAssertEqual(selection?.candidate.entry.normalizedPhrase, eligibleCandidate)
+    }
+
     func testTextNormalizationMatchesExistingBehavior() {
         XCTAssertTrue(DictionaryTextNormalization.normalizedPhrase("  Cue—Board!!! ") == "cue board")
         XCTAssertTrue(DictionaryTextNormalization.normalizedPhrase("Crème Brûlée") == "creme brulee")

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -675,6 +675,14 @@ final class DictionaryMatcherTests: XCTestCase {
         XCTAssertEqual(result.text, "I love typing on this keyboard.")
     }
 
+    func testDoesNotReplaceUnrelatedKnownWordWithStylizedDictionaryEntry() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "Cueboard")])
+
+        let input = "Go overboard talking about things."
+        XCTAssertEqual(matcher.apply(to: input).text, input)
+    }
+
     func testDoesNotReplaceKeyboardPluralInGenericProse() {
         let matcher = DictionaryMatcher(
             lexicon: PronunciationLexicon.shared,

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -416,6 +416,25 @@ final class DictionaryMatcherTests: XCTestCase {
         XCTAssertEqual(result.text, "KeyVox's lemonade")
     }
 
+    func testCandidateRelativeTrailingFormHonorsStricterConfiguredPhoneticThreshold() {
+        let scorer = ReplacementScorer(
+            textWeight: 0.50,
+            phoneticWeight: 0.40,
+            contextWeight: 0.10,
+            ambiguityMargin: 0.05,
+            commonWordOverrideThreshold: 0.94,
+            minimumPhoneticSimilarity: 0.90
+        )
+        let matcher = DictionaryMatcher(
+            lexicon: FakeLexicon(),
+            encoder: PhoneticEncoder(),
+            scorer: scorer
+        )
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "AbCde")])
+
+        XCTAssertEqual(matcher.apply(to: "abcdex").text, "abcdex")
+    }
+
     func testPreservesCandidateRelativeTrailingPluralBeforeVerb() {
         let matcher = DictionaryMatcher(
             lexicon: PronunciationLexicon.shared,

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -240,6 +240,14 @@ final class DictionaryMatcherTests: XCTestCase {
         XCTAssertEqual(result.text, "My app is called KeyVox.")
     }
 
+    func testCorrectsLowercaseStylizedBrandNearMissAfterConjunction() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "KeyVox")])
+
+        let result = matcher.apply(to: "Have you ever heard of keyboard or keybox?")
+        XCTAssertEqual(result.text, "Have you ever heard of keyboard or KeyVox?")
+    }
+
     func testCorrectsStylizedSingleTokenBrandNearMissBeforeTitlecaseProductContext() {
         let matcher = makeRuntimeMatcher()
         let entries = DictionaryBuiltInEntries.effectiveEntries(merging: [])

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/ReplacementScorerTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/ReplacementScorerTests.swift
@@ -15,6 +15,7 @@ final class ReplacementScorerTests: XCTestCase {
         let scorer = ReplacementScorer.balanced
         XCTAssertTrue(scorer.ambiguityMargin == 0.05)
         XCTAssertTrue(scorer.commonWordOverrideThreshold == 0.94)
+        XCTAssertEqual(scorer.minimumPhoneticSimilarity, 0.65)
     }
 
     func testSimilarityReturnsOneForExactAndLessForNearMatch() {
@@ -44,5 +45,27 @@ final class ReplacementScorerTests: XCTestCase {
         )
 
         XCTAssertTrue(withContext.final > withoutContext.final)
+    }
+
+    func testPhoneticGateRejectsNonExactTextWithWeakPhonetics() {
+        let scorer = ReplacementScorer.balanced
+
+        XCTAssertFalse(
+            scorer.hasRequiredPhoneticSimilarity(
+                observedText: "overboard",
+                candidateText: "cueboard",
+                phoneticSimilarity: 0.5
+            )
+        )
+    }
+
+    func testPhoneticGateAllowsExactTextRegardlessOfPronunciationCoverage() {
+        XCTAssertTrue(
+            ReplacementScorer.balanced.hasRequiredPhoneticSimilarity(
+                observedText: "cueboard",
+                candidateText: "cueboard",
+                phoneticSimilarity: 0
+            )
+        )
     }
 }


### PR DESCRIPTION
## Summary

This change prevents unrelated-sounding words from being rewritten as dictionary entries when spelling shape and surrounding context outweigh weak pronunciation evidence.

- Requires every non-exact standard dictionary candidate to meet a shared phonetic similarity minimum before replacement thresholds are evaluated.
- Preserves exact dictionary normalization even when pronunciation coverage is unavailable.
- Keeps supported phonetic near-miss, possessive, plural, split-join, and stylized-brand corrections intact.
- Updates the current KeyVoxCore `1.2.6` changelog entry.

## Root cause

- Whisper correctly emitted `Go overboard talking about things.` before dictionary normalization.
- The dictionary matcher compared `overboard` with the `Cueboard` entry and measured only `0.50` phonetic similarity.
- Text similarity and surrounding verb context still raised the candidate's final score above the lowered structural-context threshold.
- The final score could therefore approve a replacement even though its pronunciation evidence was too weak to support it.

## Dictionary matching

- Adds a shared `0.65` minimum phonetic similarity policy to the balanced replacement scorer.
- Applies the prerequisite after runtime and fallback pronunciation evidence has been assembled, so valid corrections can use their strongest supported phonetic evidence.
- Rejects non-exact standard candidates before text, context, or lowered structural thresholds can approve them.
- Exempts exact normalized text so dictionary casing and canonical formatting remain deterministic without depending on pronunciation coverage.

## Regression coverage

- Verifies `Go overboard talking about things.` remains unchanged when `Cueboard` is present in the dictionary.
- Verifies weak phonetic evidence fails the shared prerequisite.
- Verifies exact normalized dictionary text remains eligible without pronunciation evidence.
- Retains the existing dictionary matcher coverage for valid stylized, possessive, plural, multi-token, and split-join corrections.

## Changelog

- Updates the current KeyVoxCore `1.2.6` entry.
- Documents that non-exact dictionary replacements must pass the shared phonetic similarity gate before spelling and context can approve them.

## Validation

- KeyVoxCore package: 543 tests passed.
- Exact `overboard` dictionary regression passed.
- Complete dictionary matcher test class: 101 tests passed.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable minimum phonetic similarity requirement for dictionary replacements.
  - Exact text matches continue to be accepted, even when phonetic similarity is low.
  - Non-exact replacements must meet the configured phonetic threshold before being selected.

- **Bug Fixes**
  - Improved matching accuracy by preventing phonetically unrelated replacements.
  - Preserved valid corrections in contextual dictionary matching scenarios.

- **Tests**
  - Added coverage for phonetic eligibility, exact matches, and candidate selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->