### PR TITLE
fix(text-composition): preserve capitalization and hyphen spacing

### DIFF
--- a/Packages/KeyVoxTextComposition/CHANGELOG.md
+++ b/Packages/KeyVoxTextComposition/CHANGELOG.md
@@ -8,7 +8,7 @@ The format loosely follows Keep a Changelog, and the package uses semantic versi
 
 ## [1.0.3] - 2026-08-23
 
-Composed dictated capitalization, terminal marks, and missing separators with surrounding text.
+Improved dictated capitalization and spacing around colons, standalone months, hyphens, terminal marks, and surrounding text.
 
 ### Includes
 
@@ -16,12 +16,13 @@ Composed dictated capitalization, terminal marks, and missing separators with su
 - Removed an incoming model-added period when the next existing non-whitespace character is a lowercase letter.
 - Reused a matching question mark or exclamation point and replaced differing supported non-quote punctuation when processed dictation explicitly ends with either mark.
 - Left incoming terminal punctuation unchanged before straight or curly quotation marks.
+- Added one leading space when incoming text would otherwise run directly into a preceding hyphen.
 - Added one trailing space when dictated text would otherwise run into an existing letter, number, or emoji.
 - Left trailing spacing unchanged before punctuation, symbols, whitespace, or no following text, and when the dictated text already ends in whitespace.
 - Preserved incoming capitalization after a colon.
 - Preserved locale-canonical month capitalization when used alone, plus month and weekday capitalization for detected dates and spoken-number dates, while allowing relative date labels to follow normal continuation casing.
 - Shared the punctuation-boundary decision across macOS and iOS composition paths.
-- Added regression coverage for colon boundaries, standalone months, locale-canonical calendar names, relative date labels, spoken-number dates, model periods, explicit question marks and exclamation points, supported non-quote punctuation, quotation-mark boundaries, and missing trailing separators.
+- Added regression coverage for colon and hyphen boundaries, standalone months, locale-canonical calendar names, relative date labels, spoken-number dates, model periods, explicit question marks and exclamation points, supported non-quote punctuation, quotation-mark boundaries, and missing separators.
 
 ### Notes
 

--- a/Packages/KeyVoxTextComposition/CHANGELOG.md
+++ b/Packages/KeyVoxTextComposition/CHANGELOG.md
@@ -18,9 +18,10 @@ Composed dictated capitalization, terminal marks, and missing separators with su
 - Left incoming terminal punctuation unchanged before straight or curly quotation marks.
 - Added one trailing space when dictated text would otherwise run into an existing letter, number, or emoji.
 - Left trailing spacing unchanged before punctuation, symbols, whitespace, or no following text, and when the dictated text already ends in whitespace.
-- Preserved locale-canonical month and weekday capitalization for detected dates and spoken-number dates while allowing relative date labels to follow normal continuation casing.
+- Preserved incoming capitalization after a colon.
+- Preserved locale-canonical month capitalization when used alone, plus month and weekday capitalization for detected dates and spoken-number dates, while allowing relative date labels to follow normal continuation casing.
 - Shared the punctuation-boundary decision across macOS and iOS composition paths.
