### PR TITLE
fix(dictionary): require aligned phonetic evidence

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -6,9 +6,9 @@ The format loosely follows Keep a Changelog and the package uses semantic versio
 
 ---
 
-## [1.2.7] - 2026-08-27
+## [1.2.7] - 2026-08-28
 
-Numbered lists now remain detectable when their item content contains unrelated numbers.
+Numbered lists now remain detectable around unrelated numbers, and multiword dictionary replacements require phonetic agreement for every changed word.
 
 ### Includes
 
@@ -16,10 +16,12 @@ Numbered lists now remain detectable when their item content contains unrelated 
 - Allowed explicit two-item lists and lists with three or more sequential markers to remain valid when later content contains higher numbers.
 - Preserved the skipped-marker safeguard for ambiguous undelimited two-item sequences.
 - Added regression coverage for numeric ranges after a final list marker and unrelated numbers between a longer sequence of list markers.
+- Required each changed word in an aligned multiword dictionary candidate to independently pass the phonetic threshold, preventing an exact shared word from masking an unrelated word during plural or possessive matching.
+- Added regression coverage ensuring `six dictations` does not match `Big Dictation`.
 
 ### Notes
 
-- `1.2.7` tracks mixed-number list-pattern detection improvements in the shared Core engine.
+- `1.2.7` tracks mixed-number list-pattern detection and stricter multiword dictionary phonetic alignment in the shared Core engine.
 
 ---
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardCandidateScoring.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardCandidateScoring.swift
@@ -104,6 +104,12 @@ extension DictionaryMatcher {
                     let phoneticDelta = max(0, gatedFallbackPhoneticSimilarity - baseScore.phonetic)
                     let adjustedBaseFinal = min(1.0, baseScore.final + (scorer.phoneticWeight * phoneticDelta))
                     let adjustedPhoneticScore = max(baseScore.phonetic, gatedFallbackPhoneticSimilarity)
+                    guard hasRequiredAlignedTokenPhonetics(
+                        observedText: form.normalized,
+                        candidateText: candidateText
+                    ) else {
+                        continue
+                    }
                     guard scorer.hasRequiredPhoneticSimilarity(
                         observedText: form.normalized,
                         candidateText: candidateText,

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+AlignedPhoneticEvidence.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+AlignedPhoneticEvidence.swift
@@ -1,0 +1,29 @@
+extension DictionaryMatcher {
+    func hasRequiredAlignedTokenPhonetics(
+        observedText: String,
+        candidateText: String
+    ) -> Bool {
+        let observedTokens = observedText.split(separator: " ").map(String.init)
+        let candidateTokens = candidateText.split(separator: " ").map(String.init)
+
+        guard observedTokens.count > 1,
+              observedTokens.count == candidateTokens.count else {
+            return true
+        }
+
+        return zip(observedTokens, candidateTokens).allSatisfy { observed, candidate in
+            guard observed != candidate else { return true }
+
+            let observedPhonetic = encoder.scoringSignature(for: observed, lexicon: lexicon)
+            let candidatePhonetic = encoder.scoringSignature(for: candidate, lexicon: lexicon)
+            let observedFallback = encoder.fallbackSignature(for: observed)
+            let candidateFallback = encoder.fallbackSignature(for: candidate)
+            let similarity = max(
+                scorer.similarity(lhs: observedPhonetic, rhs: candidatePhonetic),
+                scorer.similarity(lhs: observedFallback, rhs: candidateFallback)
+            )
+
+            return similarity >= scorer.minimumPhoneticSimilarity
+        }
+    }
+}

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherTests.swift
@@ -4,6 +4,14 @@ import XCTest
 
 @MainActor
 final class DictionaryMatcherTests: XCTestCase {
+    func testDoesNotMatchSixDictationsToBigDictation() {
+        let matcher = makeRuntimeMatcher()
+        matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "Big Dictation")])
+        let input = "Did you try six dictations?"
+
+        XCTAssertEqual(matcher.apply(to: input).text, input)
+    }
+
     func testDoesNotMatchNumericDictionaryEntryToUnrelatedPluralTail() {
         let matcher = makeRuntimeMatcher()
         matcher.rebuildIndex(entries: [DictionaryEntry(phrase: "7-Eleven")])

--- a/iOS/KeyVox iOS.xcodeproj/project.pbxproj
+++ b/iOS/KeyVox iOS.xcodeproj/project.pbxproj
@@ -1247,10 +1247,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		F41000022FF3000100AA0001 /* XCLocalSwiftPackageReference "../Packages/KeyVoxPromotions" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../Packages/KeyVoxPromotions;
-		};
 		8E9E38942F5BF56600EAFA72 /* XCLocalSwiftPackageReference "../Packages/KeyVoxCore" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../Packages/KeyVoxCore;
@@ -1275,6 +1271,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../Packages/KeyVoxTextComposition;
 		};
+		F41000022FF3000100AA0001 /* XCLocalSwiftPackageReference "../Packages/KeyVoxPromotions" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../Packages/KeyVoxPromotions;
+		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -1297,11 +1297,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		F41000032FF3000100AA0001 /* KeyVoxPromotions */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F41000022FF3000100AA0001 /* XCLocalSwiftPackageReference "../Packages/KeyVoxPromotions" */;
-			productName = KeyVoxPromotions;
-		};
 		8E7DB28D2F80FBE0009E3576 /* SwiftSoup */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 8E7DB28C2F80FB54009E3576 /* XCRemoteSwiftPackageReference "SwiftSoup" */;
@@ -1340,6 +1335,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B4C200042FF2000100AA0001 /* XCLocalSwiftPackageReference "../Packages/KeyVoxTextComposition" */;
 			productName = KeyVoxTextComposition;
+		};
+		F41000032FF3000100AA0001 /* KeyVoxPromotions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F41000022FF3000100AA0001 /* XCLocalSwiftPackageReference "../Packages/KeyVoxPromotions" */;
+			productName = KeyVoxPromotions;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};


### PR DESCRIPTION
## Summary

- Prevents multiword dictionary candidates from passing phonetic eligibility when an exact shared word masks an unrelated changed word.
- Preserves the existing shared phonetic threshold while applying it independently to every changed aligned token.
- Records the correction in the current KeyVoxCore changelog entry.

## Dictionary matching behavior

- Compares aligned words individually before a multiword candidate can enter final scoring.
- Allows exact aligned words through without additional phonetic work.
- Requires every non-exact aligned word to satisfy the configured phonetic threshold using runtime or fallback signatures.
- Prevents plural and possessive stemming from turning six dictations into Big Dictation when the changed leading words do not sound alike.
- Keeps valid existing multiword names, numeric forms, split joins, and stylized entries on their established matching paths.

## Project metadata

- Includes the current normalized ordering of the KeyVoxPromotions local package reference and product dependency in the iOS Xcode project.

## Regression coverage

- Covers the reported six dictations sentence against a Big Dictation dictionary entry.
- Verifies the original transcription remains unchanged.

## Validation

- Full KeyVoxCore package suite — 550 tests passed.
- git diff --check origin/main...HEAD — passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictionary matching for multiword phrases by requiring each changed word to meet phonetic similarity standards.
  * Prevented exact word matches from masking unrelated words in plural and possessive phrases.
  * Improved detection of numbered lists when unrelated numbers appear nearby.
  * Prevented “six dictations” from being incorrectly matched to “Big Dictation.”

* **Documentation**
  * Updated release notes with the latest matching improvements and regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->