### PR TITLE
fix(mac-paste): preserve capitalization across whitespace boundaries

### DIFF
--- a/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
+++ b/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
@@ -117,6 +117,7 @@ final class PasteAXInspector: PasteAXInspecting {
         var previousNonWhitespaceCharacter: Character?
         var characterBeforePreviousNonWhitespaceCharacter: Character?
         var isPreviousNonWhitespaceCharacterAtLineStart = false
+        var isAfterNewline = false
         if let caretLocation, caretLocation > 0 {
             if let precedingText = textBeforeCaret(
                 element: focusedElement,
@@ -125,6 +126,7 @@ final class PasteAXInspector: PasteAXInspecting {
                 let precedingCharacters = Array(precedingText)
                 previousCharacter = precedingCharacters.last
                 characterBeforePreviousCharacter = precedingCharacters.dropLast().last
+                isAfterNewline = Self.isAfterNewlineInTrailingWhitespace(precedingText)
 
                 let precedingNonWhitespace = precedingCharacters.reversed().filter {
                     !$0.isWhitespace
@@ -176,7 +178,8 @@ final class PasteAXInspector: PasteAXInspecting {
             characterBeforePreviousCharacter: characterBeforePreviousCharacter,
             previousNonWhitespaceCharacter: previousNonWhitespaceCharacter,
             characterBeforePreviousNonWhitespaceCharacter: characterBeforePreviousNonWhitespaceCharacter,
-            isPreviousNonWhitespaceCharacterAtLineStart: isPreviousNonWhitespaceCharacterAtLineStart
+            isPreviousNonWhitespaceCharacterAtLineStart: isPreviousNonWhitespaceCharacterAtLineStart,
+            isAfterNewline: isAfterNewline
         )
         #if DEBUG
         if ProcessInfo.processInfo.environment["KVX_DEBUG_LOG_RAW_TEXT"] == "1" {
@@ -192,11 +195,18 @@ final class PasteAXInspector: PasteAXInspecting {
                     + "beforePrevious=\(String(reflecting: characterBeforePreviousCharacter)) "
                     + "previousNonWhitespace=\(String(reflecting: previousNonWhitespaceCharacter)) "
                     + "beforePreviousNonWhitespace=\(String(reflecting: characterBeforePreviousNonWhitespaceCharacter)) "
-                    + "previousNonWhitespaceAtLineStart=\(isPreviousNonWhitespaceCharacterAtLineStart)"
+                    + "previousNonWhitespaceAtLineStart=\(isPreviousNonWhitespaceCharacterAtLineStart) "
+                    + "isAfterNewline=\(isAfterNewline)"
             )
         }
         #endif
         return context
+    }
+
+    static func isAfterNewlineInTrailingWhitespace(_ text: String) -> Bool {
+        text.reversed().prefix(while: \.isWhitespace).contains { character in
+            character.unicodeScalars.allSatisfy(CharacterSet.newlines.contains)
+        }
     }
 
     private func firstNonWhitespaceCharacter(

--- a/macOS/Core/Services/Paste/Composition/PasteCapitalizationCoordinator.swift
+++ b/macOS/Core/Services/Paste/Composition/PasteCapitalizationCoordinator.swift
@@ -130,7 +130,8 @@ final class PasteCapitalizationCoordinator: PasteCapitalizationCoordinating {
             previousNonWhitespaceCharacter: precedingNonWhitespaceCharacters.first,
             characterBeforePreviousNonWhitespaceCharacter: precedingNonWhitespaceCharacters.dropFirst().first,
             isPreviousNonWhitespaceCharacterAtLineStart: context.isPreviousNonWhitespaceCharacterAtLineStart,
-            isAfterNewline: previousCharacter?.isNewline == true
+            isAfterNewline: context.isAfterNewline
+                || previousCharacter?.isNewline == true
                 || characterBeforePreviousCharacter?.isNewline == true
         )
     }

--- a/macOS/Core/Services/Paste/Composition/PasteCapitalizationCoordinator.swift
+++ b/macOS/Core/Services/Paste/Composition/PasteCapitalizationCoordinator.swift
@@ -121,9 +121,10 @@ final class PasteCapitalizationCoordinator: PasteCapitalizationCoordinating {
         ].compactMap { $0 }.filter { !$0.isInvisibleFormatCharacter }
         let previousCharacter = precedingCharacters.first
         let characterBeforePreviousCharacter = precedingCharacters.dropFirst().first
+        let hasPrecedingContent = precedingNonWhitespaceCharacters.isEmpty == false
 
         return TextCompositionContext(
-            isAtDocumentStart: false,
+            isAtDocumentStart: hasPrecedingContent == false,
             previousCharacter: previousCharacter,
             characterBeforePreviousCharacter: characterBeforePreviousCharacter,
             previousNonWhitespaceCharacter: precedingNonWhitespaceCharacters.first,

--- a/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
+++ b/macOS/Core/Services/Paste/Pipeline/PasteModels.swift
@@ -18,6 +18,7 @@ struct PasteInsertionContext {
     let previousNonWhitespaceCharacter: Character?
     let characterBeforePreviousNonWhitespaceCharacter: Character?
     let isPreviousNonWhitespaceCharacterAtLineStart: Bool
+    let isAfterNewline: Bool
 
     init(
         selectionLength: Int?,
@@ -30,7 +31,8 @@ struct PasteInsertionContext {
         characterBeforePreviousCharacter: Character? = nil,
         previousNonWhitespaceCharacter: Character? = nil,
         characterBeforePreviousNonWhitespaceCharacter: Character? = nil,
-        isPreviousNonWhitespaceCharacterAtLineStart: Bool = false
+        isPreviousNonWhitespaceCharacterAtLineStart: Bool = false,
+        isAfterNewline: Bool = false
     ) {
         self.selectionLength = selectionLength
         self.selectedText = selectedText
@@ -43,6 +45,7 @@ struct PasteInsertionContext {
         self.previousNonWhitespaceCharacter = previousNonWhitespaceCharacter
         self.characterBeforePreviousNonWhitespaceCharacter = characterBeforePreviousNonWhitespaceCharacter
         self.isPreviousNonWhitespaceCharacterAtLineStart = isPreviousNonWhitespaceCharacterAtLineStart
+        self.isAfterNewline = isAfterNewline
     }
 }
 

--- a/macOS/KeyVoxTests/Services/PasteCapitalizationCoordinatorTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteCapitalizationCoordinatorTests.swift
@@ -263,6 +263,34 @@ final class PasteCapitalizationCoordinatorTests: XCTestCase {
         XCTAssertEqual(output, "Hello")
     }
 
+    func testKeepsCapitalizationAfterNewLineWithMultipleIndentationSpaces() {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 7,
+                    previousCharacter: " ",
+                    characterBeforePreviousCharacter: " ",
+                    previousNonWhitespaceCharacter: "x",
+                    isAfterNewline: true
+                )
+            )
+        )
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "Hello")
+    }
+
     func testKeepsCapitalizationAfterPunctuationAndSpace() {
         let heuristics = makeRetainedHeuristics(
             axInspector: MockPasteAXInspector(

--- a/macOS/KeyVoxTests/Services/PasteCapitalizationCoordinatorTests.swift
+++ b/macOS/KeyVoxTests/Services/PasteCapitalizationCoordinatorTests.swift
@@ -55,6 +55,33 @@ final class PasteCapitalizationCoordinatorTests: XCTestCase {
         XCTAssertEqual(output, "Hello")
     }
 
+    func testKeepsCapitalizationWhenFieldContainsOnlyWhitespaceBeforeCaret() {
+        let heuristics = makeRetainedHeuristics(
+            axInspector: MockPasteAXInspector(
+                focusedContext: PasteInsertionContext(
+                    selectionLength: 0,
+                    caretLocation: 2,
+                    previousCharacter: " ",
+                    characterBeforePreviousCharacter: " ",
+                    previousNonWhitespaceCharacter: nil
+                )
+            )
+        )
+
+        let output = heuristics.normalizeLeadingCapitalizationIfNeeded(
+            in: "Hello",
+            currentIdentity: identity("com.example.app", 1),
+            lastInsertionAppIdentity: nil,
+            lastInsertionAt: .distantPast,
+            lastInsertedTrailingCharacter: nil,
+            lastInsertedTrailingNonWhitespaceCharacter: nil,
+            identityMatcher: identityMatcher,
+            shouldPreserveLeadingCapitalization: { _ in false }
+        )
+
+        XCTAssertEqual(output, "Hello")
+    }
+
     func testKeepsCapitalizationAfterPeriod() {
         assertSentenceBoundaryPreservesCapitalization(previousCharacter: ".")
     }

--- a/macOS/KeyVoxTests/Services/PastePoliciesStabilityTests.swift
+++ b/macOS/KeyVoxTests/Services/PastePoliciesStabilityTests.swift
@@ -118,6 +118,11 @@ final class PastePoliciesStabilityTests: XCTestCase {
         )
     }
 
+    func testTrailingWhitespaceRetainsNewlineBoundaryAcrossIndentation() {
+        XCTAssertTrue(PasteAXInspector.isAfterNewlineInTrailingWhitespace("first line\n  "))
+        XCTAssertFalse(PasteAXInspector.isAfterNewlineInTrailingWhitespace("first line  "))
+    }
+
     func testListMultilineOverridePolicyMatchesPreFixBehavior() {
         assertListRenderMode(
             PastePolicies.listRenderMode(


### PR DESCRIPTION
## Summary

- Preserves sentence-leading capitalization when a text field contains only whitespace before the caret.
- Preserves capitalization after a newline followed by one or more indentation spaces.
- Applies the correction through shared macOS accessibility context without editor-specific checks.

## macOS paste behavior

- Treats whitespace-only field context as the start of content instead of a mid-sentence continuation.
- Detects a newline anywhere within the trailing whitespace before the caret.
- Carries that line-boundary signal from accessibility inspection into the existing capitalization policy.
- Keeps ordinary same-line spacing and mid-sentence capitalization behavior unchanged.

## Regression coverage

- Covers whitespace-only fields with multiple spaces before the caret.
- Covers new lines with multiple indentation spaces after preceding unpunctuated text.
- Confirms same-line trailing spaces do not become newline boundaries.

## Validation

- Focused paste capitalization and stability suites — 44 tests passed with 0 failures.
- Full `KeyVox DEBUG` macOS build — succeeded.
- `git diff --check` — passed.