-- Added regression coverage for locale-canonical calendar names, relative date labels, spoken-number dates, model periods, explicit question marks and exclamation points, supported non-quote punctuation, quotation-mark boundaries, and missing trailing separators.
+- Added regression coverage for colon boundaries, standalone months, locale-canonical calendar names, relative date labels, spoken-number dates, model periods, explicit question marks and exclamation points, supported non-quote punctuation, quotation-mark boundaries, and missing trailing separators.
 
 ### Notes
 

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/LeadingDateCapitalizationPolicy.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/LeadingDateCapitalizationPolicy.swift
@@ -13,9 +13,11 @@ enum LeadingDateCapitalizationPolicy {
         let leadingWordEnd = text[capitalizationIndex...]
             .firstIndex(where: { $0.isLetter == false }) ?? text.endIndex
         let leadingWord = String(text[capitalizationIndex..<leadingWordEnd])
-        guard canonicalCalendarSymbols(for: locale).contains(leadingWord) else {
+        let calendarSymbols = canonicalCalendarSymbols(for: locale)
+        guard calendarSymbols.all.contains(leadingWord) else {
             return false
         }
+        guard calendarSymbols.months.contains(leadingWord) == false else { return true }
 
         let nsText = text as NSString
         let fullRange = NSRange(location: 0, length: nsText.length)
@@ -33,7 +35,9 @@ enum LeadingDateCapitalizationPolicy {
         )
     }
 
-    private static func canonicalCalendarSymbols(for locale: Locale) -> Set<String> {
+    private static func canonicalCalendarSymbols(
+        for locale: Locale
+    ) -> (all: Set<String>, months: Set<String>) {
         let formatter = DateFormatter()
         formatter.locale = locale
 
@@ -41,11 +45,13 @@ enum LeadingDateCapitalizationPolicy {
         calendar.locale = locale
         formatter.calendar = calendar
 
-        let symbolGroups = [
+        let monthSymbolGroups = [
             formatter.monthSymbols,
             formatter.shortMonthSymbols,
             formatter.standaloneMonthSymbols,
             formatter.shortStandaloneMonthSymbols,
+        ]
+        let weekdaySymbolGroups = [
             formatter.weekdaySymbols,
             formatter.shortWeekdaySymbols,
             formatter.standaloneWeekdaySymbols,
@@ -54,9 +60,13 @@ enum LeadingDateCapitalizationPolicy {
         let trimmingCharacters = CharacterSet.whitespacesAndNewlines
             .union(.punctuationCharacters)
 
-        return Set(symbolGroups.compactMap { $0 }.flatMap { $0 }.map {
+        let months = Set(monthSymbolGroups.compactMap { $0 }.flatMap { $0 }.map {
             $0.trimmingCharacters(in: trimmingCharacters)
         })
+        let weekdays = Set(weekdaySymbolGroups.compactMap { $0 }.flatMap { $0 }.map {
+            $0.trimmingCharacters(in: trimmingCharacters)
+        })
+        return (months.union(weekdays), months)
     }
 
     private static func beginsWithLocalizedSpelledOutNumber(

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionCharacterClassifier.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionCharacterClassifier.swift
@@ -3,6 +3,10 @@ enum TextCompositionCharacterClassifier {
         character == ":"
     }
 
+    static func isHyphenSeparator(_ character: Character) -> Bool {
+        character == "-"
+    }
+
     static func isEmoji(_ character: Character) -> Bool {
         let scalars = Array(character.unicodeScalars)
         guard let baseScalar = scalars.first else { return false }

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionCharacterClassifier.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionCharacterClassifier.swift
@@ -1,4 +1,8 @@
 enum TextCompositionCharacterClassifier {
+    static func isClauseIntroductionBoundary(_ character: Character) -> Bool {
+        character == ":"
+    }
+
     static func isEmoji(_ character: Character) -> Bool {
         let scalars = Array(character.unicodeScalars)
         guard let baseScalar = scalars.first else { return false }

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
@@ -325,6 +325,7 @@ public enum TextCompositionPolicy {
         )
         return previousIsWordLike
             || previousIsTriggerPunctuation
+            || TextCompositionCharacterClassifier.isHyphenSeparator(previousCharacter)
             || TextCompositionCharacterClassifier.isEmoji(previousCharacter)
     }
 }

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
@@ -122,6 +122,13 @@ public enum TextCompositionPolicy {
             return true
         }
 
+        if let previousNonWhitespaceCharacter = context.previousNonWhitespaceCharacter,
+           TextCompositionCharacterClassifier.isClauseIntroductionBoundary(
+               previousNonWhitespaceCharacter
+           ) {
+            return true
+        }
+
         if isImmediatelyAfterTerminalPunctuationAndDelimiter(context) {
             return true
         }

--- a/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TextCompositionPolicyTests.swift
+++ b/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TextCompositionPolicyTests.swift
@@ -120,7 +120,6 @@ final class TextCompositionPolicyTests: XCTestCase {
             Character("{"),
             Character("/"),
             Character("\\"),
-            Character(":"),
             Character("<"),
             Character(">"),
             Character("&"),
@@ -175,6 +174,15 @@ final class TextCompositionPolicyTests: XCTestCase {
                 normalize("This is new.", context: trailingWhitespaceDocumentStartContext),
                 "This is new."
             )
+        }
+    }
+
+    func testColonPreservesIncomingCapitalization() {
+        for precedingText in ["Existing text:", "Existing text:  "] {
+            let context = TextCompositionContext(precedingText: precedingText)
+
+            XCTAssertTrue(TextCompositionPolicy.isSentenceStart(in: context))
+            XCTAssertEqual(normalize("This is new.", context: context), "This is new.")
         }
     }
 
@@ -282,6 +290,24 @@ final class TextCompositionPolicyTests: XCTestCase {
                 in: dateText,
                 startingAt: capitalizationIndex,
                 locale: formatter.locale
+            )
+        )
+    }
+
+    func testDateCapitalizationPreservesStandaloneMonthName() throws {
+        let locale = Locale(identifier: "en_US_POSIX")
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.calendar = Calendar(identifier: .gregorian)
+        let month = try XCTUnwrap(formatter.monthSymbols.first)
+        let text = month + " was memorable."
+        let capitalizationIndex = try XCTUnwrap(text.indices.first)
+
+        XCTAssertTrue(
+            LeadingDateCapitalizationPolicy.shouldPreserveCapitalization(
+                in: text,
+                startingAt: capitalizationIndex,
+                locale: locale
             )
         )
     }

--- a/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TextCompositionPolicyTests.swift
+++ b/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TextCompositionPolicyTests.swift
@@ -428,6 +428,11 @@ final class TextCompositionPolicyTests: XCTestCase {
         XCTAssertEqual(applySpacing(to: "there", after: "("), "there")
     }
 
+    func testHyphenInsertsSingleLeadingSpace() {
+        XCTAssertEqual(applySpacing(to: "there", after: "-"), " there")
+        XCTAssertEqual(applySpacing(to: " there", after: "-"), " there")
+    }
+
     private func normalize(
         _ text: String,
         context: TextCompositionContext

--- a/macOS/KeyVoxTests/Services/PasteCapitalizationCoordinatorTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteCapitalizationCoordinatorTests.swift
@@ -262,6 +262,32 @@ final class PasteCapitalizationCoordinatorTests: XCTestCase {
         XCTAssertEqual(output, "Hello")
     }
 
+    func testKeepsCapitalizationAfterColon() {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 10,
+                    previousCharacter: " ",
+                    previousNonWhitespaceCharacter: ":"
+                )
+            )
+        )
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "Hello")
+    }
+
     func testLowercasesDefaultSentenceCaseMidSentence() {
         let heuristics = makeRetainedHeuristics(
             axInspector: MockPasteAXInspector(
@@ -322,6 +348,13 @@ final class PasteCapitalizationCoordinatorTests: XCTestCase {
     func testPreservesMixedCaseMidSentence() {
         let output = normalizeMidSentence("OpenAI")
         XCTAssertEqual(output, "OpenAI")
+    }
+
+    func testPreservesStandaloneMonthNameMidSentence() throws {
+        let month = try XCTUnwrap(DateFormatter().monthSymbols.first).capitalized
+        let text = month + " was memorable."
+
+        XCTAssertEqual(normalizeMidSentence(text), text)
     }
 
     func testPreservesLeadingNonLetterMidSentence() {

--- a/macOS/KeyVoxTests/Services/PasteSpacingCoordinatorTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteSpacingCoordinatorTests.swift
@@ -157,6 +157,28 @@ final class PasteSpacingCoordinatorTests: XCTestCase {
         XCTAssertEqual(output, " hello")
     }
 
+    func testInsertsLeadingSpaceFromAXContextAfterHyphen() {
+        let inspector = MockPasteAXInspector(
+            focusedContext: PasteInsertionContext(
+                selectionLength: 0,
+                caretLocation: 8,
+                previousCharacter: "-"
+            )
+        )
+        let heuristics = makeRetainedHeuristics(axInspector: inspector, heuristicTTL: 10)
+
+        let output = heuristics.applySmartLeadingSeparatorIfNeeded(
+            to: "hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            identityMatcher: identityMatcher
+        )
+
+        XCTAssertEqual(output, " hello")
+    }
+
     func testInsertsLeadingSpaceFromAXContextWhenPreviousCharacterIsEmoji() {
         for previousCharacter in [Character("😎"), Character("©️"), Character("#️⃣")] {
             let inspector = MockPasteAXInspector(


### PR DESCRIPTION
## Summary

This change preserves expected capitalization when dictated text is composed after a colon or begins with a locale-recognized standalone month name, and inserts missing spacing after a preceding hyphen.

- Treats a colon as a shared capitalization boundary, including when whitespace follows it.
- Preserves full and abbreviated localized month names without requiring a day or year.
- Inserts one leading space when incoming text would otherwise run directly into a preceding hyphen.
- Keeps ordinary mid-sentence capitalization normalization and existing spacing behavior unchanged outside these boundaries.
- Updates the current `KeyVoxTextComposition` `1.0.3` changelog entry.

## Root cause

- Shared text composition lowercases default sentence-case text when insertion occurs in an ordinary continuation context.
- A bare colon was previously grouped with non-terminal punctuation, so incoming `Hello` became `hello` after text such as `Side note:`.
- The locale-aware calendar policy recognized month and weekday symbols but preserved them only when the system date detector found a date or a localized spelled-out number followed.
- A standalone month sentence such as `October was great.` therefore fell through to normal continuation lowercasing.
- The smart leading-separator policy handled words, supported punctuation, and emoji, but did not classify a preceding hyphen as a spacing boundary, allowing incoming text to attach directly to it.

## Composition capitalization and spacing

- Adds a shared clause-introduction classification for colons and evaluates the previous non-whitespace character so both immediate and space-separated insertion contexts behave consistently.
- Separates locale-derived month symbols from the broader calendar-symbol set.
- Preserves standalone full and abbreviated month names before consulting the date detector.
- Retains the existing detected-date and spoken-number handling for months and weekdays.
- Adds a shared hyphen-separator classification to the leading-spacing policy.
- Inserts exactly one leading space after a hyphen and leaves incoming text unchanged when it already begins with whitespace.
- Applies through the shared package used by both macOS and iOS composition paths.

## Behavior boundaries

- Standalone weekdays still require recognized date context; this change only broadens standalone month handling.
- Locale data remains the source of truth, so no English month names are hard-coded.
- Lexically ambiguous month names such as `May` and `March` preserve capitalization when they begin incoming text by design.
- Colon capitalization and hyphen spacing are separate shared boundary rules.
- Hyphen spacing does not alter other opening delimiters, incoming punctuation, or existing whitespace.

## Regression coverage

- Verifies capitalization is preserved directly after a colon and after a colon followed by whitespace.
- Verifies a locale-derived standalone month remains capitalized in the shared package.
- Verifies the macOS composition consumer preserves colon-boundary capitalization.
- Verifies the macOS composition consumer capitalizes its localized month fixture before exercising standalone-month preservation, making the regression deterministic across process locales.
- Verifies shared composition inserts one space after a hyphen without duplicating existing whitespace.
- Verifies the macOS spacing consumer carries the hyphen boundary through its editor-context path.
- Retains existing coverage for sentence boundaries, quotations, emoji, detected dates, spoken-number dates, relative date labels, ordinary continuation lowercasing, and existing separator behavior.

## Changelog

- Updates the current `KeyVoxTextComposition` `1.0.3` entry.
- Documents colon-boundary capitalization, standalone localized month preservation, hyphen spacing, and their regression coverage.

## Validation

- KeyVoxTextComposition package: 33 tests passed.
- macOS `PasteCapitalizationCoordinatorTests`: 29 tests passed.
- macOS `PasteSpacingCoordinatorTests`: 16 tests passed.
- `git diff --check` passed.