### PR TITLE
fix(text-composition): preserve punctuation before line and URL boundaries

### DIFF
--- a/Packages/KeyVoxTextComposition/CHANGELOG.md
+++ b/Packages/KeyVoxTextComposition/CHANGELOG.md
@@ -8,12 +8,13 @@ The format loosely follows Keep a Changelog, and the package uses semantic versi
 
 ## [1.0.3] - 2026-08-23
 
-Improved dictated capitalization and spacing around colons, standalone months, hyphens, terminal marks, and surrounding text.
+Improved dictated capitalization, punctuation, and spacing around colons, standalone months, hyphens, terminal marks, URLs, line boundaries, and surrounding text.
 
 ### Includes
 
 - Removed an incoming model-added period when supported non-quote punctuation already follows the selected text.
 - Removed an incoming model-added period when the next existing non-whitespace character is a lowercase letter.
+- Preserved an incoming model-added period when the following content begins on a new line or with a URL.
 - Reused a matching question mark or exclamation point and replaced differing supported non-quote punctuation when processed dictation explicitly ends with either mark.
 - Left incoming terminal punctuation unchanged before straight or curly quotation marks.
 - Added one leading space when incoming text would otherwise run directly into a preceding hyphen.
@@ -22,11 +23,11 @@ Improved dictated capitalization and spacing around colons, standalone months, h
 - Preserved incoming capitalization after a colon.
 - Preserved locale-canonical month capitalization when used alone, plus month and weekday capitalization for detected dates and spoken-number dates, while allowing relative date labels to follow normal continuation casing.
 - Shared the punctuation-boundary decision across macOS and iOS composition paths.
-- Added regression coverage for colon and hyphen boundaries, standalone months, locale-canonical calendar names, relative date labels, spoken-number dates, model periods, explicit question marks and exclamation points, supported non-quote punctuation, quotation-mark boundaries, and missing separators.
+- Added regression coverage for colon and hyphen boundaries, standalone months, locale-canonical calendar names, relative date labels, spoken-number dates, model periods, explicit question marks and exclamation points, supported non-quote punctuation, quotation-mark boundaries, new lines, URLs, and missing separators.
 
 ### Notes
 
-- `1.0.3` bumps the tracked patch version for locale-aware capitalization, punctuation-aware composition, and missing trailing separators.
+- `1.0.3` bumps the tracked patch version for locale-aware capitalization, punctuation-aware composition across line and URL boundaries, and missing trailing separators.
 
 ## [1.0.2] - 2026-08-08
 

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TerminalPunctuationCompositionPolicy.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TerminalPunctuationCompositionPolicy.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct TerminalPunctuationCompositionResult: Equatable, Sendable {
     public let text: String
     public let shouldReplaceFollowingPunctuation: Bool
@@ -12,7 +14,8 @@ public enum TerminalPunctuationCompositionPolicy {
     public static func resolve(
         text: String,
         followingCharacter: Character?,
-        followingNonWhitespaceCharacter: Character? = nil
+        followingNonWhitespaceCharacter: Character? = nil,
+        followingText: String? = nil
     ) -> TerminalPunctuationCompositionResult {
         guard let followingCharacter,
               let incomingPunctuation = text.last,
@@ -26,6 +29,14 @@ public enum TerminalPunctuationCompositionPolicy {
         let nextContentCharacter = followingCharacter.isWhitespace
             ? followingNonWhitespaceCharacter
             : followingCharacter
+        let startsNewLine = followingCharacter.isNewline
+        let startsWithURL = followingText.map(URLShapeDetector.startsWithURL) == true
+        if incomingPunctuation == ".", startsNewLine || startsWithURL {
+            return TerminalPunctuationCompositionResult(
+                text: text,
+                shouldReplaceFollowingPunctuation: false
+            )
+        }
         if incomingPunctuation == ".", nextContentCharacter?.isLowercase == true {
             return TerminalPunctuationCompositionResult(
                 text: String(text.dropLast()),
@@ -68,5 +79,11 @@ public enum TerminalPunctuationCompositionPolicy {
         default:
             return false
         }
+    }
+}
+
+private extension Character {
+    var isNewline: Bool {
+        unicodeScalars.allSatisfy(CharacterSet.newlines.contains)
     }
 }

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/URLShapeDetector.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/URLShapeDetector.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum URLShapeDetector {
+    private static let detector = try? NSDataDetector(
+        types: NSTextCheckingResult.CheckingType.link.rawValue
+    )
+
+    static func startsWithURL(afterLeadingWhitespaceIn text: String) -> Bool {
+        let candidate = String(text.drop(while: \.isWhitespace))
+        guard candidate.isEmpty == false, let detector else { return false }
+
+        let range = NSRange(candidate.startIndex..<candidate.endIndex, in: candidate)
+        guard let match = detector.firstMatch(in: candidate, range: range) else {
+            return false
+        }
+        return match.resultType == .link && match.range.location == 0
+    }
+}

--- a/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TerminalPunctuationCompositionPolicyTests.swift
+++ b/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TerminalPunctuationCompositionPolicyTests.swift
@@ -19,6 +19,42 @@ final class TerminalPunctuationCompositionPolicyTests: XCTestCase {
         }
     }
 
+    func testModelPeriodIsPreservedBeforeLowercaseContentOnFollowingLine() {
+        let result = TerminalPunctuationCompositionPolicy.resolve(
+            text: "This is cool.",
+            followingCharacter: "\n",
+            followingNonWhitespaceCharacter: "t",
+            followingText: "\ntest"
+        )
+
+        XCTAssertEqual(result.text, "This is cool.")
+        XCTAssertFalse(result.shouldReplaceFollowingPunctuation)
+    }
+
+    func testModelPeriodIsPreservedBeforeURLOnFollowingLine() {
+        let result = TerminalPunctuationCompositionPolicy.resolve(
+            text: "This is cool.",
+            followingCharacter: "\n",
+            followingNonWhitespaceCharacter: "h",
+            followingText: "\nhttps://example.com"
+        )
+
+        XCTAssertEqual(result.text, "This is cool.")
+        XCTAssertFalse(result.shouldReplaceFollowingPunctuation)
+    }
+
+    func testModelPeriodIsPreservedBeforeURLOnSameLine() {
+        let result = TerminalPunctuationCompositionPolicy.resolve(
+            text: "This is cool.",
+            followingCharacter: " ",
+            followingNonWhitespaceCharacter: "h",
+            followingText: " https://example.com"
+        )
+
+        XCTAssertEqual(result.text, "This is cool.")
+        XCTAssertFalse(result.shouldReplaceFollowingPunctuation)
+    }
+
     func testModelPeriodIsPreservedBeforeNonLowercaseContent() {
         for followingCharacter in [Character("A"), Character("2"), Character("😎")] {
             let result = TerminalPunctuationCompositionPolicy.resolve(

--- a/iOS/KeyVox Keyboard/Core/Input/KeyboardTextInputController.swift
+++ b/iOS/KeyVox Keyboard/Core/Input/KeyboardTextInputController.swift
@@ -183,7 +183,8 @@ final class KeyboardTextInputController {
         let punctuationResolution = TerminalPunctuationCompositionPolicy.resolve(
             text: preparedText,
             followingCharacter: followingCharacter,
-            followingNonWhitespaceCharacter: followingNonWhitespaceCharacter
+            followingNonWhitespaceCharacter: followingNonWhitespaceCharacter,
+            followingText: contextAfterInput
         )
         let insertionText = TrailingSeparatorCompositionPolicy.applyIfNeeded(
             to: punctuationResolution.text,

--- a/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardTextInputControllerTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/Keyboard/KeyboardTextInputControllerTests.swift
@@ -316,6 +316,29 @@ struct KeyboardTextInputControllerTests {
         }
     }
 
+    @Test func transcriptionInsertionPreservesPeriodBeforeNewLineAndURLContent() {
+        let insertionCases = [
+            (followingText: "\ntest", expected: "This is cool.\ntest"),
+            (followingText: "\nhttps://example.com", expected: "This is cool.\nhttps://example.com"),
+            (followingText: "https://example.com", expected: "This is cool. https://example.com"),
+        ]
+        for testCase in insertionCases {
+            let documentProxy = StatefulSelectionDocumentProxy(
+                text: testCase.followingText,
+                caretBefore: testCase.followingText
+            )
+            let controller = KeyboardTextInputController(
+                documentProxy: documentProxy,
+                emitKeypress: {}
+            )
+
+            let inserted = controller.insertTranscription("This is cool.")
+
+            #expect(inserted == true)
+            #expect(documentProxy.text == testCase.expected)
+        }
+    }
+
     @Test func transcriptionInsertionDoesNotAddTrailingSeparatorBeforePunctuation() {
         for punctuation in [".", ",", "?", "!", ":", ";"] {
             let original = "That's\(punctuation)"

--- a/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
+++ b/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
@@ -112,6 +112,7 @@ final class PasteAXInspector: PasteAXInspecting {
         var previousCharacter: Character?
         var followingCharacter: Character?
         var followingNonWhitespaceCharacter: Character?
+        var followingText: String?
         var characterBeforePreviousCharacter: Character?
         var previousNonWhitespaceCharacter: Character?
         var characterBeforePreviousNonWhitespaceCharacter: Character?
@@ -146,6 +147,10 @@ final class PasteAXInspector: PasteAXInspecting {
         if let caretLocation,
            let selectionLength {
             let followingLocation = caretLocation + selectionLength
+            followingText = textFollowingSelection(
+                from: followingLocation,
+                element: focusedElement
+            )
             followingCharacter = stringForRange(
                 CFRange(location: followingLocation, length: 1),
                 element: focusedElement
@@ -167,6 +172,7 @@ final class PasteAXInspector: PasteAXInspecting {
             previousCharacter: previousCharacter,
             followingCharacter: followingCharacter,
             followingNonWhitespaceCharacter: followingNonWhitespaceCharacter,
+            followingText: followingText,
             characterBeforePreviousCharacter: characterBeforePreviousCharacter,
             previousNonWhitespaceCharacter: previousNonWhitespaceCharacter,
             characterBeforePreviousNonWhitespaceCharacter: characterBeforePreviousNonWhitespaceCharacter,
@@ -209,6 +215,32 @@ final class PasteAXInspector: PasteAXInspecting {
             }
         }
         return nil
+    }
+
+    private func textFollowingSelection(
+        from location: Int,
+        element: AXUIElement
+    ) -> String? {
+        if let value = valueString(for: element) {
+            let safeLocation = min(max(0, location), value.utf16.count)
+            return String(decoding: value.utf16.dropFirst(safeLocation), as: UTF16.self)
+        }
+
+        var longestText: String?
+        for length in 1...maxFollowingNonWhitespaceScanLength {
+            guard let text = stringForRange(
+                CFRange(location: location, length: length),
+                element: element
+            ) else {
+                break
+            }
+            longestText = text
+            let content = text.drop(while: \.isWhitespace)
+            if content.dropFirst().contains(where: \.isWhitespace) {
+                break
+            }
+        }
+        return longestText
     }
 
     func focusedUIElement() -> AXUIElement? {

--- a/macOS/Core/Services/Paste/Composition/PasteTerminalPunctuationCoordinator.swift
+++ b/macOS/Core/Services/Paste/Composition/PasteTerminalPunctuationCoordinator.swift
@@ -44,7 +44,8 @@ final class PasteTerminalPunctuationCoordinator: PasteTerminalPunctuationCoordin
         let resolution = TerminalPunctuationCompositionPolicy.resolve(
             text: text,
             followingCharacter: context.followingCharacter,
-            followingNonWhitespaceCharacter: context.followingNonWhitespaceCharacter
+            followingNonWhitespaceCharacter: context.followingNonWhitespaceCharacter,
+            followingText: context.followingText
         )
         guard resolution.shouldReplaceFollowingPunctuation else {
             return PasteTerminalPunctuationInsertion(

--- a/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
+++ b/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
@@ -13,6 +13,7 @@ struct PasteInsertionContext {
     let previousCharacter: Character?
     let followingCharacter: Character?
     let followingNonWhitespaceCharacter: Character?
+    let followingText: String?
     let characterBeforePreviousCharacter: Character?
     let previousNonWhitespaceCharacter: Character?
     let characterBeforePreviousNonWhitespaceCharacter: Character?
@@ -25,6 +26,7 @@ struct PasteInsertionContext {
         previousCharacter: Character?,
         followingCharacter: Character? = nil,
         followingNonWhitespaceCharacter: Character? = nil,
+        followingText: String? = nil,
         characterBeforePreviousCharacter: Character? = nil,
         previousNonWhitespaceCharacter: Character? = nil,
         characterBeforePreviousNonWhitespaceCharacter: Character? = nil,
@@ -36,6 +38,7 @@ struct PasteInsertionContext {
         self.previousCharacter = previousCharacter
         self.followingCharacter = followingCharacter
         self.followingNonWhitespaceCharacter = followingNonWhitespaceCharacter
+        self.followingText = followingText
         self.characterBeforePreviousCharacter = characterBeforePreviousCharacter
         self.previousNonWhitespaceCharacter = previousNonWhitespaceCharacter
         self.characterBeforePreviousNonWhitespaceCharacter = characterBeforePreviousNonWhitespaceCharacter

--- a/macOS/KeyVoxTests/Services/PasteTerminalPunctuationCoordinatorTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteTerminalPunctuationCoordinatorTests.swift
@@ -25,6 +25,42 @@ final class PasteTerminalPunctuationCoordinatorTests: XCTestCase {
         XCTAssertTrue(inspector.expandedSelections.isEmpty)
     }
 
+    func testPreservesModelPeriodBeforeNewLineAndURLContent() {
+        let element = AXUIElementCreateApplication(getpid())
+        let insertionCases = [
+            (followingText: "\ntest", followingCharacter: Character("\n"), nextContent: Character("t")),
+            (
+                followingText: "\nhttps://example.com",
+                followingCharacter: Character("\n"),
+                nextContent: Character("h")
+            ),
+            (
+                followingText: " https://example.com",
+                followingCharacter: Character(" "),
+                nextContent: Character("h")
+            ),
+        ]
+        for testCase in insertionCases {
+            let inspector = TerminalPunctuationAXInspector(
+                context: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 0,
+                    previousCharacter: nil,
+                    followingCharacter: testCase.followingCharacter,
+                    followingNonWhitespaceCharacter: testCase.nextContent,
+                    followingText: testCase.followingText
+                ),
+                element: element
+            )
+            let coordinator = PasteTerminalPunctuationCoordinator(axInspector: inspector)
+
+            let output = coordinator.resolveAdjacentTerminalPunctuation(in: "This is cool.")
+
+            XCTAssertEqual(output.text, "This is cool.")
+            XCTAssertTrue(inspector.expandedSelections.isEmpty)
+        }
+    }
+
     func testRemovesModelPeriodBeforeExistingPunctuation() {
         let element = AXUIElementCreateApplication(getpid())
         for existingPunctuation in [


### PR DESCRIPTION
## Summary

This change preserves terminal punctuation when dictated text is inserted before content on a new line or before an adjacent URL, while retaining the existing lowercase-continuation behavior for ordinary prose.

- Treats a following new line as a hard punctuation boundary.
- Recognizes URL-shaped following content through the shared composition package.
- Carries the available following text through both iOS keyboard and macOS paste composition paths.
- Keeps model-added period removal unchanged for genuine lowercase sentence continuations.
- Updates the current `KeyVoxTextComposition` `1.0.3` changelog entry.

## Root cause

- Shared punctuation composition previously looked past whitespace and removed an incoming model-added period whenever the next visible character was lowercase.
- That correctly handled ordinary continuations, but it also treated lowercase content on a following line as part of the same sentence.
- URLs commonly begin with lowercase characters, so an adjacent URL produced the same false continuation signal.
- The composition policy received only the immediate and next non-whitespace characters, which was not enough context to distinguish URL structure from ordinary prose.

## Terminal punctuation composition

- Extends shared punctuation resolution with the available following text.
- Preserves an incoming model-added period when the immediate following character is a new line.
- Uses structural link detection to recognize when the next content begins with a URL.
- Keeps URL recognition in a dedicated shared detector rather than hard-coding domains or example text.
- Passes iOS document-proxy context into the shared policy.
- Collects and carries macOS Accessibility text following the active selection into the same policy.
- Applies the same composition decision across iOS and macOS insertion paths.

## Behavior boundaries

- URL handling applies when the URL is the next existing content after the insertion point.
- A URL elsewhere in the text box does not globally change punctuation behavior.
- Ordinary lowercase continuation text still absorbs a model-added period.
- Existing question-mark, exclamation-mark, punctuation-replacement, quotation, and separator behavior remains unchanged.
- The change does not rewrite existing editor content.

## Regression coverage

- Verifies an incoming period is preserved before lowercase content on a following line.
- Verifies an incoming period is preserved before a URL on a following line.
- Verifies an incoming period is preserved before a URL on the same line.
- Verifies the shared policy still removes a model-added period before an ordinary lowercase continuation.
- Verifies the complete iOS keyboard insertion result for all three reported boundaries.
- Verifies the macOS paste coordinator carries all three boundaries through its editor-context path.

## Changelog

- Updates the current `KeyVoxTextComposition` `1.0.3` entry.
- Refreshes the summary, included behavior, regression coverage, and package-version notes for line and URL boundaries.

## Validation

- KeyVoxTextComposition package: 36 tests passed.
- iOS `KeyboardTextInputControllerTests` focused regression passed.
- macOS `PasteTerminalPunctuationCoordinatorTests`: 1 focused test passed.
- `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved punctuation handling during transcription and paste insertion.
  * Terminal periods are now preserved before new lines, lowercase text, and URLs.
  * Added appropriate spacing before URLs when they follow text on the same line.

* **Tests**
  * Expanded regression coverage for newline, URL, punctuation, and spacing scenarios across iOS and macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->