### PR TITLE
fix(ios-speak): continue model downloads in background

### DIFF
--- a/iOS/Docs/CODEMAP.md
+++ b/iOS/Docs/CODEMAP.md
@@ -1,5 +1,5 @@
 # KeyVox iOS Code Map
-**Last Updated: 2026-08-28**
+**Last Updated: 2026-09-03**
 
 ## Project Overview
 
@@ -32,7 +32,7 @@ The current default runtime flow is:
 
 ## Architecture
 
-- **`KeyVox iOS/`**: app lifecycle, grouped app composition/routing/integration surfaces, onboarding state, app haptics, App Group storage, iCloud sync, dictation model background downloads, local Vibes model download/validation, bundled Vibes adapter lookup, app-owned local style rewrite inference, PocketTTS install ownership and playback-scoped runtime ownership, audio capture, transcription/session management, KeyVox Vibes app wiring, Live Activity coordination, and the SwiftUI shell.
+- **`KeyVox iOS/`**: app lifecycle, grouped app composition/routing/integration surfaces, onboarding state, app haptics, App Group storage, iCloud sync, reusable resumable download transport, dictation model background downloads, local Vibes model download/validation, bundled Vibes adapter lookup, app-owned local style rewrite inference, PocketTTS install ownership and playback-scoped runtime ownership, audio capture, transcription/session management, KeyVox Vibes app wiring, Live Activity coordination, and the SwiftUI shell.
 - **`KeyVox Keyboard/`**: custom keyboard controller, presentation-scoped keyboard view lifecycle, toolbar modes, copied-text speak transport, keyboard playback pause/resume/stop controls, call-aware warning detection, key grid UI, full-access instructional surface, live indicator rendering, host-app launch handoff, haptics, cursor trackpad behavior, and platform-owned insertion coordination.
 - **`KeyVox Widget/`**: ActivityKit/WidgetKit surface for the lock screen and Dynamic Island, plus the stop-session App Intent.
 - **`../Packages/KeyVoxCore/`**: shared dictation pipeline, provider seams, dictation-language values/display names, the Whisper Base language catalog and service configuration, whole-capture Whisper VAD coordination, deterministic paragraph/list state and variant handling, dictionary store, post-processing order, model-artifact cleanup, guarded compact-time/date/math normalization, silence heuristics, and list formatting behavior.
@@ -147,6 +147,11 @@ iOS/
 │   │   │   ├── AudioRecorder+Session.swift
 │   │   │   ├── AudioRecorder+StopPipeline.swift
 │   │   │   └── AudioRecorder+Streaming.swift
+│   │   ├── Downloads/
+│   │   │   ├── ResumableDownloadTaskDescriptor.swift
+│   │   │   ├── ResumableDownloadTransport.swift
+│   │   │   ├── ResumableDownloadTransport+Lifecycle.swift
+│   │   │   └── ResumableDownloadTransport+SessionDelegate.swift
 │   │   ├── Extensions/
 │   │   │   └── String+NilIfEmpty.swift
 │   │   ├── ModelDownloader/
@@ -170,9 +175,18 @@ iOS/
 │   │   ├── TTS/
 │   │   │   ├── AudioModeCoordinator.swift
 │   │   │   ├── PocketTTSAssetLocator.swift
+│   │   │   ├── PocketTTSBackgroundDownloadCoordinator.swift
+│   │   │   ├── PocketTTSBackgroundDownloadCoordinator+DownloadState.swift
+│   │   │   ├── PocketTTSBackgroundDownloadCoordinator+RateLimit.swift
+│   │   │   ├── PocketTTSBackgroundDownloadCoordinator+Scheduling.swift
+│   │   │   ├── PocketTTSBackgroundDownloadCoordinator+Transport.swift
+│   │   │   ├── PocketTTSBackgroundDownloadCoordinator+TransportDelegate.swift
+│   │   │   ├── PocketTTSBackgroundDownloadJob.swift
+│   │   │   ├── PocketTTSBackgroundDownloadJobStore.swift
 │   │   │   ├── PocketTTSEngine.swift
 │   │   │   ├── PocketTTSInstallManifest.swift
 │   │   │   ├── PocketTTSModelCatalog.swift
+│   │   │   ├── PocketTTSModelManager+BackgroundLifecycle.swift
 │   │   │   ├── PocketTTSModelManager+InstallLifecycle.swift
 │   │   │   ├── PocketTTSModelManager+Support.swift
 │   │   │   ├── PocketTTSModelManager.swift
@@ -572,7 +586,8 @@ Packages/
   - SwiftUI app entry point.
   - Injects all app-wide environment objects.
   - Registers model-download background tasks.
-  - Handles scene activation/background callbacks for transcription recovery, model recovery, onboarding keyboard-tour arming, Dictation Shortcut intro scheduling, and shortcut-route consumption.
+  - Handles scene activation/background callbacks for transcription recovery, model recovery, onboarding keyboard-tour arming, Dictation Shortcut intro scheduling, shortcut-route consumption, and Speak download transport handoffs.
+  - Starts the Speak foreground-to-background handoff during `.inactive`, while the app still has foreground execution time, and hands the transfer back during `.active`.
   - Consumes any cold-launch URL route that was captured before SwiftUI rendered and pre-presents `ReturnToHostView` without animation before routing `keyvoxios://record/start`.
 - `KeyVox iOS/App/Composition/SharedPaths.swift`
   - Centralizes rooted app-group, cache, and install filesystem locations used by app-owned services.
@@ -597,7 +612,7 @@ Packages/
 - `KeyVox iOS/App/Shortcuts/KeyVoxSpeakShortcutsProvider.swift`
   - Registers the Toggle Dictation and KeyVox Speak App Shortcut phrases surfaced in the Shortcuts system.
 - `KeyVox iOS/App/Lifecycle/AppDelegate.swift`
-  - Receives background `URLSession` callbacks for model downloads and forwards them into `ModelManager`.
+  - Receives background `URLSession` callbacks and routes each configured session identifier to its owning Dictation or Speak model manager.
 - `KeyVox iOS/App/Lifecycle/AppSceneDelegate.swift`
   - Captures cold-launch scene connection URLs before the first root render and forwards them into the launch-route store.
 - `KeyVox iOS/App/Routing/AppLaunchRouteStore.swift`
@@ -751,6 +766,19 @@ Packages/
 
 ### Model Installation and Recovery
 
+- `KeyVox iOS/Core/Downloads/ResumableDownloadTransport.swift`
+  - Reusable transport owner for paired foreground and background `URLSession` instances, per-family session configuration, task discovery and deduplication, pending resume data, cancellation, and background-session completion handlers.
+  - Contains no model catalog, installation path, retry policy, persisted job, or finalization logic. Each model family supplies those policies through `ResumableDownloadTransportDelegate`.
+- `KeyVox iOS/Core/Downloads/ResumableDownloadTransport+Lifecycle.swift`
+  - Owns the reusable foreground/background handoff state machine.
+  - Cancels tasks with resume data, transfers the resume tokens to the destination session through the family delegate, and follows a newer lifecycle state if the app changes phase while a handoff is running.
+- `KeyVox iOS/Core/Downloads/ResumableDownloadTransport+SessionDelegate.swift`
+  - Converts raw `URLSessionDownloadDelegate` callbacks into family-neutral progress, temporary-file completion, task completion, and background-event notifications.
+- `KeyVox iOS/Core/Downloads/ResumableDownloadTaskDescriptor.swift`
+  - Encodes and decodes the universal `jobID` plus `artifactID` identity stored in `URLSessionTask.taskDescription`.
+  - Family separation comes from distinct transport instances and background-session identifiers, allowing independent download families to run simultaneously without sharing or cancelling each other's tasks.
+  - The transport is reusable because model-specific persistence, installation, scheduling, and retry behavior stay behind its delegate boundary.
+
 - `KeyVox iOS/Core/ModelDownloader/ModelManager.swift`
   - Observable owner of per-model install state, active-install gating, user-facing download/delete/repair actions, and relaunch recovery.
   - Enforces one active download/install at a time and keeps provider selection persistence outside the model manager.
@@ -792,11 +820,30 @@ Packages/
   - PocketTTS shared-runtime and per-voice artifact metadata plus approximate voice download sizes used by settings.
 - `KeyVox iOS/Core/TTS/PocketTTSModelManager.swift`
   - Observable owner of shared PocketTTS Core ML install state and independent per-voice install state.
-  - Keeps the public install-state surface, readiness queries, and queue state for the follow-up voice install flow.
+  - Keeps the public install-state surface, readiness queries, lifecycle bridge to the reusable transport, and queue state for the follow-up voice install flow.
+- `KeyVox iOS/Core/TTS/PocketTTSModelManager+BackgroundLifecycle.swift`
+  - Creates or resumes persisted Speak download jobs, maps their progress into public install state, performs foreground-owned finalization, and starts the queued voice only after a combined Home engine-plus-voice request finishes installing the shared engine.
 - `KeyVox iOS/Core/TTS/PocketTTSModelManager+InstallLifecycle.swift`
-  - Install, repair, delete, and queued follow-up voice install sequencing for PocketTTS runtime and voice assets.
+  - Public install, repair, and delete entry points for PocketTTS runtime and voice assets.
 - `KeyVox iOS/Core/TTS/PocketTTSModelManager+Support.swift`
-  - Shared staging, manifest, filesystem replacement, download, and install-helper utilities used by the PocketTTS manager lifecycle split.
+  - Shared staging, manifest, filesystem replacement, and install-helper utilities used by the PocketTTS manager lifecycle split.
+- `KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadJob.swift`
+  - Persisted Speak job model containing the install target, dynamic artifact identity, per-artifact byte progress, retry timing, finalization state, and optional voice queued after a shared-engine install.
+- `KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadJobStore.swift`
+  - Atomic JSON persistence seam for the active Speak job at the existing rooted PocketTTS install location.
+- `KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator.swift`
+  - Speak-specific download owner built on `ResumableDownloadTransport`.
+  - Reconciles persisted artifact state with both sessions, prepares zero-byte and remote artifacts, preserves monotonic byte progress across handoffs, and keeps foreground downloads sequential while allowing the background session to own the full remaining job.
+- `KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+Transport.swift`
+  - Adapts a transport handoff back into the active Speak job, selecting the existing Speak scheduling policy for the destination session.
+- `KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+TransportDelegate.swift`
+  - Handles family-neutral transport callbacks at the Speak boundary, moves completed temporary files into Speak staging, validates HTTP responses, and dispatches completion into Speak scheduling or retry behavior.
+- `KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+DownloadState.swift`
+  - Owns persisted Speak artifact progress, completion, and failure mutations plus state-change publication.
+- `KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+Scheduling.swift`
+  - Advances the next sequential foreground Speak artifact after a successful foreground task completes.
+- `KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+RateLimit.swift`
+  - Owns Speak HTTP 429 parsing, persisted retry timing, and background retry task creation.
 - `KeyVox iOS/Core/TTS/PocketTTSEngine.swift`
   - App-owned streaming TTS engine wrapper around the local PocketTTS runtime.
   - Owns the app-side runtime injection seam, explicit prepare/unload lifecycle, prepared-runtime compute-mode guards, and debug load/unload visibility.

--- a/iOS/Docs/ENGINEERING.md
+++ b/iOS/Docs/ENGINEERING.md
@@ -2,7 +2,7 @@
 
 This document captures the current implementation rules and maintainer-facing architecture for the iOS app, keyboard extension, and widget extension.
 
-**Last Updated: 2026-08-28**
+**Last Updated: 2026-09-03**
 
 ## Design Philosophy
 
@@ -195,6 +195,7 @@ Service ownership rules:
 
 `KeyVox iOS/Core/` owns app runtime services that are not view or composition concerns:
 
+- `Downloads/` owns the reusable foreground/background transfer mechanism: paired sessions, task identity, resume-data handoffs, lifecycle transition serialization, and raw transport callbacks. It must remain independent of any model family’s catalog, persisted job schema, install paths, retry policy, scheduling policy, or finalization.
 - `ModelDownloader/` owns dictation model install, validation, recovery, and background download behavior.
 - `LocalRewriteModel/` owns the Vibes rewrite base model catalog, foreground install state, manifest validation, SHA-256 checks, bundled adapter lookup, and installed-model invalidation.
 - `StyleRewrite/` owns the app adapter from dictation output and keyboard IPC requests into the reusable style rewrite and local inference packages.
@@ -984,6 +985,8 @@ Primary owners:
 ### PocketTTS Install Rules
 
 - PocketTTS is split into one shared `PocketTTS CoreML` runtime install plus independently downloaded voice prompt installs.
+- Settings downloads the shared Speak engine by itself; the user chooses and downloads a voice separately.
+- Home and the shared Speak setup surface request a combined first-use install, but this remains two ordered jobs: install the shared engine first, then start the queued selected voice.
 - deleting the shared PocketTTS runtime removes the entire PocketTTS install root, including any downloaded voices
 - the selected playback voice is persisted in `AppSettingsStore`
 - the settings UI may surface approximate voice download sizes, but install validation still depends on the manifest-backed artifact set
@@ -993,7 +996,15 @@ Primary owners:
 
 ### Runtime Structure Rules
 
-- `PocketTTSModelManager` is split by concern into `PocketTTSModelManager.swift`, `PocketTTSModelManager+InstallLifecycle.swift`, and `PocketTTSModelManager+Support.swift`
+- `PocketTTSModelManager` is split by concern into `PocketTTSModelManager.swift`, `PocketTTSModelManager+BackgroundLifecycle.swift`, `PocketTTSModelManager+InstallLifecycle.swift`, and `PocketTTSModelManager+Support.swift`.
+- Speak background download ownership is split by concern:
+  - `PocketTTSBackgroundDownloadCoordinator.swift` owns Speak job reconciliation and artifact preparation.
+  - `PocketTTSBackgroundDownloadCoordinator+Transport.swift` adapts shared transport handoffs into Speak scheduling.
+  - `PocketTTSBackgroundDownloadCoordinator+TransportDelegate.swift` handles transport events and claims completed temporary files into Speak staging.
+  - `PocketTTSBackgroundDownloadCoordinator+DownloadState.swift` owns persisted artifact state changes.
+  - `PocketTTSBackgroundDownloadCoordinator+Scheduling.swift` advances sequential foreground work.
+  - `PocketTTSBackgroundDownloadCoordinator+RateLimit.swift` owns HTTP 429 retry timing and retry scheduling.
+  - `PocketTTSBackgroundDownloadJob.swift` and `PocketTTSBackgroundDownloadJobStore.swift` own the durable Speak job and its atomic JSON persistence.
 - `PocketTTSEngine` owns the app-side runtime wrapper seam around `KeyVoxPocketTTSRuntime` so tests can verify runtime creation, preparation, compute-mode requests, and unload behavior without instantiating real Core ML assets.
 - `TTSManager` is split by concern into `TTSManager.swift`, `TTSManager+Playback.swift`, `TTSManager+State.swift`, `TTSManager+RuntimeUnload.swift`, `TTSManager+SystemPlayback.swift`, `TTSManager+AppLifecycle.swift`, and `TTSManagerPolicy.swift`
   - `TTSManager+RuntimeUnload.swift` owns Speak Timeout scheduling, cancellation on new playback, memory-warning unloads, asset-invalidation unloads, and debug unload-reason logging.
@@ -1068,7 +1079,44 @@ Primary owners:
 
 ### Background Download Rules
 
-`ModelBackgroundDownloadCoordinator` owns the background `URLSession`.
+Dictation and Speak currently have separate model-family coordinators. `ModelBackgroundDownloadCoordinator` owns Dictation’s existing background-only system. Speak uses the reusable `ResumableDownloadTransport` through `PocketTTSBackgroundDownloadCoordinator`.
+
+#### Reusable Handoff Transport
+
+`ResumableDownloadTransport` is the shared mechanism for production-speed foreground downloads plus continued background transfer.
+
+Rules:
+
+- each model family receives its own transport instance and unique background-session identifier; tasks from one family must never cancel, replace, or reconcile against another family
+- task identity is the universal `jobID` plus `artifactID` descriptor stored in `URLSessionTask.taskDescription`
+- the foreground session uses the default URLSession configuration so an active-app download follows the normal foreground network path
+- the background session enables launch events, waits for connectivity, uses the App Group container, and remains non-discretionary when started while the app still has foreground execution time
+- foreground-to-background handoff begins on `.inactive`, not after `.background`; waiting until `.background` can cause iOS to treat newly created background transfers as discretionary and leave them parked
+- background-to-foreground handoff begins on `.active`
+- handoff cancels source tasks with `cancel(byProducingResumeData:)`, gives those resume tokens to the owning family, and recreates work in the destination session without resetting persisted aggregate progress
+- lifecycle changes that occur during a handoff are serialized; after the current transition finishes, the transport immediately follows the newest requested phase
+- the owning family must synchronously move a completed URLSession temporary file into its own staging location during the completion callback
+- the transport must not select install paths, define artifact order, interpret HTTP retry policy, mutate a family’s persisted job, or finalize an installation
+- any configured download server used with resumable handoff must honor byte-range requests
+- the abstraction supports simultaneous downloads across model families because each family has an independent instance and session namespace; it intentionally does not add multi-job support within one family
+- the transport is reusable across independent download families without owning or coupling their model-specific behavior
+
+#### Speak Download Policy
+
+- `PocketTTSBackgroundDownloadJob` persists the target, dynamic artifact URLs, byte counts, per-artifact state, `retryNotBefore`, finalization state, and optional queued voice
+- the active job is stored as `Models/tts/pockettts/background-download-job.json`; final engine and voice locations remain `Models/tts/pockettts/Model/` and `Models/tts/pockettts/Voices/<voice>/`
+- foreground Speak transfer schedules one artifact at a time, matching the original foreground behavior and avoiding a burst of resolver requests
+- background Speak transfer schedules the remaining persisted artifact set into the Speak background session so iOS can continue it while the app is suspended
+- moving between sessions preserves the previously recorded byte count when URLSession briefly reports a smaller task-local value, preventing visible progress from dropping during handoff
+- HTTP 429 responses persist their retry date from `Retry-After` or `RateLimit`; the coordinator recreates the retry task in the background session instead of failing the entire install immediately
+- download completion is not installation completion: staged artifacts are finalized only while the app is active
+- shared-engine finalization writes and validates the existing manifest at the existing model root; voice finalization writes and validates the selected voice root
+- a Settings shared-engine request ends after engine finalization; a combined Home/setup request then starts its explicitly queued voice download
+- there is no legacy foreground fallback path: active downloads use the foreground side of the reusable transport and inactive downloads use its background side
+
+#### Dictation Background Downloads
+
+`ModelBackgroundDownloadCoordinator` owns the Dictation background `URLSession`.
 
 Rules:
 

--- a/iOS/KeyVox iOS.xcodeproj/project.pbxproj
+++ b/iOS/KeyVox iOS.xcodeproj/project.pbxproj
@@ -728,7 +728,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cueit.keyvox.ios.KeyVox-Share";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -763,7 +763,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cueit.keyvox.ios.KeyVox-Share";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -797,7 +797,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cueit.keyvox.ios.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -831,7 +831,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cueit.keyvox.ios.keyboard;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -868,7 +868,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cueit.keyvox.ios.KeyVox-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -905,7 +905,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cueit.keyvox.ios.KeyVox-Widget";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1072,7 +1072,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cueit.keyvox.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1117,7 +1117,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cueit.keyvox.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/iOS/KeyVox iOS/App/Composition/AppServiceRegistry.swift
+++ b/iOS/KeyVox iOS/App/Composition/AppServiceRegistry.swift
@@ -244,7 +244,21 @@ final class AppServiceRegistry {
         )
         let ttsSystemPlaybackController = TTSSystemPlaybackController()
         let ttsEngine = PocketTTSEngine(fileManager: fileManager)
-        let pocketTTSModelManager = PocketTTSModelManager(fileManager: fileManager)
+        let pocketTTSBackgroundDownloadJobStore = PocketTTSBackgroundDownloadJobStore(
+            fileManager: fileManager,
+            jobURLProvider: { SharedPaths.pocketTTSDownloadJobURL(fileManager: fileManager) }
+        )
+        let pocketTTSBackgroundDownloadCoordinator = PocketTTSBackgroundDownloadCoordinator(
+            fileManager: fileManager,
+            jobStore: pocketTTSBackgroundDownloadJobStore,
+            stagingRootProvider: { target in
+                try PocketTTSModelManager.makeStagingRootURL(fileManager: fileManager, target: target)
+            }
+        )
+        let pocketTTSModelManager = PocketTTSModelManager(
+            fileManager: fileManager,
+            backgroundDownloadCoordinator: pocketTTSBackgroundDownloadCoordinator
+        )
         let ttsManager = TTSManager(
             settingsStore: settingsStore,
             appHaptics: appHaptics,

--- a/iOS/KeyVox iOS/App/Composition/SharedPaths.swift
+++ b/iOS/KeyVox iOS/App/Composition/SharedPaths.swift
@@ -154,6 +154,11 @@ nonisolated enum SharedPaths {
             .appendingPathComponent("Voices", isDirectory: true)
     }
 
+    static func pocketTTSDownloadJobURL(fileManager: FileManager = .default) -> URL? {
+        pocketTTSRootDirectoryURL(fileManager: fileManager)?
+            .appendingPathComponent("background-download-job.json", isDirectory: false)
+    }
+
     static func localRewriteRootDirectoryURL(fileManager: FileManager = .default) -> URL? {
         modelsDirectoryURL(fileManager: fileManager)?
             .appendingPathComponent("rewrite", isDirectory: true)

--- a/iOS/KeyVox iOS/App/Lifecycle/AppDelegate.swift
+++ b/iOS/KeyVox iOS/App/Lifecycle/AppDelegate.swift
@@ -7,10 +7,20 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         handleEventsForBackgroundURLSession identifier: String,
         completionHandler: @escaping () -> Void
     ) {
-        AppServiceRegistry.shared.modelManager.handleBackgroundURLSessionEvents(
-            identifier: identifier,
-            completionHandler: completionHandler
-        )
+        switch identifier {
+        case ModelBackgroundDownloadCoordinator.sessionIdentifier:
+            AppServiceRegistry.shared.modelManager.handleBackgroundURLSessionEvents(
+                identifier: identifier,
+                completionHandler: completionHandler
+            )
+        case PocketTTSBackgroundDownloadCoordinator.sessionIdentifier:
+            AppServiceRegistry.shared.pocketTTSModelManager.handleBackgroundURLSessionEvents(
+                identifier: identifier,
+                completionHandler: completionHandler
+            )
+        default:
+            completionHandler()
+        }
     }
 
     func application(

--- a/iOS/KeyVox iOS/App/Lifecycle/KeyVoxiOSApp.swift
+++ b/iOS/KeyVox iOS/App/Lifecycle/KeyVoxiOSApp.swift
@@ -150,11 +150,11 @@ struct KeyVoxApp: App {
                     case .background:
                         transcriptionManager.handleAppDidEnterBackground()
                         ttsManager.handleAppDidEnterBackground()
-                        pocketTTSModelManager.handleAppDidEnterBackground()
                         modelManager.handleAppDidEnterBackground()
                         onboardingStore.handleAppDidEnterBackground()
                     case .inactive:
                         ttsManager.handleAppWillResignActive()
+                        pocketTTSModelManager.handleAppWillResignActive()
                     @unknown default:
                         break
                     }

--- a/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTaskDescriptor.swift
+++ b/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTaskDescriptor.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+struct ResumableDownloadTaskDescriptor: Sendable {
+    nonisolated private static let separator = "::"
+
+    let jobID: UUID
+    let artifactID: String
+
+    nonisolated var encoded: String {
+        let encodedArtifactID = Data(artifactID.utf8).base64EncodedString()
+        return jobID.uuidString + Self.separator + encodedArtifactID
+    }
+
+    nonisolated init(jobID: UUID, artifactID: String) {
+        self.jobID = jobID
+        self.artifactID = artifactID
+    }
+
+    nonisolated init?(encoded: String) {
+        let components = encoded.components(separatedBy: Self.separator)
+        guard components.count == 2,
+              let jobID = UUID(uuidString: components[0]),
+              let artifactData = Data(base64Encoded: components[1]),
+              let artifactID = String(data: artifactData, encoding: .utf8) else {
+            return nil
+        }
+        self.jobID = jobID
+        self.artifactID = artifactID
+    }
+}

--- a/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport+Lifecycle.swift
+++ b/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport+Lifecycle.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+extension ResumableDownloadTransport {
+    func handleAppDidBecomeActive() async {
+        guard beginTransition(appIsActive: true) else { return }
+        await transition(to: .foreground)
+    }
+
+    func handleAppWillResignActive() {
+        guard beginTransition(appIsActive: false) else { return }
+        Task { [weak self] in
+            await self?.transition(to: .background)
+        }
+    }
+
+    private func beginTransition(appIsActive: Bool) -> Bool {
+        withLifecycleLock {
+            self.appIsActive = appIsActive
+            guard !isTransitioning else { return false }
+            isTransitioning = true
+            return true
+        }
+    }
+
+    private func transition(to destination: ResumableDownloadSessionKind) async {
+        defer {
+            completeTransition(currentSession: destination)
+        }
+
+        let source: ResumableDownloadSessionKind = destination == .foreground ? .background : .foreground
+        let sourceTasks = await downloadTasks(in: source)
+        var resumeDataByArtifactID = takePendingResumeData()
+
+        for task in sourceTasks {
+            guard let descriptor = taskDescriptor(for: task) else {
+                task.cancel()
+                continue
+            }
+            if let resumeData = await cancelProducingResumeData(task) {
+                resumeDataByArtifactID[descriptor.artifactID] = resumeData
+            }
+        }
+
+        guard let delegate else {
+            storePendingResumeData(resumeDataByArtifactID)
+            return
+        }
+        let remainingResumeData = await delegate.resumableDownloadTransport(
+            self,
+            prepareDownloadsFor: destination,
+            resumeDataByArtifactID: resumeDataByArtifactID
+        )
+        storePendingResumeData(remainingResumeData)
+    }
+
+    private func completeTransition(currentSession: ResumableDownloadSessionKind) {
+        let currentSessionIsForeground = currentSession == .foreground
+        let nextSession = withLifecycleLock { () -> ResumableDownloadSessionKind? in
+            guard appIsActive != currentSessionIsForeground else {
+                isTransitioning = false
+                return nil
+            }
+            return appIsActive ? .foreground : .background
+        }
+        guard let nextSession else { return }
+
+        Task { [weak self] in
+            await self?.transition(to: nextSession)
+        }
+    }
+
+    private func cancelProducingResumeData(_ task: URLSessionDownloadTask) async -> Data? {
+        await withCheckedContinuation { continuation in
+            task.cancel { resumeData in
+                continuation.resume(returning: resumeData)
+            }
+        }
+    }
+}

--- a/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport+Lifecycle.swift
+++ b/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport+Lifecycle.swift
@@ -2,8 +2,10 @@ import Foundation
 
 extension ResumableDownloadTransport {
     func handleAppDidBecomeActive() async {
-        guard beginTransition(appIsActive: true) else { return }
-        await transition(to: .foreground)
+        if beginTransition(appIsActive: true) {
+            await transition(to: .foreground)
+        }
+        await waitForLifecycleStability()
     }
 
     func handleAppWillResignActive() {
@@ -55,13 +57,17 @@ extension ResumableDownloadTransport {
 
     private func completeTransition(currentSession: ResumableDownloadSessionKind) {
         let currentSessionIsForeground = currentSession == .foreground
+        var stabilityWaiters: [CheckedContinuation<Void, Never>] = []
         let nextSession = withLifecycleLock { () -> ResumableDownloadSessionKind? in
             guard appIsActive != currentSessionIsForeground else {
                 isTransitioning = false
+                stabilityWaiters = lifecycleStabilityWaiters
+                lifecycleStabilityWaiters.removeAll()
                 return nil
             }
             return appIsActive ? .foreground : .background
         }
+        stabilityWaiters.forEach { $0.resume() }
         guard let nextSession else { return }
 
         Task { [weak self] in
@@ -73,6 +79,19 @@ extension ResumableDownloadTransport {
         await withCheckedContinuation { continuation in
             task.cancel { resumeData in
                 continuation.resume(returning: resumeData)
+            }
+        }
+    }
+
+    private func waitForLifecycleStability() async {
+        await withCheckedContinuation { continuation in
+            let shouldResumeImmediately = withLifecycleLock {
+                guard isTransitioning else { return true }
+                lifecycleStabilityWaiters.append(continuation)
+                return false
+            }
+            if shouldResumeImmediately {
+                continuation.resume()
             }
         }
     }

--- a/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport+SessionDelegate.swift
+++ b/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport+SessionDelegate.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+extension ResumableDownloadTransport: URLSessionDownloadDelegate {
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard let descriptor = taskDescriptor(for: downloadTask) else { return }
+        delegate?.resumableDownloadTransport(
+            self,
+            didWriteDataFor: descriptor,
+            taskIdentifier: downloadTask.taskIdentifier,
+            totalBytesWritten: totalBytesWritten,
+            totalBytesExpectedToWrite: totalBytesExpectedToWrite
+        )
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        guard let descriptor = taskDescriptor(for: downloadTask) else { return }
+        delegate?.resumableDownloadTransport(
+            self,
+            didFinishDownloading: descriptor,
+            to: location,
+            response: downloadTask.response
+        )
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let descriptor = taskDescriptor(for: task) else { return }
+        let sessionKind: ResumableDownloadSessionKind = session === self.session(for: .foreground)
+            ? .foreground
+            : .background
+        delegate?.resumableDownloadTransport(
+            self,
+            didComplete: descriptor,
+            in: sessionKind,
+            error: error
+        )
+    }
+
+    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        finishBackgroundSessionEventsIfNeeded()
+    }
+}

--- a/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport.swift
+++ b/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport.swift
@@ -44,6 +44,7 @@ final class ResumableDownloadTransport: NSObject {
     weak var delegate: ResumableDownloadTransportDelegate?
     var appIsActive = false
     var isTransitioning = false
+    var lifecycleStabilityWaiters: [CheckedContinuation<Void, Never>] = []
     private var pendingResumeDataByArtifactID: [String: Data] = [:]
     private var backgroundSessionCompletionHandler: (() -> Void)?
 

--- a/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport.swift
+++ b/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+enum ResumableDownloadSessionKind: Sendable, Equatable {
+    case foreground
+    case background
+}
+
+protocol ResumableDownloadTransportDelegate: AnyObject {
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        prepareDownloadsFor sessionKind: ResumableDownloadSessionKind,
+        resumeDataByArtifactID: [String: Data]
+    ) async -> [String: Data]
+
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didWriteDataFor descriptor: ResumableDownloadTaskDescriptor,
+        taskIdentifier: Int,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    )
+
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didFinishDownloading descriptor: ResumableDownloadTaskDescriptor,
+        to location: URL,
+        response: URLResponse?
+    )
+
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didComplete descriptor: ResumableDownloadTaskDescriptor,
+        in sessionKind: ResumableDownloadSessionKind,
+        error: Error?
+    )
+}
+
+final class ResumableDownloadTransport: NSObject {
+    private let sessionIdentifier: String
+    private let sharedContainerIdentifier: String
+    private let lifecycleLock = NSLock()
+    private let completionHandlerLock = NSLock()
+
+    weak var delegate: ResumableDownloadTransportDelegate?
+    var appIsActive = false
+    var isTransitioning = false
+    private var pendingResumeDataByArtifactID: [String: Data] = [:]
+    private var backgroundSessionCompletionHandler: (() -> Void)?
+
+    private lazy var backgroundSession: URLSession = {
+        let configuration = URLSessionConfiguration.background(withIdentifier: sessionIdentifier)
+        configuration.sharedContainerIdentifier = sharedContainerIdentifier
+        configuration.sessionSendsLaunchEvents = true
+        configuration.waitsForConnectivity = true
+        configuration.isDiscretionary = false
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+    }()
+
+    private lazy var foregroundSession: URLSession = {
+        URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+    }()
+
+    init(
+        sessionIdentifier: String,
+        sharedContainerIdentifier: String,
+        delegate: ResumableDownloadTransportDelegate
+    ) {
+        self.sessionIdentifier = sessionIdentifier
+        self.sharedContainerIdentifier = sharedContainerIdentifier
+        self.delegate = delegate
+    }
+
+    func registerBackgroundSessionCompletionHandler(_ completionHandler: @escaping () -> Void) {
+        completionHandlerLock.lock()
+        backgroundSessionCompletionHandler = completionHandler
+        completionHandlerLock.unlock()
+        _ = backgroundSession
+    }
+
+    func session(for kind: ResumableDownloadSessionKind) -> URLSession {
+        switch kind {
+        case .foreground:
+            foregroundSession
+        case .background:
+            backgroundSession
+        }
+    }
+
+    func downloadTasks(in kind: ResumableDownloadSessionKind) async -> [URLSessionDownloadTask] {
+        await withCheckedContinuation { continuation in
+            session(for: kind).getAllTasks { tasks in
+                continuation.resume(
+                    returning: tasks.compactMap { task in
+                        guard task.state != .completed else { return nil }
+                        return task as? URLSessionDownloadTask
+                    }
+                )
+            }
+        }
+    }
+
+    func deduplicatedTasksByArtifactID(
+        from tasks: [URLSessionDownloadTask],
+        jobID: UUID
+    ) -> [String: URLSessionDownloadTask] {
+        var result: [String: URLSessionDownloadTask] = [:]
+        for task in tasks {
+            guard let descriptor = taskDescriptor(for: task), descriptor.jobID == jobID else { continue }
+            if result[descriptor.artifactID] == nil {
+                result[descriptor.artifactID] = task
+            } else {
+                task.cancel()
+            }
+        }
+        return result
+    }
+
+    func taskDescriptor(for task: URLSessionTask) -> ResumableDownloadTaskDescriptor? {
+        task.taskDescription.flatMap(ResumableDownloadTaskDescriptor.init(encoded:))
+    }
+
+    func shouldUseBackgroundSession(
+        jobID: UUID,
+        existingBackgroundTasks: [URLSessionDownloadTask]
+    ) -> Bool {
+        if existingBackgroundTasks.contains(where: { taskDescriptor(for: $0)?.jobID == jobID }) {
+            return true
+        }
+
+        return withLifecycleLock {
+            !appIsActive || isTransitioning
+        }
+    }
+
+    func isReadyForForegroundScheduling() -> Bool {
+        withLifecycleLock {
+            appIsActive && !isTransitioning
+        }
+    }
+
+    func takePendingResumeData() -> [String: Data] {
+        withLifecycleLock {
+            let resumeData = pendingResumeDataByArtifactID
+            pendingResumeDataByArtifactID.removeAll()
+            return resumeData
+        }
+    }
+
+    func storePendingResumeData(_ resumeData: [String: Data]) {
+        withLifecycleLock {
+            pendingResumeDataByArtifactID = resumeData
+        }
+    }
+
+    func cancelAllTasks() async {
+        let backgroundTasks = await downloadTasks(in: .background)
+        let foregroundTasks = await downloadTasks(in: .foreground)
+        (backgroundTasks + foregroundTasks).forEach { $0.cancel() }
+        storePendingResumeData([:])
+    }
+
+    func cancelAllTasksWithoutWaiting() {
+        backgroundSession.getAllTasks { tasks in
+            tasks.forEach { $0.cancel() }
+        }
+        foregroundSession.getAllTasks { tasks in
+            tasks.forEach { $0.cancel() }
+        }
+        storePendingResumeData([:])
+    }
+
+    func finishBackgroundSessionEventsIfNeeded() {
+        completionHandlerLock.lock()
+        let completionHandler = backgroundSessionCompletionHandler
+        backgroundSessionCompletionHandler = nil
+        completionHandlerLock.unlock()
+        completionHandler?()
+    }
+
+    func withLifecycleLock<T>(_ operation: () -> T) -> T {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+        return operation()
+    }
+}

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+DownloadState.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+DownloadState.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+extension PocketTTSBackgroundDownloadCoordinator {
+    func updateArtifact(
+        for descriptor: ResumableDownloadTaskDescriptor,
+        mutate: (inout PocketTTSBackgroundArtifactState, PocketTTSBackgroundArtifact) -> Void
+    ) {
+        let job = withJobStoreLock { () -> PocketTTSBackgroundDownloadJob? in
+            guard var job = jobStore.load(), job.id == descriptor.jobID,
+                  let artifact = job.artifacts.first(where: { $0.relativePath == descriptor.artifactID }) else {
+                return nil
+            }
+            var state = job.artifactState(for: descriptor.artifactID)
+            mutate(&state, artifact)
+            job.setArtifactState(state, for: descriptor.artifactID)
+            if job.isReadyForFinalization {
+                job.finalizationState = .pending
+                job.lastErrorMessage = nil
+            }
+            try? jobStore.save(job)
+            return job
+        }
+        guard let job else { return }
+        stateDidChange?(job)
+    }
+
+    func updateDownloadProgress(
+        for descriptor: ResumableDownloadTaskDescriptor,
+        taskIdentifier: Int,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        let job = withJobStoreLock { () -> PocketTTSBackgroundDownloadJob? in
+            guard var job = jobStore.load(), job.id == descriptor.jobID,
+                  let artifact = job.artifacts.first(where: { $0.relativePath == descriptor.artifactID }) else {
+                return nil
+            }
+
+            let previousProgress = job.downloadProgressFraction
+            var state = job.artifactState(for: descriptor.artifactID)
+            state.phase = .downloading
+            state.taskIdentifier = taskIdentifier
+            state.completedBytes = max(totalBytesWritten, 0)
+            state.expectedBytes = totalBytesExpectedToWrite > 0
+                ? totalBytesExpectedToWrite
+                : artifact.expectedByteCount
+            state.retryNotBefore = nil
+            state.errorMessage = nil
+            state.updatedAt = .now
+            job.setArtifactState(state, for: descriptor.artifactID)
+
+            guard job.downloadProgressFraction - previousProgress >= Self.minimumProgressPersistenceFraction else {
+                return nil
+            }
+
+            try? jobStore.save(job)
+            return job
+        }
+        guard let job else { return }
+        stateDidChange?(job)
+    }
+
+    func markArtifactFailed(for descriptor: ResumableDownloadTaskDescriptor, error: Error) {
+        #if DEBUG
+        NSLog(
+            "[PocketTTSBackgroundDownloadCoordinator] Download failed for %@: %@",
+            descriptor.artifactID,
+            error.localizedDescription
+        )
+        #endif
+        updateArtifact(for: descriptor) { state, _ in
+            state.phase = .failed
+            state.taskIdentifier = nil
+            state.retryNotBefore = nil
+            state.errorMessage = error.localizedDescription
+            state.updatedAt = .now
+        }
+        updateLoadedJob {
+            $0.finalizationState = .failed
+            $0.lastErrorMessage = error.localizedDescription
+        }
+    }
+
+    func markJobFailed(jobID: UUID, error: Error) {
+        let job = withJobStoreLock { () -> PocketTTSBackgroundDownloadJob? in
+            guard var job = jobStore.load(), job.id == jobID else { return nil }
+            job.finalizationState = .failed
+            job.lastErrorMessage = error.localizedDescription
+            job.updatedAt = .now
+            try? jobStore.save(job)
+            return job
+        }
+        guard let job else { return }
+        stateDidChange?(job)
+    }
+}

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+DownloadState.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+DownloadState.swift
@@ -75,10 +75,7 @@ extension PocketTTSBackgroundDownloadCoordinator {
             state.errorMessage = error.localizedDescription
             state.updatedAt = .now
         }
-        updateLoadedJob {
-            $0.finalizationState = .failed
-            $0.lastErrorMessage = error.localizedDescription
-        }
+        markJobFailed(jobID: descriptor.jobID, error: error)
     }
 
     func markJobFailed(jobID: UUID, error: Error) {

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+RateLimit.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+RateLimit.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+extension PocketTTSBackgroundDownloadCoordinator {
+    func markArtifactWaitingForRateLimitRetry(
+        for descriptor: ResumableDownloadTaskDescriptor,
+        response: HTTPURLResponse
+    ) {
+        let retryDate = rateLimitRetryDate(from: response)
+        let retryDelay = max(Int(retryDate.timeIntervalSinceNow.rounded(.up)), 1)
+        #if DEBUG
+        NSLog(
+            "[PocketTTSBackgroundDownloadCoordinator] HTTP 429 for %@. Retrying after %d seconds.",
+            descriptor.artifactID,
+            retryDelay
+        )
+        #endif
+        updateArtifact(for: descriptor) { state, _ in
+            state.phase = .pending
+            state.taskIdentifier = nil
+            state.completedBytes = 0
+            state.retryNotBefore = retryDate
+            state.errorMessage = nil
+            state.updatedAt = .now
+        }
+    }
+
+    func retryRateLimitedArtifactIfNeeded(for descriptor: ResumableDownloadTaskDescriptor) {
+        let update = try? withJobStoreLock { () -> (PocketTTSBackgroundDownloadJob, URLSessionDownloadTask)? in
+            guard var job = jobStore.load(),
+                  job.id == descriptor.jobID,
+                  job.finalizationState != .failed,
+                  let artifact = job.artifacts.first(where: { $0.relativePath == descriptor.artifactID }) else {
+                return nil
+            }
+
+            var state = job.artifactState(for: descriptor.artifactID)
+            guard state.phase == .pending, state.retryNotBefore != nil else { return nil }
+
+            let task = transport.session(for: .background).downloadTask(with: artifact.remoteURL)
+            task.taskDescription = descriptor.encoded
+            task.earliestBeginDate = state.retryNotBefore
+            state.phase = .downloading
+            state.taskIdentifier = task.taskIdentifier
+            state.completedBytes = 0
+            state.expectedBytes = artifact.expectedByteCount
+            state.errorMessage = nil
+            state.updatedAt = .now
+            job.setArtifactState(state, for: descriptor.artifactID)
+            job.lastErrorMessage = nil
+            job.finalizationState = .awaitingDownloads
+            try jobStore.save(job)
+            return (job, task)
+        }
+
+        guard let update else { return }
+        stateDidChange?(update.0)
+        update.1.resume()
+    }
+
+    private func rateLimitRetryDate(from response: HTTPURLResponse) -> Date {
+        if let retryAfter = response.value(forHTTPHeaderField: "Retry-After"),
+           let seconds = TimeInterval(retryAfter) {
+            return Date().addingTimeInterval(max(seconds, 1))
+        }
+
+        if let rateLimit = response.value(forHTTPHeaderField: "RateLimit"),
+           let timeRange = rateLimit.range(of: "t="),
+           let seconds = TimeInterval(
+               String(rateLimit[timeRange.upperBound...].prefix { $0.isNumber })
+           ) {
+            return Date().addingTimeInterval(max(seconds, 1))
+        }
+
+        return Date().addingTimeInterval(60)
+    }
+}

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+Scheduling.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+Scheduling.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+extension PocketTTSBackgroundDownloadCoordinator {
+    func resumeForegroundDownloadIfNeeded(for jobID: UUID) {
+        guard transport.isReadyForForegroundScheduling() else { return }
+
+        var resumeDataByRelativePath = transport.takePendingResumeData()
+        do {
+            guard let existingJob = loadJob(),
+                  existingJob.id == jobID,
+                  existingJob.finalizationState != .failed else {
+                return
+            }
+            let stagingRootURL = try stagingRootProvider(existingJob.target)
+            try fileManager.createDirectory(at: stagingRootURL, withIntermediateDirectories: true)
+            let job = try withJobStoreLock { () -> PocketTTSBackgroundDownloadJob? in
+                guard var job = jobStore.load(), job.id == jobID else { return nil }
+                try prepareDownloads(
+                    in: &job,
+                    stagingRootURL: stagingRootURL,
+                    existingTasks: [:],
+                    session: transport.session(for: .foreground),
+                    schedulesEntireJob: false,
+                    resumeDataByRelativePath: &resumeDataByRelativePath
+                )
+                try jobStore.save(job)
+                return job
+            }
+            transport.storePendingResumeData(resumeDataByRelativePath)
+            guard let job else { return }
+            stateDidChange?(job)
+        } catch {
+            transport.storePendingResumeData(resumeDataByRelativePath)
+            markJobFailed(jobID: jobID, error: error)
+        }
+    }
+}

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+Scheduling.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+Scheduling.swift
@@ -5,6 +5,7 @@ extension PocketTTSBackgroundDownloadCoordinator {
         guard transport.isReadyForForegroundScheduling() else { return }
 
         var resumeDataByRelativePath = transport.takePendingResumeData()
+        defer { transport.storePendingResumeData(resumeDataByRelativePath) }
         do {
             guard let existingJob = loadJob(),
                   existingJob.id == jobID,
@@ -26,11 +27,9 @@ extension PocketTTSBackgroundDownloadCoordinator {
                 try jobStore.save(job)
                 return job
             }
-            transport.storePendingResumeData(resumeDataByRelativePath)
             guard let job else { return }
             stateDidChange?(job)
         } catch {
-            transport.storePendingResumeData(resumeDataByRelativePath)
             markJobFailed(jobID: jobID, error: error)
         }
     }

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+Transport.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+Transport.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+extension PocketTTSBackgroundDownloadCoordinator {
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        prepareDownloadsFor sessionKind: ResumableDownloadSessionKind,
+        resumeDataByArtifactID: [String: Data]
+    ) async -> [String: Data] {
+        var remainingResumeData = resumeDataByArtifactID
+        guard let existingJob = loadJob() else { return [:] }
+
+        let sessionTasks = await transport.downloadTasks(in: sessionKind)
+        let existingTasks = transport.deduplicatedTasksByArtifactID(
+            from: sessionTasks,
+            jobID: existingJob.id
+        )
+
+        do {
+            let stagingRootURL = try stagingRootProvider(existingJob.target)
+            try fileManager.createDirectory(at: stagingRootURL, withIntermediateDirectories: true)
+            let job = try withJobStoreLock { () -> PocketTTSBackgroundDownloadJob? in
+                guard var job = jobStore.load(), job.id == existingJob.id else { return nil }
+                try prepareDownloads(
+                    in: &job,
+                    stagingRootURL: stagingRootURL,
+                    existingTasks: existingTasks,
+                    session: transport.session(for: sessionKind),
+                    schedulesEntireJob: sessionKind == .background,
+                    resumeDataByRelativePath: &remainingResumeData
+                )
+                try jobStore.save(job)
+                return job
+            }
+            guard let job else { return remainingResumeData }
+            stateDidChange?(job)
+        } catch {
+            markJobFailed(jobID: existingJob.id, error: error)
+        }
+
+        return remainingResumeData
+    }
+}

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+TransportDelegate.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator+TransportDelegate.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+extension PocketTTSBackgroundDownloadCoordinator {
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didWriteDataFor descriptor: ResumableDownloadTaskDescriptor,
+        taskIdentifier: Int,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        updateDownloadProgress(
+            for: descriptor,
+            taskIdentifier: taskIdentifier,
+            totalBytesWritten: totalBytesWritten,
+            totalBytesExpectedToWrite: totalBytesExpectedToWrite
+        )
+    }
+
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didFinishDownloading descriptor: ResumableDownloadTaskDescriptor,
+        to location: URL,
+        response: URLResponse?
+    ) {
+        guard let job = loadJob(), job.id == descriptor.jobID else { return }
+
+        do {
+            guard let response = response as? HTTPURLResponse else {
+                throw URLError(.badServerResponse)
+            }
+            guard 200 ..< 300 ~= response.statusCode else {
+                if response.statusCode == 429 {
+                    markArtifactWaitingForRateLimitRetry(for: descriptor, response: response)
+                    return
+                }
+                throw NSError(
+                    domain: "PocketTTSBackgroundDownloadCoordinator",
+                    code: response.statusCode,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "Speak download failed with HTTP \(response.statusCode) for \(descriptor.artifactID).",
+                    ]
+                )
+            }
+            let stagingRootURL = try stagingRootProvider(job.target)
+            let destinationURL = try stagedArtifactURL(
+                stagingRootURL: stagingRootURL,
+                relativePath: descriptor.artifactID
+            )
+            try fileManager.createDirectory(
+                at: destinationURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
+            }
+            try fileManager.moveItem(at: location, to: destinationURL)
+            let fileSize = (try fileManager.attributesOfItem(atPath: destinationURL.path)[.size] as? NSNumber)?.int64Value ?? 0
+            updateArtifact(for: descriptor) { state, _ in
+                state.phase = .downloaded
+                state.taskIdentifier = nil
+                state.completedBytes = fileSize
+                state.expectedBytes = max(state.expectedBytes ?? 0, fileSize)
+                state.retryNotBefore = nil
+                state.errorMessage = nil
+                state.updatedAt = .now
+            }
+        } catch {
+            markArtifactFailed(for: descriptor, error: error)
+        }
+    }
+
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didComplete descriptor: ResumableDownloadTaskDescriptor,
+        in sessionKind: ResumableDownloadSessionKind,
+        error: Error?
+    ) {
+        guard let error else {
+            if sessionKind == .foreground {
+                resumeForegroundDownloadIfNeeded(for: descriptor.jobID)
+            } else {
+                retryRateLimitedArtifactIfNeeded(for: descriptor)
+            }
+            return
+        }
+        let nsError = error as NSError
+        guard !(nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled) else { return }
+        markArtifactFailed(for: descriptor, error: error)
+    }
+
+}

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator.swift
@@ -1,23 +1,20 @@
 import Foundation
 
-final class PocketTTSBackgroundDownloadCoordinator: NSObject {
+final class PocketTTSBackgroundDownloadCoordinator: ResumableDownloadTransportDelegate {
     static let sessionIdentifier = "com.cueit.keyvox.speak-download.background-session"
+    static let minimumProgressPersistenceFraction = 0.01
 
     var stateDidChange: (@Sendable (PocketTTSBackgroundDownloadJob?) -> Void)?
 
-    private let fileManager: FileManager
-    private let jobStore: PocketTTSBackgroundDownloadJobStore
-    private let stagingRootProvider: (PocketTTSInstallTarget) throws -> URL
-    private let completionHandlerLock = NSLock()
-    private var backgroundSessionCompletionHandler: (() -> Void)?
-    private lazy var session: URLSession = {
-        let configuration = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
-        configuration.sharedContainerIdentifier = SharedPaths.appGroupID
-        configuration.sessionSendsLaunchEvents = true
-        configuration.waitsForConnectivity = true
-        configuration.isDiscretionary = false
-        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-    }()
+    let fileManager: FileManager
+    let jobStore: PocketTTSBackgroundDownloadJobStore
+    let stagingRootProvider: (PocketTTSInstallTarget) throws -> URL
+    let jobStoreLock = NSLock()
+    lazy var transport = ResumableDownloadTransport(
+        sessionIdentifier: Self.sessionIdentifier,
+        sharedContainerIdentifier: SharedPaths.appGroupID,
+        delegate: self
+    )
 
     init(
         fileManager: FileManager = .default,
@@ -30,28 +27,160 @@ final class PocketTTSBackgroundDownloadCoordinator: NSObject {
     }
 
     func loadJob() -> PocketTTSBackgroundDownloadJob? {
-        jobStore.load()
+        withJobStoreLock {
+            jobStore.load()
+        }
     }
 
     func registerBackgroundSessionCompletionHandler(_ completionHandler: @escaping () -> Void) {
-        completionHandlerLock.lock()
-        backgroundSessionCompletionHandler = completionHandler
-        completionHandlerLock.unlock()
+        transport.registerBackgroundSessionCompletionHandler(completionHandler)
+    }
+
+    func handleAppDidBecomeActive() async {
+        await transport.handleAppDidBecomeActive()
+    }
+
+    func handleAppWillResignActive() {
+        transport.handleAppWillResignActive()
     }
 
     func startOrResumeJob(_ requestedJob: PocketTTSBackgroundDownloadJob) async throws {
-        var job = loadJob().flatMap { $0.id == requestedJob.id ? $0 : nil } ?? requestedJob
-        let stagingRootURL = try stagingRootProvider(job.target)
+        let stagingRootURL = try stagingRootProvider(requestedJob.target)
         try fileManager.createDirectory(at: stagingRootURL, withIntermediateDirectories: true)
-        try persist(job)
+        let initialJob = try withJobStoreLock {
+            let job = jobStore.load().flatMap { $0.id == requestedJob.id ? $0 : nil } ?? requestedJob
+            try jobStore.save(job)
+            return job
+        }
+        stateDidChange?(initialJob)
 
-        let tasks = await allDownloadTasks()
-        tasks.filter { taskDescriptor(for: $0)?.jobID != job.id }.forEach { $0.cancel() }
-        let existingTasks = deduplicatedTasksByRelativePath(from: tasks, jobID: job.id)
+        let backgroundTasks = await transport.downloadTasks(in: .background)
+        let foregroundTasks = await transport.downloadTasks(in: .foreground)
+        let allTasks = backgroundTasks + foregroundTasks
+        allTasks.filter { transport.taskDescriptor(for: $0)?.jobID != requestedJob.id }.forEach { $0.cancel() }
 
+        let useBackgroundSession = transport.shouldUseBackgroundSession(
+            jobID: requestedJob.id,
+            existingBackgroundTasks: backgroundTasks
+        )
+        if useBackgroundSession {
+            foregroundTasks
+                .filter { transport.taskDescriptor(for: $0)?.jobID == requestedJob.id }
+                .forEach { $0.cancel() }
+        }
+        let existingTasks = transport.deduplicatedTasksByArtifactID(
+            from: useBackgroundSession ? backgroundTasks : foregroundTasks,
+            jobID: requestedJob.id
+        )
+        let sessionKind: ResumableDownloadSessionKind = useBackgroundSession ? .background : .foreground
+        let transferSession = transport.session(for: sessionKind)
+        var resumeDataByRelativePath = useBackgroundSession ? [:] : transport.takePendingResumeData()
+
+        let job = try withJobStoreLock { () -> PocketTTSBackgroundDownloadJob? in
+            guard var job = jobStore.load(), job.id == requestedJob.id else { return nil }
+            try prepareDownloads(
+                in: &job,
+                stagingRootURL: stagingRootURL,
+                existingTasks: existingTasks,
+                session: transferSession,
+                schedulesEntireJob: useBackgroundSession,
+                resumeDataByRelativePath: &resumeDataByRelativePath
+            )
+            try jobStore.save(job)
+            return job
+        }
+
+        if !useBackgroundSession {
+            transport.storePendingResumeData(resumeDataByRelativePath)
+        }
+        guard let job else { return }
+        stateDidChange?(job)
+    }
+
+    func synchronizeWithSystemTasks() async -> PocketTTSBackgroundDownloadJob? {
+        guard let jobID = loadJob()?.id else { return nil }
+        let backgroundTasks = await transport.downloadTasks(in: .background)
+        let foregroundTasks = await transport.downloadTasks(in: .foreground)
+        let tasks = backgroundTasks + foregroundTasks
+        let tasksByRelativePath = transport.deduplicatedTasksByArtifactID(from: tasks, jobID: jobID)
+        let job = withJobStoreLock { () -> PocketTTSBackgroundDownloadJob? in
+            guard var job = jobStore.load(), job.id == jobID else { return nil }
+
+            for artifact in job.artifacts {
+                var state = job.artifactState(for: artifact.relativePath)
+                if state.phase == .downloaded { continue }
+                if let task = tasksByRelativePath[artifact.relativePath] {
+                    state.phase = .downloading
+                    state.taskIdentifier = task.taskIdentifier
+                    state.completedBytes = max(
+                        state.completedBytes,
+                        max(task.countOfBytesReceived, 0)
+                    )
+                    state.expectedBytes = task.countOfBytesExpectedToReceive > 0
+                        ? task.countOfBytesExpectedToReceive
+                        : artifact.expectedByteCount
+                    state.errorMessage = nil
+                    state.updatedAt = .now
+                } else if state.phase == .downloading {
+                    state.phase = .pending
+                    state.taskIdentifier = nil
+                    state.updatedAt = .now
+                }
+                job.setArtifactState(state, for: artifact.relativePath)
+            }
+
+            if job.isReadyForFinalization, job.finalizationState != .inProgress {
+                job.finalizationState = .pending
+            }
+            try? jobStore.save(job)
+            return job
+        }
+        stateDidChange?(job)
+        return job
+    }
+
+    func markFinalizationInProgress() {
+        updateLoadedJob {
+            $0.finalizationState = .inProgress
+            $0.lastErrorMessage = nil
+        }
+    }
+
+    func markFinalizationFailed(message: String) {
+        updateLoadedJob {
+            $0.finalizationState = .failed
+            $0.lastErrorMessage = message
+        }
+    }
+
+    func clearJob() async {
+        await transport.cancelAllTasks()
+        withJobStoreLock {
+            try? jobStore.clear()
+        }
+        stateDidChange?(nil)
+    }
+
+    func cancelAndClearJob() {
+        transport.cancelAllTasksWithoutWaiting()
+        withJobStoreLock {
+            try? jobStore.clear()
+        }
+        stateDidChange?(nil)
+    }
+
+    func prepareDownloads(
+        in job: inout PocketTTSBackgroundDownloadJob,
+        stagingRootURL: URL,
+        existingTasks: [String: URLSessionDownloadTask],
+        session: URLSession,
+        schedulesEntireJob: Bool,
+        resumeDataByRelativePath: inout [String: Data]
+    ) throws {
         for artifact in job.artifacts {
             var state = job.artifactState(for: artifact.relativePath)
             if state.phase == .downloaded {
+                resumeDataByRelativePath.removeValue(forKey: artifact.relativePath)
                 continue
             }
 
@@ -76,24 +205,25 @@ final class PocketTTSBackgroundDownloadCoordinator: NSObject {
                 continue
             }
 
-            normalizeQueuedArtifacts(
-                in: &job,
-                activeRelativePath: artifact.relativePath,
-                existingTasks: existingTasks
-            )
-
             let task: URLSessionDownloadTask
             if let existingTask = existingTasks[artifact.relativePath] {
+                resumeDataByRelativePath.removeValue(forKey: artifact.relativePath)
                 task = existingTask
-                state.completedBytes = max(existingTask.countOfBytesReceived, 0)
+                state.completedBytes = max(
+                    state.completedBytes,
+                    max(existingTask.countOfBytesReceived, 0)
+                )
                 state.expectedBytes = existingTask.countOfBytesExpectedToReceive > 0
                     ? existingTask.countOfBytesExpectedToReceive
                     : artifact.expectedByteCount
+            } else if let resumeData = resumeDataByRelativePath.removeValue(forKey: artifact.relativePath) {
+                task = session.downloadTask(withResumeData: resumeData)
+                task.taskDescription = ResumableDownloadTaskDescriptor(jobID: job.id, artifactID: artifact.relativePath).encoded
+                state.expectedBytes = artifact.expectedByteCount
             } else {
                 task = session.downloadTask(with: artifact.remoteURL)
-                task.taskDescription = TaskDescriptor(jobID: job.id, relativePath: artifact.relativePath).encoded
+                task.taskDescription = ResumableDownloadTaskDescriptor(jobID: job.id, artifactID: artifact.relativePath).encoded
                 task.earliestBeginDate = state.retryNotBefore
-                state.completedBytes = 0
                 state.expectedBytes = artifact.expectedByteCount
             }
 
@@ -104,128 +234,17 @@ final class PocketTTSBackgroundDownloadCoordinator: NSObject {
             job.setArtifactState(state, for: artifact.relativePath)
             job.lastErrorMessage = nil
             job.finalizationState = .awaitingDownloads
-            try persist(job)
             task.resume()
-            return
+            if !schedulesEntireJob {
+                return
+            }
         }
 
         job.lastErrorMessage = nil
-        job.finalizationState = .pending
-        try persist(job)
+        job.finalizationState = job.isReadyForFinalization ? .pending : .awaitingDownloads
     }
 
-    func synchronizeWithSystemTasks() async -> PocketTTSBackgroundDownloadJob? {
-        guard var job = loadJob() else { return nil }
-        let tasks = await allDownloadTasks()
-        let tasksByRelativePath = deduplicatedTasksByRelativePath(from: tasks, jobID: job.id)
-
-        for artifact in job.artifacts {
-            var state = job.artifactState(for: artifact.relativePath)
-            if state.phase == .downloaded { continue }
-            if let task = tasksByRelativePath[artifact.relativePath] {
-                state.phase = .downloading
-                state.taskIdentifier = task.taskIdentifier
-                state.completedBytes = max(task.countOfBytesReceived, 0)
-                state.expectedBytes = task.countOfBytesExpectedToReceive > 0
-                    ? task.countOfBytesExpectedToReceive
-                    : artifact.expectedByteCount
-                state.errorMessage = nil
-                state.updatedAt = .now
-            } else if state.phase == .downloading {
-                state.phase = .pending
-                state.taskIdentifier = nil
-                state.updatedAt = .now
-            }
-            job.setArtifactState(state, for: artifact.relativePath)
-        }
-
-        if job.isReadyForFinalization, job.finalizationState != .inProgress {
-            job.finalizationState = .pending
-        }
-        try? persist(job)
-        return job
-    }
-
-    func markFinalizationInProgress() {
-        updateLoadedJob {
-            $0.finalizationState = .inProgress
-            $0.lastErrorMessage = nil
-        }
-    }
-
-    func markFinalizationFailed(message: String) {
-        updateLoadedJob {
-            $0.finalizationState = .failed
-            $0.lastErrorMessage = message
-        }
-    }
-
-    func clearJob() async {
-        let tasks = await allDownloadTasks()
-        tasks.forEach { $0.cancel() }
-        try? jobStore.clear()
-        stateDidChange?(nil)
-    }
-
-    func cancelAndClearJob() {
-        session.getAllTasks { tasks in
-            tasks.forEach { $0.cancel() }
-        }
-        try? jobStore.clear()
-        stateDidChange?(nil)
-    }
-
-    private func normalizeQueuedArtifacts(
-        in job: inout PocketTTSBackgroundDownloadJob,
-        activeRelativePath: String,
-        existingTasks: [String: URLSessionDownloadTask]
-    ) {
-        for (relativePath, task) in existingTasks where relativePath != activeRelativePath {
-            task.cancel()
-            var state = job.artifactState(for: relativePath)
-            guard state.phase != .downloaded else { continue }
-            state.phase = .pending
-            state.taskIdentifier = nil
-            state.completedBytes = 0
-            state.updatedAt = .now
-            job.setArtifactState(state, for: relativePath)
-        }
-    }
-
-    private func allDownloadTasks() async -> [URLSessionDownloadTask] {
-        await withCheckedContinuation { continuation in
-            session.getAllTasks { tasks in
-                continuation.resume(
-                    returning: tasks.compactMap { task in
-                        guard task.state != .completed else { return nil }
-                        return task as? URLSessionDownloadTask
-                    }
-                )
-            }
-        }
-    }
-
-    private func deduplicatedTasksByRelativePath(
-        from tasks: [URLSessionDownloadTask],
-        jobID: UUID
-    ) -> [String: URLSessionDownloadTask] {
-        var result: [String: URLSessionDownloadTask] = [:]
-        for task in tasks {
-            guard let descriptor = taskDescriptor(for: task), descriptor.jobID == jobID else { continue }
-            if result[descriptor.relativePath] == nil {
-                result[descriptor.relativePath] = task
-            } else {
-                task.cancel()
-            }
-        }
-        return result
-    }
-
-    private func taskDescriptor(for task: URLSessionTask) -> TaskDescriptor? {
-        task.taskDescription.flatMap(TaskDescriptor.init(encoded:))
-    }
-
-    private func stagedArtifactURL(stagingRootURL: URL, relativePath: String) throws -> URL {
+    func stagedArtifactURL(stagingRootURL: URL, relativePath: String) throws -> URL {
         let standardizedRootURL = stagingRootURL.standardizedFileURL
         let destinationURL = standardizedRootURL.appendingPathComponent(relativePath).standardizedFileURL
         let rootPath = standardizedRootURL.path.hasSuffix("/")
@@ -237,227 +256,22 @@ final class PocketTTSBackgroundDownloadCoordinator: NSObject {
         return destinationURL
     }
 
-    private func persist(_ job: PocketTTSBackgroundDownloadJob) throws {
-        try jobStore.save(job)
+    func withJobStoreLock<T>(_ operation: () throws -> T) rethrows -> T {
+        jobStoreLock.lock()
+        defer { jobStoreLock.unlock() }
+        return try operation()
+    }
+
+    func updateLoadedJob(_ mutate: (inout PocketTTSBackgroundDownloadJob) -> Void) {
+        let job = withJobStoreLock { () -> PocketTTSBackgroundDownloadJob? in
+            guard var job = jobStore.load() else { return nil }
+            mutate(&job)
+            job.updatedAt = .now
+            try? jobStore.save(job)
+            return job
+        }
+        guard let job else { return }
         stateDidChange?(job)
     }
 
-    private func updateLoadedJob(_ mutate: (inout PocketTTSBackgroundDownloadJob) -> Void) {
-        guard var job = loadJob() else { return }
-        mutate(&job)
-        job.updatedAt = .now
-        try? persist(job)
-    }
-
-    private func finishBackgroundSessionEventsIfNeeded() {
-        completionHandlerLock.lock()
-        let completionHandler = backgroundSessionCompletionHandler
-        backgroundSessionCompletionHandler = nil
-        completionHandlerLock.unlock()
-        completionHandler?()
-    }
-}
-
-extension PocketTTSBackgroundDownloadCoordinator: URLSessionDownloadDelegate {
-    func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didWriteData bytesWritten: Int64,
-        totalBytesWritten: Int64,
-        totalBytesExpectedToWrite: Int64
-    ) {
-        guard let descriptor = taskDescriptor(for: downloadTask) else { return }
-        updateArtifact(for: descriptor) { state, artifact in
-            state.phase = .downloading
-            state.taskIdentifier = downloadTask.taskIdentifier
-            state.completedBytes = max(totalBytesWritten, 0)
-            state.expectedBytes = totalBytesExpectedToWrite > 0
-                ? totalBytesExpectedToWrite
-                : artifact.expectedByteCount
-            state.retryNotBefore = nil
-            state.errorMessage = nil
-            state.updatedAt = .now
-        }
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didFinishDownloadingTo location: URL
-    ) {
-        guard let descriptor = taskDescriptor(for: downloadTask),
-              let job = loadJob(), job.id == descriptor.jobID else { return }
-
-        do {
-            guard let response = downloadTask.response as? HTTPURLResponse else {
-                throw URLError(.badServerResponse)
-            }
-            guard 200 ..< 300 ~= response.statusCode else {
-                if response.statusCode == 429 {
-                    markArtifactWaitingForRateLimitRetry(for: descriptor, response: response)
-                    return
-                }
-                throw NSError(
-                    domain: "PocketTTSBackgroundDownloadCoordinator",
-                    code: response.statusCode,
-                    userInfo: [
-                        NSLocalizedDescriptionKey: "Speak download failed with HTTP \(response.statusCode) for \(descriptor.relativePath).",
-                    ]
-                )
-            }
-            let stagingRootURL = try stagingRootProvider(job.target)
-            let destinationURL = try stagedArtifactURL(
-                stagingRootURL: stagingRootURL,
-                relativePath: descriptor.relativePath
-            )
-            try fileManager.createDirectory(
-                at: destinationURL.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            if fileManager.fileExists(atPath: destinationURL.path) {
-                try fileManager.removeItem(at: destinationURL)
-            }
-            try fileManager.moveItem(at: location, to: destinationURL)
-            let fileSize = (try fileManager.attributesOfItem(atPath: destinationURL.path)[.size] as? NSNumber)?.int64Value ?? 0
-            updateArtifact(for: descriptor) { state, _ in
-                state.phase = .downloaded
-                state.taskIdentifier = nil
-                state.completedBytes = fileSize
-                state.expectedBytes = max(state.expectedBytes ?? 0, fileSize)
-                state.retryNotBefore = nil
-                state.errorMessage = nil
-                state.updatedAt = .now
-            }
-        } catch {
-            markArtifactFailed(for: descriptor, error: error)
-        }
-    }
-
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        guard let descriptor = taskDescriptor(for: task) else { return }
-        guard let error else {
-            resumeQueuedDownloadIfNeeded()
-            return
-        }
-        let nsError = error as NSError
-        guard !(nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled) else { return }
-        markArtifactFailed(for: descriptor, error: error)
-    }
-
-    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
-        finishBackgroundSessionEventsIfNeeded()
-    }
-
-    private func updateArtifact(
-        for descriptor: TaskDescriptor,
-        mutate: (inout PocketTTSBackgroundArtifactState, PocketTTSBackgroundArtifact) -> Void
-    ) {
-        guard var job = loadJob(), job.id == descriptor.jobID,
-              let artifact = job.artifacts.first(where: { $0.relativePath == descriptor.relativePath }) else {
-            return
-        }
-        var state = job.artifactState(for: descriptor.relativePath)
-        mutate(&state, artifact)
-        job.setArtifactState(state, for: descriptor.relativePath)
-        if job.isReadyForFinalization {
-            job.finalizationState = .pending
-            job.lastErrorMessage = nil
-        }
-        try? persist(job)
-    }
-
-    private func markArtifactFailed(for descriptor: TaskDescriptor, error: Error) {
-        #if DEBUG
-        NSLog(
-            "[PocketTTSBackgroundDownloadCoordinator] Download failed for %@: %@",
-            descriptor.relativePath,
-            error.localizedDescription
-        )
-        #endif
-        updateArtifact(for: descriptor) { state, _ in
-            state.phase = .failed
-            state.taskIdentifier = nil
-            state.retryNotBefore = nil
-            state.errorMessage = error.localizedDescription
-            state.updatedAt = .now
-        }
-        updateLoadedJob {
-            $0.finalizationState = .failed
-            $0.lastErrorMessage = error.localizedDescription
-        }
-    }
-
-    private func markArtifactWaitingForRateLimitRetry(
-        for descriptor: TaskDescriptor,
-        response: HTTPURLResponse
-    ) {
-        let retryDate = rateLimitRetryDate(from: response)
-        let retryDelay = max(Int(retryDate.timeIntervalSinceNow.rounded(.up)), 1)
-        #if DEBUG
-        NSLog(
-            "[PocketTTSBackgroundDownloadCoordinator] HTTP 429 for %@. Retrying after %d seconds.",
-            descriptor.relativePath,
-            retryDelay
-        )
-        #endif
-        updateArtifact(for: descriptor) { state, _ in
-            state.phase = .pending
-            state.taskIdentifier = nil
-            state.completedBytes = 0
-            state.retryNotBefore = retryDate
-            state.errorMessage = nil
-            state.updatedAt = .now
-        }
-    }
-
-    private func rateLimitRetryDate(from response: HTTPURLResponse) -> Date {
-        if let retryAfter = response.value(forHTTPHeaderField: "Retry-After"),
-           let seconds = TimeInterval(retryAfter) {
-            return Date().addingTimeInterval(max(seconds, 1))
-        }
-
-        if let rateLimit = response.value(forHTTPHeaderField: "RateLimit"),
-           let timeRange = rateLimit.range(of: "t="),
-           let seconds = TimeInterval(
-               String(rateLimit[timeRange.upperBound...].prefix { $0.isNumber })
-           ) {
-            return Date().addingTimeInterval(max(seconds, 1))
-        }
-
-        return Date().addingTimeInterval(60)
-    }
-
-    private func resumeQueuedDownloadIfNeeded() {
-        guard let job = loadJob(), job.finalizationState != .failed else { return }
-        Task { [weak self] in
-            try? await self?.startOrResumeJob(job)
-        }
-    }
-}
-
-private struct TaskDescriptor {
-    let jobID: UUID
-    let relativePath: String
-
-    nonisolated var encoded: String? {
-        let encodedPath = Data(relativePath.utf8).base64EncodedString()
-        return jobID.uuidString + "::" + encodedPath
-    }
-
-    nonisolated init(jobID: UUID, relativePath: String) {
-        self.jobID = jobID
-        self.relativePath = relativePath
-    }
-
-    nonisolated init?(encoded: String) {
-        let components = encoded.components(separatedBy: "::")
-        guard components.count == 2,
-              let jobID = UUID(uuidString: components[0]),
-              let pathData = Data(base64Encoded: components[1]),
-              let relativePath = String(data: pathData, encoding: .utf8) else {
-            return nil
-        }
-        self.jobID = jobID
-        self.relativePath = relativePath
-    }
 }

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadCoordinator.swift
@@ -1,0 +1,463 @@
+import Foundation
+
+final class PocketTTSBackgroundDownloadCoordinator: NSObject {
+    static let sessionIdentifier = "com.cueit.keyvox.speak-download.background-session"
+
+    var stateDidChange: (@Sendable (PocketTTSBackgroundDownloadJob?) -> Void)?
+
+    private let fileManager: FileManager
+    private let jobStore: PocketTTSBackgroundDownloadJobStore
+    private let stagingRootProvider: (PocketTTSInstallTarget) throws -> URL
+    private let completionHandlerLock = NSLock()
+    private var backgroundSessionCompletionHandler: (() -> Void)?
+    private lazy var session: URLSession = {
+        let configuration = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
+        configuration.sharedContainerIdentifier = SharedPaths.appGroupID
+        configuration.sessionSendsLaunchEvents = true
+        configuration.waitsForConnectivity = true
+        configuration.isDiscretionary = false
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+    }()
+
+    init(
+        fileManager: FileManager = .default,
+        jobStore: PocketTTSBackgroundDownloadJobStore,
+        stagingRootProvider: @escaping (PocketTTSInstallTarget) throws -> URL
+    ) {
+        self.fileManager = fileManager
+        self.jobStore = jobStore
+        self.stagingRootProvider = stagingRootProvider
+    }
+
+    func loadJob() -> PocketTTSBackgroundDownloadJob? {
+        jobStore.load()
+    }
+
+    func registerBackgroundSessionCompletionHandler(_ completionHandler: @escaping () -> Void) {
+        completionHandlerLock.lock()
+        backgroundSessionCompletionHandler = completionHandler
+        completionHandlerLock.unlock()
+    }
+
+    func startOrResumeJob(_ requestedJob: PocketTTSBackgroundDownloadJob) async throws {
+        var job = loadJob().flatMap { $0.id == requestedJob.id ? $0 : nil } ?? requestedJob
+        let stagingRootURL = try stagingRootProvider(job.target)
+        try fileManager.createDirectory(at: stagingRootURL, withIntermediateDirectories: true)
+        try persist(job)
+
+        let tasks = await allDownloadTasks()
+        tasks.filter { taskDescriptor(for: $0)?.jobID != job.id }.forEach { $0.cancel() }
+        let existingTasks = deduplicatedTasksByRelativePath(from: tasks, jobID: job.id)
+
+        for artifact in job.artifacts {
+            var state = job.artifactState(for: artifact.relativePath)
+            if state.phase == .downloaded {
+                continue
+            }
+
+            if artifact.expectedByteCount == 0 {
+                let destinationURL = try stagedArtifactURL(
+                    stagingRootURL: stagingRootURL,
+                    relativePath: artifact.relativePath
+                )
+                try fileManager.createDirectory(
+                    at: destinationURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try Data().write(to: destinationURL, options: .atomic)
+                state.phase = .downloaded
+                state.taskIdentifier = nil
+                state.completedBytes = 0
+                state.expectedBytes = 0
+                state.retryNotBefore = nil
+                state.errorMessage = nil
+                state.updatedAt = .now
+                job.setArtifactState(state, for: artifact.relativePath)
+                continue
+            }
+
+            normalizeQueuedArtifacts(
+                in: &job,
+                activeRelativePath: artifact.relativePath,
+                existingTasks: existingTasks
+            )
+
+            let task: URLSessionDownloadTask
+            if let existingTask = existingTasks[artifact.relativePath] {
+                task = existingTask
+                state.completedBytes = max(existingTask.countOfBytesReceived, 0)
+                state.expectedBytes = existingTask.countOfBytesExpectedToReceive > 0
+                    ? existingTask.countOfBytesExpectedToReceive
+                    : artifact.expectedByteCount
+            } else {
+                task = session.downloadTask(with: artifact.remoteURL)
+                task.taskDescription = TaskDescriptor(jobID: job.id, relativePath: artifact.relativePath).encoded
+                task.earliestBeginDate = state.retryNotBefore
+                state.completedBytes = 0
+                state.expectedBytes = artifact.expectedByteCount
+            }
+
+            state.phase = .downloading
+            state.taskIdentifier = task.taskIdentifier
+            state.errorMessage = nil
+            state.updatedAt = .now
+            job.setArtifactState(state, for: artifact.relativePath)
+            job.lastErrorMessage = nil
+            job.finalizationState = .awaitingDownloads
+            try persist(job)
+            task.resume()
+            return
+        }
+
+        job.lastErrorMessage = nil
+        job.finalizationState = .pending
+        try persist(job)
+    }
+
+    func synchronizeWithSystemTasks() async -> PocketTTSBackgroundDownloadJob? {
+        guard var job = loadJob() else { return nil }
+        let tasks = await allDownloadTasks()
+        let tasksByRelativePath = deduplicatedTasksByRelativePath(from: tasks, jobID: job.id)
+
+        for artifact in job.artifacts {
+            var state = job.artifactState(for: artifact.relativePath)
+            if state.phase == .downloaded { continue }
+            if let task = tasksByRelativePath[artifact.relativePath] {
+                state.phase = .downloading
+                state.taskIdentifier = task.taskIdentifier
+                state.completedBytes = max(task.countOfBytesReceived, 0)
+                state.expectedBytes = task.countOfBytesExpectedToReceive > 0
+                    ? task.countOfBytesExpectedToReceive
+                    : artifact.expectedByteCount
+                state.errorMessage = nil
+                state.updatedAt = .now
+            } else if state.phase == .downloading {
+                state.phase = .pending
+                state.taskIdentifier = nil
+                state.updatedAt = .now
+            }
+            job.setArtifactState(state, for: artifact.relativePath)
+        }
+
+        if job.isReadyForFinalization, job.finalizationState != .inProgress {
+            job.finalizationState = .pending
+        }
+        try? persist(job)
+        return job
+    }
+
+    func markFinalizationInProgress() {
+        updateLoadedJob {
+            $0.finalizationState = .inProgress
+            $0.lastErrorMessage = nil
+        }
+    }
+
+    func markFinalizationFailed(message: String) {
+        updateLoadedJob {
+            $0.finalizationState = .failed
+            $0.lastErrorMessage = message
+        }
+    }
+
+    func clearJob() async {
+        let tasks = await allDownloadTasks()
+        tasks.forEach { $0.cancel() }
+        try? jobStore.clear()
+        stateDidChange?(nil)
+    }
+
+    func cancelAndClearJob() {
+        session.getAllTasks { tasks in
+            tasks.forEach { $0.cancel() }
+        }
+        try? jobStore.clear()
+        stateDidChange?(nil)
+    }
+
+    private func normalizeQueuedArtifacts(
+        in job: inout PocketTTSBackgroundDownloadJob,
+        activeRelativePath: String,
+        existingTasks: [String: URLSessionDownloadTask]
+    ) {
+        for (relativePath, task) in existingTasks where relativePath != activeRelativePath {
+            task.cancel()
+            var state = job.artifactState(for: relativePath)
+            guard state.phase != .downloaded else { continue }
+            state.phase = .pending
+            state.taskIdentifier = nil
+            state.completedBytes = 0
+            state.updatedAt = .now
+            job.setArtifactState(state, for: relativePath)
+        }
+    }
+
+    private func allDownloadTasks() async -> [URLSessionDownloadTask] {
+        await withCheckedContinuation { continuation in
+            session.getAllTasks { tasks in
+                continuation.resume(
+                    returning: tasks.compactMap { task in
+                        guard task.state != .completed else { return nil }
+                        return task as? URLSessionDownloadTask
+                    }
+                )
+            }
+        }
+    }
+
+    private func deduplicatedTasksByRelativePath(
+        from tasks: [URLSessionDownloadTask],
+        jobID: UUID
+    ) -> [String: URLSessionDownloadTask] {
+        var result: [String: URLSessionDownloadTask] = [:]
+        for task in tasks {
+            guard let descriptor = taskDescriptor(for: task), descriptor.jobID == jobID else { continue }
+            if result[descriptor.relativePath] == nil {
+                result[descriptor.relativePath] = task
+            } else {
+                task.cancel()
+            }
+        }
+        return result
+    }
+
+    private func taskDescriptor(for task: URLSessionTask) -> TaskDescriptor? {
+        task.taskDescription.flatMap(TaskDescriptor.init(encoded:))
+    }
+
+    private func stagedArtifactURL(stagingRootURL: URL, relativePath: String) throws -> URL {
+        let standardizedRootURL = stagingRootURL.standardizedFileURL
+        let destinationURL = standardizedRootURL.appendingPathComponent(relativePath).standardizedFileURL
+        let rootPath = standardizedRootURL.path.hasSuffix("/")
+            ? standardizedRootURL.path
+            : standardizedRootURL.path + "/"
+        guard destinationURL.path.hasPrefix(rootPath) else {
+            throw CocoaError(.fileWriteInvalidFileName)
+        }
+        return destinationURL
+    }
+
+    private func persist(_ job: PocketTTSBackgroundDownloadJob) throws {
+        try jobStore.save(job)
+        stateDidChange?(job)
+    }
+
+    private func updateLoadedJob(_ mutate: (inout PocketTTSBackgroundDownloadJob) -> Void) {
+        guard var job = loadJob() else { return }
+        mutate(&job)
+        job.updatedAt = .now
+        try? persist(job)
+    }
+
+    private func finishBackgroundSessionEventsIfNeeded() {
+        completionHandlerLock.lock()
+        let completionHandler = backgroundSessionCompletionHandler
+        backgroundSessionCompletionHandler = nil
+        completionHandlerLock.unlock()
+        completionHandler?()
+    }
+}
+
+extension PocketTTSBackgroundDownloadCoordinator: URLSessionDownloadDelegate {
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard let descriptor = taskDescriptor(for: downloadTask) else { return }
+        updateArtifact(for: descriptor) { state, artifact in
+            state.phase = .downloading
+            state.taskIdentifier = downloadTask.taskIdentifier
+            state.completedBytes = max(totalBytesWritten, 0)
+            state.expectedBytes = totalBytesExpectedToWrite > 0
+                ? totalBytesExpectedToWrite
+                : artifact.expectedByteCount
+            state.retryNotBefore = nil
+            state.errorMessage = nil
+            state.updatedAt = .now
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        guard let descriptor = taskDescriptor(for: downloadTask),
+              let job = loadJob(), job.id == descriptor.jobID else { return }
+
+        do {
+            guard let response = downloadTask.response as? HTTPURLResponse else {
+                throw URLError(.badServerResponse)
+            }
+            guard 200 ..< 300 ~= response.statusCode else {
+                if response.statusCode == 429 {
+                    markArtifactWaitingForRateLimitRetry(for: descriptor, response: response)
+                    return
+                }
+                throw NSError(
+                    domain: "PocketTTSBackgroundDownloadCoordinator",
+                    code: response.statusCode,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "Speak download failed with HTTP \(response.statusCode) for \(descriptor.relativePath).",
+                    ]
+                )
+            }
+            let stagingRootURL = try stagingRootProvider(job.target)
+            let destinationURL = try stagedArtifactURL(
+                stagingRootURL: stagingRootURL,
+                relativePath: descriptor.relativePath
+            )
+            try fileManager.createDirectory(
+                at: destinationURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
+            }
+            try fileManager.moveItem(at: location, to: destinationURL)
+            let fileSize = (try fileManager.attributesOfItem(atPath: destinationURL.path)[.size] as? NSNumber)?.int64Value ?? 0
+            updateArtifact(for: descriptor) { state, _ in
+                state.phase = .downloaded
+                state.taskIdentifier = nil
+                state.completedBytes = fileSize
+                state.expectedBytes = max(state.expectedBytes ?? 0, fileSize)
+                state.retryNotBefore = nil
+                state.errorMessage = nil
+                state.updatedAt = .now
+            }
+        } catch {
+            markArtifactFailed(for: descriptor, error: error)
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let descriptor = taskDescriptor(for: task) else { return }
+        guard let error else {
+            resumeQueuedDownloadIfNeeded()
+            return
+        }
+        let nsError = error as NSError
+        guard !(nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled) else { return }
+        markArtifactFailed(for: descriptor, error: error)
+    }
+
+    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        finishBackgroundSessionEventsIfNeeded()
+    }
+
+    private func updateArtifact(
+        for descriptor: TaskDescriptor,
+        mutate: (inout PocketTTSBackgroundArtifactState, PocketTTSBackgroundArtifact) -> Void
+    ) {
+        guard var job = loadJob(), job.id == descriptor.jobID,
+              let artifact = job.artifacts.first(where: { $0.relativePath == descriptor.relativePath }) else {
+            return
+        }
+        var state = job.artifactState(for: descriptor.relativePath)
+        mutate(&state, artifact)
+        job.setArtifactState(state, for: descriptor.relativePath)
+        if job.isReadyForFinalization {
+            job.finalizationState = .pending
+            job.lastErrorMessage = nil
+        }
+        try? persist(job)
+    }
+
+    private func markArtifactFailed(for descriptor: TaskDescriptor, error: Error) {
+        #if DEBUG
+        NSLog(
+            "[PocketTTSBackgroundDownloadCoordinator] Download failed for %@: %@",
+            descriptor.relativePath,
+            error.localizedDescription
+        )
+        #endif
+        updateArtifact(for: descriptor) { state, _ in
+            state.phase = .failed
+            state.taskIdentifier = nil
+            state.retryNotBefore = nil
+            state.errorMessage = error.localizedDescription
+            state.updatedAt = .now
+        }
+        updateLoadedJob {
+            $0.finalizationState = .failed
+            $0.lastErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func markArtifactWaitingForRateLimitRetry(
+        for descriptor: TaskDescriptor,
+        response: HTTPURLResponse
+    ) {
+        let retryDate = rateLimitRetryDate(from: response)
+        let retryDelay = max(Int(retryDate.timeIntervalSinceNow.rounded(.up)), 1)
+        #if DEBUG
+        NSLog(
+            "[PocketTTSBackgroundDownloadCoordinator] HTTP 429 for %@. Retrying after %d seconds.",
+            descriptor.relativePath,
+            retryDelay
+        )
+        #endif
+        updateArtifact(for: descriptor) { state, _ in
+            state.phase = .pending
+            state.taskIdentifier = nil
+            state.completedBytes = 0
+            state.retryNotBefore = retryDate
+            state.errorMessage = nil
+            state.updatedAt = .now
+        }
+    }
+
+    private func rateLimitRetryDate(from response: HTTPURLResponse) -> Date {
+        if let retryAfter = response.value(forHTTPHeaderField: "Retry-After"),
+           let seconds = TimeInterval(retryAfter) {
+            return Date().addingTimeInterval(max(seconds, 1))
+        }
+
+        if let rateLimit = response.value(forHTTPHeaderField: "RateLimit"),
+           let timeRange = rateLimit.range(of: "t="),
+           let seconds = TimeInterval(
+               String(rateLimit[timeRange.upperBound...].prefix { $0.isNumber })
+           ) {
+            return Date().addingTimeInterval(max(seconds, 1))
+        }
+
+        return Date().addingTimeInterval(60)
+    }
+
+    private func resumeQueuedDownloadIfNeeded() {
+        guard let job = loadJob(), job.finalizationState != .failed else { return }
+        Task { [weak self] in
+            try? await self?.startOrResumeJob(job)
+        }
+    }
+}
+
+private struct TaskDescriptor {
+    let jobID: UUID
+    let relativePath: String
+
+    nonisolated var encoded: String? {
+        let encodedPath = Data(relativePath.utf8).base64EncodedString()
+        return jobID.uuidString + "::" + encodedPath
+    }
+
+    nonisolated init(jobID: UUID, relativePath: String) {
+        self.jobID = jobID
+        self.relativePath = relativePath
+    }
+
+    nonisolated init?(encoded: String) {
+        let components = encoded.components(separatedBy: "::")
+        guard components.count == 2,
+              let jobID = UUID(uuidString: components[0]),
+              let pathData = Data(base64Encoded: components[1]),
+              let relativePath = String(data: pathData, encoding: .utf8) else {
+            return nil
+        }
+        self.jobID = jobID
+        self.relativePath = relativePath
+    }
+}

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadJob.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadJob.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+struct PocketTTSBackgroundArtifact: Codable, Equatable, Sendable {
+    let relativePath: String
+    let remoteURL: URL
+    let expectedByteCount: Int64
+}
+
+enum PocketTTSBackgroundArtifactPhase: String, Codable, Sendable {
+    case pending
+    case downloading
+    case downloaded
+    case failed
+}
+
+struct PocketTTSBackgroundArtifactState: Codable, Equatable, Sendable {
+    var phase: PocketTTSBackgroundArtifactPhase = .pending
+    var taskIdentifier: Int?
+    var completedBytes: Int64 = 0
+    var expectedBytes: Int64?
+    var retryNotBefore: Date?
+    var errorMessage: String?
+    var updatedAt: Date = .now
+}
+
+enum PocketTTSBackgroundFinalizationState: String, Codable, Sendable {
+    case awaitingDownloads
+    case pending
+    case inProgress
+    case failed
+}
+
+struct PocketTTSBackgroundDownloadJob: Codable, Equatable, Sendable {
+    let id: UUID
+    let target: PocketTTSInstallTarget
+    let artifacts: [PocketTTSBackgroundArtifact]
+    var artifactStatesByRelativePath: [String: PocketTTSBackgroundArtifactState]
+    var queuedVoiceAfterSharedModel: AppSettingsStore.TTSVoice?
+    var finalizationState: PocketTTSBackgroundFinalizationState
+    var lastErrorMessage: String?
+    var updatedAt: Date
+
+    init(
+        id: UUID = UUID(),
+        target: PocketTTSInstallTarget,
+        descriptor: PocketTTSDescriptor,
+        queuedVoiceAfterSharedModel: AppSettingsStore.TTSVoice? = nil
+    ) {
+        self.id = id
+        self.target = target
+        self.artifacts = descriptor.artifacts.map {
+            PocketTTSBackgroundArtifact(
+                relativePath: $0.relativePath,
+                remoteURL: $0.remoteURL,
+                expectedByteCount: $0.expectedByteCount
+            )
+        }
+        self.artifactStatesByRelativePath = Dictionary(
+            uniqueKeysWithValues: descriptor.artifacts.map {
+                ($0.relativePath, PocketTTSBackgroundArtifactState(expectedBytes: $0.expectedByteCount))
+            }
+        )
+        self.queuedVoiceAfterSharedModel = queuedVoiceAfterSharedModel
+        self.finalizationState = .awaitingDownloads
+        self.lastErrorMessage = nil
+        self.updatedAt = .now
+    }
+
+    mutating func setArtifactState(
+        _ state: PocketTTSBackgroundArtifactState,
+        for relativePath: String
+    ) {
+        artifactStatesByRelativePath[relativePath] = state
+        updatedAt = .now
+    }
+
+    func artifactState(for relativePath: String) -> PocketTTSBackgroundArtifactState {
+        artifactStatesByRelativePath[relativePath] ?? PocketTTSBackgroundArtifactState()
+    }
+
+    var downloadProgressFraction: Double {
+        let expectedBytes = artifacts.reduce(into: Int64(0)) { total, artifact in
+            let state = artifactState(for: artifact.relativePath)
+            total += max(state.expectedBytes ?? artifact.expectedByteCount, artifact.expectedByteCount)
+        }
+        guard expectedBytes > 0 else { return isReadyForFinalization ? 1 : 0 }
+
+        let completedBytes = artifacts.reduce(into: Int64(0)) { total, artifact in
+            let state = artifactState(for: artifact.relativePath)
+            let expected = max(state.expectedBytes ?? artifact.expectedByteCount, artifact.expectedByteCount)
+            total += min(state.completedBytes, expected)
+        }
+        return min(max(Double(completedBytes) / Double(expectedBytes), 0), 1)
+    }
+
+    var isReadyForFinalization: Bool {
+        artifacts.allSatisfy { artifactState(for: $0.relativePath).phase == .downloaded }
+    }
+}
+
+extension PocketTTSInstallTarget: Codable, Sendable {
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case voice
+    }
+
+    private enum Kind: String, Codable {
+        case sharedModel
+        case voice
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .kind) {
+        case .sharedModel:
+            self = .sharedModel
+        case .voice:
+            self = .voice(try container.decode(AppSettingsStore.TTSVoice.self, forKey: .voice))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .sharedModel:
+            try container.encode(Kind.sharedModel, forKey: .kind)
+        case .voice(let voice):
+            try container.encode(Kind.voice, forKey: .kind)
+            try container.encode(voice, forKey: .voice)
+        }
+    }
+}

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadJobStore.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadJobStore.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct PocketTTSBackgroundDownloadJobStore {
+    let fileManager: FileManager
+    let jobURLProvider: () -> URL?
+
+    func load() -> PocketTTSBackgroundDownloadJob? {
+        guard let jobURL = jobURLProvider(),
+              fileManager.fileExists(atPath: jobURL.path),
+              let data = try? Data(contentsOf: jobURL) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(PocketTTSBackgroundDownloadJob.self, from: data)
+    }
+
+    func save(_ job: PocketTTSBackgroundDownloadJob) throws {
+        guard let jobURL = jobURLProvider() else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let directoryURL = jobURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(job).write(to: jobURL, options: .atomic)
+    }
+
+    func clear() throws {
+        guard let jobURL = jobURLProvider(), fileManager.fileExists(atPath: jobURL.path) else {
+            return
+        }
+        try fileManager.removeItem(at: jobURL)
+    }
+}

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+BackgroundLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+BackgroundLifecycle.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+extension PocketTTSModelManager {
+    func startBackgroundInstall(
+        descriptor: PocketTTSDescriptor,
+        target: PocketTTSInstallTarget,
+        queuedVoiceAfterSharedModel: AppSettingsStore.TTSVoice? = nil
+    ) async throws {
+        if let existingJob = backgroundDownloadCoordinator.loadJob() {
+            guard existingJob.target == target else {
+                throw NSError(
+                    domain: "PocketTTSModelManager",
+                    code: 11,
+                    userInfo: [NSLocalizedDescriptionKey: "Another Speak download is already in progress."]
+                )
+            }
+            try await backgroundDownloadCoordinator.startOrResumeJob(existingJob)
+            refreshStatus()
+            return
+        }
+
+        let stagingRootURL = try Self.makeStagingRootURL(fileManager: fileManager, target: target)
+        try Self.prepareDirectory(stagingRootURL, fileManager: fileManager)
+        let job = PocketTTSBackgroundDownloadJob(
+            target: target,
+            descriptor: descriptor,
+            queuedVoiceAfterSharedModel: queuedVoiceAfterSharedModel
+        )
+        try await backgroundDownloadCoordinator.startOrResumeJob(job)
+        refreshStatus()
+    }
+
+    func handleBackgroundDownloadStateChanged() async {
+        refreshStatus()
+        await resumeForegroundFinalizationIfNeeded()
+    }
+
+    func resumeForegroundFinalizationIfNeeded() async {
+        guard appIsActive,
+              installTask == nil,
+              !isFinalizationInFlight,
+              let job = backgroundDownloadCoordinator.loadJob(),
+              job.isReadyForFinalization else {
+            return
+        }
+
+        isFinalizationInFlight = true
+        backgroundDownloadCoordinator.markFinalizationInProgress()
+        defer { isFinalizationInFlight = false }
+
+        do {
+            applyInstallState(.installing(progress: 0.95), to: job.target)
+            try finalizeBackgroundInstall(job)
+            let queuedVoice = job.queuedVoiceAfterSharedModel
+            try? fileManager.removeItem(
+                at: Self.makeStagingRootURL(fileManager: fileManager, target: job.target)
+            )
+            await backgroundDownloadCoordinator.clearJob()
+            refreshStatus()
+
+            if job.target == .sharedModel,
+               let queuedVoice,
+               !assetLocator.isVoiceInstalled(queuedVoice) {
+                downloadVoice(queuedVoice)
+            }
+        } catch {
+            Self.log("Background install finalization failed with error: \(error.localizedDescription)")
+            backgroundDownloadCoordinator.markFinalizationFailed(message: error.localizedDescription)
+            applyInstallState(.failed(error.localizedDescription), to: job.target)
+        }
+    }
+
+    func applyBackgroundJobState(_ job: PocketTTSBackgroundDownloadJob) {
+        let state: PocketTTSInstallState
+        if job.finalizationState == .failed, let message = job.lastErrorMessage {
+            state = .failed(message)
+        } else if job.isReadyForFinalization || job.finalizationState == .inProgress {
+            state = .installing(progress: 0.95)
+        } else {
+            state = .downloading(progress: min(max(job.downloadProgressFraction * 0.92, 0), 0.92))
+        }
+        applyInstallState(state, to: job.target)
+    }
+}
+
+private extension PocketTTSModelManager {
+    func applyInstallState(_ state: PocketTTSInstallState, to target: PocketTTSInstallTarget) {
+        switch target {
+        case .sharedModel:
+            sharedModelInstallState = state
+        case .voice(let voice):
+            voiceInstallStates[voice] = state
+        }
+    }
+
+    func finalizeBackgroundInstall(_ job: PocketTTSBackgroundDownloadJob) throws {
+        let stagingRootURL = try Self.makeStagingRootURL(fileManager: fileManager, target: job.target)
+        let manifest = PocketTTSInstallManifest(
+            sourceRepository: PocketTTSModelCatalog.repositoryID,
+            artifactSizesByRelativePath: Dictionary(
+                uniqueKeysWithValues: job.artifacts.map { ($0.relativePath, $0.expectedByteCount) }
+            )
+        )
+
+        switch job.target {
+        case .sharedModel:
+            let stagedModelRootURL = stagingRootURL.appendingPathComponent("Model", isDirectory: true)
+            let finalModelRootURL = try Self.finalSharedModelRootURL(fileManager: fileManager)
+            if fileManager.fileExists(atPath: stagedModelRootURL.path) {
+                try Self.replaceDirectory(
+                    at: finalModelRootURL,
+                    with: stagedModelRootURL,
+                    fileManager: fileManager
+                )
+            } else if !fileManager.fileExists(atPath: finalModelRootURL.path) {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            try Self.writeManifest(
+                manifest,
+                to: Self.finalSharedManifestRootURL(fileManager: fileManager)
+            )
+            guard assetLocator.isSharedModelInstalled() else {
+                throw NSError(
+                    domain: "PocketTTSModelManager",
+                    code: 5,
+                    userInfo: [NSLocalizedDescriptionKey: "Speak engine install validation failed."]
+                )
+            }
+
+        case .voice(let voice):
+            let stagedVoiceDirectoryURL = stagingRootURL
+                .appendingPathComponent("Voices", isDirectory: true)
+                .appendingPathComponent(voice.rawValue, isDirectory: true)
+            let finalVoiceRootURL = try Self.finalVoiceRootURL(voice, fileManager: fileManager)
+            if fileManager.fileExists(atPath: stagedVoiceDirectoryURL.path) {
+                try Self.replaceDirectory(
+                    at: finalVoiceRootURL,
+                    with: stagedVoiceDirectoryURL,
+                    fileManager: fileManager
+                )
+            } else if !fileManager.fileExists(atPath: finalVoiceRootURL.path) {
+                throw CocoaError(.fileNoSuchFile)
+            }
+            try Self.writeManifest(manifest, to: finalVoiceRootURL)
+            guard assetLocator.isVoiceInstalled(voice) else {
+                throw NSError(
+                    domain: "PocketTTSModelManager",
+                    code: 8,
+                    userInfo: [NSLocalizedDescriptionKey: "\(voice.displayName) voice install validation failed."]
+                )
+            }
+        }
+    }
+}

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+BackgroundLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+BackgroundLifecycle.swift
@@ -30,8 +30,13 @@ extension PocketTTSModelManager {
         refreshStatus()
     }
 
-    func handleBackgroundDownloadStateChanged() async {
-        refreshStatus()
+    func handleBackgroundDownloadStateChanged(_ job: PocketTTSBackgroundDownloadJob?) async {
+        if let job {
+            activeInstallTarget = job.target
+            applyBackgroundJobState(job)
+        } else {
+            refreshStatus()
+        }
         await resumeForegroundFinalizationIfNeeded()
     }
 

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+InstallLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+InstallLifecycle.swift
@@ -16,82 +16,50 @@ extension PocketTTSModelManager {
     }
 
     func repairVoiceEnsuringSharedModel(_ voice: AppSettingsStore.TTSVoice) {
-        pendingVoiceInstallAfterSharedModel = voice
-
         if assetLocator.isSharedModelInstalled() {
-            pendingVoiceInstallAfterSharedModel = nil
             repairVoiceIfNeeded(voice)
             return
         }
 
-        repairSharedModelIfNeeded()
+        deleteSharedModel()
+        pendingVoiceInstallAfterSharedModel = voice
+        downloadSharedModel()
     }
 
     func downloadSharedModel() {
         guard installTask == nil else { return }
+        if let existingJob = backgroundDownloadCoordinator.loadJob(), existingJob.target != .sharedModel {
+            return
+        }
         activeInstallTarget = .sharedModel
 
-        installTask = Task { [fileManager, session] in
+        installTask = Task { [session] in
+            defer {
+                installTask = nil
+                refreshStatus()
+            }
+
             do {
                 Self.log("Shared model install requested.")
-                await MainActor.run {
-                    self.sharedModelInstallState = .downloading(progress: 0)
+                sharedModelInstallState = .downloading(progress: 0)
+
+                if let existingJob = backgroundDownloadCoordinator.loadJob() {
+                    try await backgroundDownloadCoordinator.startOrResumeJob(existingJob)
+                    return
                 }
 
                 let descriptor = try await PocketTTSModelCatalog.fetchSharedModelDescriptor(session: session)
-                try await self.install(
+                try await startBackgroundInstall(
                     descriptor: descriptor,
                     target: .sharedModel,
-                    stagingRootURL: try Self.makeStagingRootURL(fileManager: fileManager, target: .sharedModel),
-                    finalRootURL: try Self.finalSharedModelRootURL(fileManager: fileManager),
-                    progress: { progress in
-                        self.sharedModelInstallState = .downloading(progress: progress)
-                    },
-                    installing: {
-                        self.sharedModelInstallState = .installing(progress: 0.95)
-                    }
+                    queuedVoiceAfterSharedModel: pendingVoiceInstallAfterSharedModel
                 )
-
-                let manifest = PocketTTSInstallManifest(
-                    sourceRepository: PocketTTSModelCatalog.repositoryID,
-                    artifactSizesByRelativePath: Dictionary(
-                        uniqueKeysWithValues: descriptor.artifacts.map { ($0.relativePath, $0.expectedByteCount) }
-                    )
-                )
-                try Self.writeManifest(
-                    manifest,
-                    to: try Self.finalSharedManifestRootURL(fileManager: fileManager)
-                )
-
-                guard self.assetLocator.isSharedModelInstalled() else {
-                    throw NSError(
-                        domain: "PocketTTSModelManager",
-                        code: 5,
-                        userInfo: [NSLocalizedDescriptionKey: "Speak engine install validation failed."]
-                    )
-                }
-
-                let queuedVoice = self.pendingVoiceInstallAfterSharedModel.flatMap { voice in
-                    self.assetLocator.isVoiceInstalled(voice) ? nil : voice
-                }
-
-                await MainActor.run {
-                    if let queuedVoice {
-                        self.voiceInstallStates[queuedVoice] = .downloading(progress: 0)
-                        self.activeInstallTarget = .voice(queuedVoice)
-                    }
-                    self.sharedModelInstallState = .ready
-                }
-                Self.log("Shared model install completed successfully.")
+                pendingVoiceInstallAfterSharedModel = nil
             } catch {
                 Self.log("Shared model install failed with error: \(error.localizedDescription)")
-                await MainActor.run {
-                    self.sharedModelInstallState = .failed(error.localizedDescription)
-                }
-                self.pendingVoiceInstallAfterSharedModel = nil
+                sharedModelInstallState = .failed(error.localizedDescription)
+                pendingVoiceInstallAfterSharedModel = nil
             }
-
-            await self.finishSharedModelInstall(fileManager: fileManager, session: session)
         }
     }
 
@@ -104,6 +72,7 @@ extension PocketTTSModelManager {
         onDidInvalidateInstalledAssets?()
         installTask?.cancel()
         installTask = nil
+        backgroundDownloadCoordinator.cancelAndClearJob()
         activeInstallTarget = nil
         pendingVoiceInstallAfterSharedModel = nil
 
@@ -124,20 +93,38 @@ extension PocketTTSModelManager {
 
     func downloadVoice(_ voice: AppSettingsStore.TTSVoice) {
         guard installTask == nil else { return }
+        if let existingJob = backgroundDownloadCoordinator.loadJob(), existingJob.target != .voice(voice) {
+            return
+        }
         activeInstallTarget = .voice(voice)
 
-        installTask = Task { [fileManager, session] in
-            await self.performVoiceInstall(voice, fileManager: fileManager, session: session)
+        installTask = Task { [session] in
+            defer {
+                installTask = nil
+                refreshStatus()
+            }
 
-            await MainActor.run {
-                self.installTask = nil
-                self.activeInstallTarget = nil
+            do {
+                voiceInstallStates[voice] = .downloading(progress: 0)
+                if let existingJob = backgroundDownloadCoordinator.loadJob() {
+                    try await backgroundDownloadCoordinator.startOrResumeJob(existingJob)
+                    return
+                }
+
+                let descriptor = try await PocketTTSModelCatalog.fetchVoiceDescriptor(for: voice, session: session)
+                try await startBackgroundInstall(descriptor: descriptor, target: .voice(voice))
+            } catch {
+                Self.log("Voice install failed for \(voice.rawValue) with error: \(error.localizedDescription)")
+                voiceInstallStates[voice] = .failed(error.localizedDescription)
             }
         }
     }
 
     func deleteVoice(_ voice: AppSettingsStore.TTSVoice) {
         onDidInvalidateInstalledAssets?()
+        if backgroundDownloadCoordinator.loadJob()?.target == .voice(voice) {
+            backgroundDownloadCoordinator.cancelAndClearJob()
+        }
         if let voiceRootURL = SharedPaths.pocketTTSVoiceDirectoryURL(fileManager: fileManager)?
             .appendingPathComponent(voice.rawValue, isDirectory: true) {
             try? fileManager.removeItem(at: voiceRootURL)
@@ -149,140 +136,5 @@ extension PocketTTSModelManager {
     func repairVoiceIfNeeded(_ voice: AppSettingsStore.TTSVoice) {
         deleteVoice(voice)
         downloadVoice(voice)
-    }
-}
-
-private extension PocketTTSModelManager {
-    func finishSharedModelInstall(
-        fileManager: FileManager,
-        session: URLSession
-    ) async {
-        guard assetLocator.isSharedModelInstalled(),
-              let pendingVoice = pendingVoiceInstallAfterSharedModel,
-              assetLocator.isVoiceInstalled(pendingVoice) == false else {
-            pendingVoiceInstallAfterSharedModel = nil
-            await MainActor.run {
-                self.installTask = nil
-                self.activeInstallTarget = nil
-            }
-            return
-        }
-
-        pendingVoiceInstallAfterSharedModel = nil
-        await performVoiceInstall(pendingVoice, fileManager: fileManager, session: session)
-
-        await MainActor.run {
-            self.installTask = nil
-            self.activeInstallTarget = nil
-        }
-    }
-
-    func performVoiceInstall(
-        _ voice: AppSettingsStore.TTSVoice,
-        fileManager: FileManager,
-        session: URLSession
-    ) async {
-        do {
-            Self.log("Voice install requested for \(voice.rawValue).")
-            await MainActor.run {
-                self.voiceInstallStates[voice] = .downloading(progress: 0)
-            }
-
-            let descriptor = try await PocketTTSModelCatalog.fetchVoiceDescriptor(for: voice, session: session)
-            try await self.install(
-                descriptor: descriptor,
-                target: .voice(voice),
-                stagingRootURL: try Self.makeStagingRootURL(fileManager: fileManager, target: .voice(voice)),
-                finalRootURL: try Self.finalVoiceRootURL(voice, fileManager: fileManager),
-                progress: { progress in
-                    self.voiceInstallStates[voice] = .downloading(progress: progress)
-                },
-                installing: {
-                    self.voiceInstallStates[voice] = .installing(progress: 0.95)
-                }
-            )
-
-            let manifest = PocketTTSInstallManifest(
-                sourceRepository: PocketTTSModelCatalog.repositoryID,
-                artifactSizesByRelativePath: Dictionary(
-                    uniqueKeysWithValues: descriptor.artifacts.map { ($0.relativePath, $0.expectedByteCount) }
-                )
-            )
-            try Self.writeManifest(
-                manifest,
-                to: try Self.finalVoiceRootURL(voice, fileManager: fileManager)
-            )
-
-            guard self.assetLocator.isVoiceInstalled(voice) else {
-                throw NSError(
-                    domain: "PocketTTSModelManager",
-                    code: 8,
-                    userInfo: [NSLocalizedDescriptionKey: "\(voice.displayName) voice install validation failed."]
-                )
-            }
-
-            await MainActor.run {
-                self.voiceInstallStates[voice] = .ready
-            }
-            Self.log("Voice install completed successfully for \(voice.rawValue).")
-        } catch {
-            Self.log("Voice install failed for \(voice.rawValue) with error: \(error.localizedDescription)")
-            await MainActor.run {
-                self.voiceInstallStates[voice] = .failed(error.localizedDescription)
-            }
-        }
-    }
-
-    func install(
-        descriptor: PocketTTSDescriptor,
-        target: PocketTTSInstallTarget,
-        stagingRootURL: URL,
-        finalRootURL: URL,
-        progress: @escaping @MainActor (Double) -> Void,
-        installing: @escaping @MainActor () -> Void
-    ) async throws {
-        Self.log("Fetched descriptor with \(descriptor.artifacts.count) artifacts (\(descriptor.requiredDownloadBytes) bytes).")
-        try Self.prepareDirectory(stagingRootURL, fileManager: fileManager)
-        Self.log("Prepared staging directory at \(stagingRootURL.path).")
-
-        var completedBytes: Int64 = 0
-        let totalBytes = max(descriptor.requiredDownloadBytes, 1)
-
-        for artifact in descriptor.artifacts {
-            let destinationURL = stagingRootURL.appendingPathComponent(artifact.relativePath, isDirectory: false)
-            try Self.prepareParentDirectory(for: destinationURL, fileManager: fileManager)
-
-            if artifact.expectedByteCount == 0 {
-                try Data().write(to: destinationURL, options: [.atomic])
-            } else {
-                Self.log("Downloading artifact \(artifact.relativePath) from \(artifact.remoteURL.absoluteString).")
-                let temporaryURL = try await Self.download(artifact.remoteURL, using: session)
-                try Self.replaceItem(at: destinationURL, with: temporaryURL, fileManager: fileManager)
-            }
-
-            completedBytes += artifact.expectedByteCount
-            let currentProgress = min(max(Double(completedBytes) / Double(totalBytes), 0), 0.92)
-            await MainActor.run {
-                progress(currentProgress)
-            }
-        }
-
-        await MainActor.run {
-            installing()
-        }
-
-        switch target {
-        case .sharedModel:
-            try Self.replaceDirectory(
-                at: finalRootURL,
-                with: stagingRootURL.appendingPathComponent("Model", isDirectory: true),
-                fileManager: fileManager
-            )
-        case .voice(let voice):
-            let stagedVoiceDirectoryURL = stagingRootURL
-                .appendingPathComponent("Voices", isDirectory: true)
-                .appendingPathComponent(voice.rawValue, isDirectory: true)
-            try Self.replaceDirectory(at: finalRootURL, with: stagedVoiceDirectoryURL, fileManager: fileManager)
-        }
     }
 }

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+InstallLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+InstallLifecycle.swift
@@ -34,9 +34,14 @@ extension PocketTTSModelManager {
         activeInstallTarget = .sharedModel
 
         installTask = Task { [session] in
+            var installError: Error?
             defer {
                 installTask = nil
-                refreshStatus()
+                if let installError {
+                    sharedModelInstallState = .failed(installError.localizedDescription)
+                } else {
+                    refreshStatus()
+                }
             }
 
             do {
@@ -57,7 +62,7 @@ extension PocketTTSModelManager {
                 pendingVoiceInstallAfterSharedModel = nil
             } catch {
                 Self.log("Shared model install failed with error: \(error.localizedDescription)")
-                sharedModelInstallState = .failed(error.localizedDescription)
+                installError = error
                 pendingVoiceInstallAfterSharedModel = nil
             }
         }
@@ -99,9 +104,14 @@ extension PocketTTSModelManager {
         activeInstallTarget = .voice(voice)
 
         installTask = Task { [session] in
+            var installError: Error?
             defer {
                 installTask = nil
-                refreshStatus()
+                if let installError {
+                    voiceInstallStates[voice] = .failed(installError.localizedDescription)
+                } else {
+                    refreshStatus()
+                }
             }
 
             do {
@@ -115,7 +125,7 @@ extension PocketTTSModelManager {
                 try await startBackgroundInstall(descriptor: descriptor, target: .voice(voice))
             } catch {
                 Self.log("Voice install failed for \(voice.rawValue) with error: \(error.localizedDescription)")
-                voiceInstallStates[voice] = .failed(error.localizedDescription)
+                installError = error
             }
         }
     }

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+Support.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+Support.swift
@@ -68,33 +68,6 @@ extension PocketTTSModelManager {
         try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
     }
 
-    static func prepareParentDirectory(for url: URL, fileManager: FileManager) throws {
-        let parentURL = url.deletingLastPathComponent()
-        try fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
-    }
-
-    static func download(_ url: URL, using session: URLSession) async throws -> URL {
-        let (temporaryURL, response) = try await session.download(from: url)
-        guard let httpResponse = response as? HTTPURLResponse,
-              200 ..< 300 ~= httpResponse.statusCode else {
-            log("Download request failed for \(url.absoluteString).")
-            throw NSError(
-                domain: "PocketTTSModelManager",
-                code: 4,
-                userInfo: [NSLocalizedDescriptionKey: "Speak engine download failed."]
-            )
-        }
-        log("Download request succeeded for \(url.absoluteString) with status \(httpResponse.statusCode).")
-        return temporaryURL
-    }
-
-    static func replaceItem(at destinationURL: URL, with temporaryURL: URL, fileManager: FileManager) throws {
-        if fileManager.fileExists(atPath: destinationURL.path) {
-            try fileManager.removeItem(at: destinationURL)
-        }
-        try fileManager.moveItem(at: temporaryURL, to: destinationURL)
-    }
-
     static func writeManifest(_ manifest: PocketTTSInstallManifest, to rootURL: URL) throws {
         try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true, attributes: nil)
         let manifestURL = rootURL.appendingPathComponent(PocketTTSInstallManifest.filename, isDirectory: false)

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+Support.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager+Support.swift
@@ -35,7 +35,7 @@ extension PocketTTSModelManager {
         return rootURL
     }
 
-    static func makeStagingRootURL(
+    nonisolated static func makeStagingRootURL(
         fileManager: FileManager,
         target: PocketTTSInstallTarget
     ) throws -> URL {

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager.swift
@@ -58,9 +58,9 @@ final class PocketTTSModelManager: ObservableObject {
         self.voiceInstallStates = Dictionary(
             uniqueKeysWithValues: AppSettingsStore.TTSVoice.userFacingCases.map { ($0, .notInstalled) }
         )
-        self.backgroundDownloadCoordinator.stateDidChange = { [weak self] _ in
+        self.backgroundDownloadCoordinator.stateDidChange = { [weak self] job in
             Task { @MainActor [weak self] in
-                await self?.handleBackgroundDownloadStateChanged()
+                await self?.handleBackgroundDownloadStateChanged(job)
             }
         }
         refreshStatus()
@@ -94,6 +94,7 @@ final class PocketTTSModelManager: ObservableObject {
         Task { [weak self] in
             guard let self else { return }
             await self.backgroundDownloadCoordinator.handleAppDidBecomeActive()
+            guard self.appIsActive else { return }
             let job = await self.backgroundDownloadCoordinator.synchronizeWithSystemTasks()
             if let job,
                !job.isReadyForFinalization,

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager.swift
@@ -93,6 +93,7 @@ final class PocketTTSModelManager: ObservableObject {
         appIsActive = true
         Task { [weak self] in
             guard let self else { return }
+            await self.backgroundDownloadCoordinator.handleAppDidBecomeActive()
             let job = await self.backgroundDownloadCoordinator.synchronizeWithSystemTasks()
             if let job,
                !job.isReadyForFinalization,
@@ -104,8 +105,9 @@ final class PocketTTSModelManager: ObservableObject {
         }
     }
 
-    func handleAppDidEnterBackground() {
+    func handleAppWillResignActive() {
         appIsActive = false
+        backgroundDownloadCoordinator.handleAppWillResignActive()
     }
 
     func handleBackgroundURLSessionEvents(

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager.swift
@@ -38,21 +38,31 @@ final class PocketTTSModelManager: ObservableObject {
     let fileManager: FileManager
     let session: URLSession
     let assetLocator: PocketTTSAssetLocator
+    let backgroundDownloadCoordinator: PocketTTSBackgroundDownloadCoordinator
     var installTask: Task<Void, Never>?
     var pendingVoiceInstallAfterSharedModel: AppSettingsStore.TTSVoice?
     var onDidInvalidateInstalledAssets: (() -> Void)?
+    var appIsActive = false
+    var isFinalizationInFlight = false
 
     init(
         fileManager: FileManager = .default,
         session: URLSession = .shared,
-        assetLocator: PocketTTSAssetLocator? = nil
+        assetLocator: PocketTTSAssetLocator? = nil,
+        backgroundDownloadCoordinator: PocketTTSBackgroundDownloadCoordinator
     ) {
         self.fileManager = fileManager
         self.session = session
         self.assetLocator = assetLocator ?? PocketTTSAssetLocator(fileManager: fileManager)
+        self.backgroundDownloadCoordinator = backgroundDownloadCoordinator
         self.voiceInstallStates = Dictionary(
             uniqueKeysWithValues: AppSettingsStore.TTSVoice.userFacingCases.map { ($0, .notInstalled) }
         )
+        self.backgroundDownloadCoordinator.stateDidChange = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.handleBackgroundDownloadStateChanged()
+            }
+        }
         refreshStatus()
     }
 
@@ -70,13 +80,44 @@ final class PocketTTSModelManager: ObservableObject {
         for voice in AppSettingsStore.TTSVoice.userFacingCases {
             voiceInstallStates[voice] = assetLocator.isVoiceInstalled(voice) ? .ready : .notInstalled
         }
+
+        guard let job = backgroundDownloadCoordinator.loadJob() else {
+            activeInstallTarget = nil
+            return
+        }
+        activeInstallTarget = job.target
+        applyBackgroundJobState(job)
     }
 
     func handleAppDidBecomeActive() {
-        refreshStatus()
+        appIsActive = true
+        Task { [weak self] in
+            guard let self else { return }
+            let job = await self.backgroundDownloadCoordinator.synchronizeWithSystemTasks()
+            if let job,
+               !job.isReadyForFinalization,
+               job.finalizationState != .failed {
+                try? await self.backgroundDownloadCoordinator.startOrResumeJob(job)
+            }
+            self.refreshStatus()
+            await self.resumeForegroundFinalizationIfNeeded()
+        }
     }
 
-    func handleAppDidEnterBackground() {}
+    func handleAppDidEnterBackground() {
+        appIsActive = false
+    }
+
+    func handleBackgroundURLSessionEvents(
+        identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        guard identifier == PocketTTSBackgroundDownloadCoordinator.sessionIdentifier else {
+            completionHandler()
+            return
+        }
+        backgroundDownloadCoordinator.registerBackgroundSessionCompletionHandler(completionHandler)
+    }
 
     func isSharedModelReady() -> Bool {
         if case .ready = sharedModelInstallState {


### PR DESCRIPTION
## Summary

- Keeps KeyVox Speak engine and voice downloads on the normal foreground network path while the app is active.
- Hands active transfers to a background URL session when the app becomes inactive and returns them to the foreground session when the app becomes active.
- Extracts the session-handoff mechanics into a reusable, model-neutral resumable download transport while keeping Speak policy inside the Speak coordinator.
- Preserves the existing Speak install locations and the distinct Settings and Home download flows.

## Foreground and background handoff

- Uses paired foreground and background URL sessions with a dedicated Speak background-session identifier.
- Starts the foreground-to-background handoff during the inactive lifecycle transition so iOS receives the background work while foreground execution time remains available.
- Cancels source tasks by producing resume data and recreates them in the destination session without restarting completed work.
- Serializes lifecycle transitions and follows the newest requested app state when another transition occurs during a handoff.
- Preserves aggregate byte progress across session-local progress changes so the displayed percentage does not regress during handoff.
- Uses the default URL session configuration in the foreground so active downloads retain the previous foreground transfer behavior and speed.

## Reusable transport boundary

- Adds ResumableDownloadTransport for paired-session ownership, task identity, resume-data transfer, lifecycle transitions, background completion handlers, and URL session delegate forwarding.
- Keeps model catalogs, artifact ordering, persisted jobs, retry policy, filesystem paths, installation, and finalization outside the shared transport.
- Gives each model family an independent transport instance and session namespace, allowing unrelated model families to download simultaneously without sharing or cancelling tasks.
- Splits the Speak coordinator into focused files for transport adaptation, callbacks, download state, sequential scheduling, and rate-limit handling.

## Speak download behavior

- Keeps foreground Speak artifacts sequential, matching the original transfer order and avoiding bursts of resolver requests.
- Allows the background session to own the remaining persisted artifact set while the app is suspended.
- Persists artifact identity, byte progress, retry timing, finalization state, and an optional voice queued after the shared engine.
- Defers HTTP 429 retries using the available server retry window while keeping permanent HTTP failures visible.
- Reconnects persisted jobs to URL session tasks after relaunch and performs installation finalization only while the app is active.
- Removes the replaced background-only transfer path instead of retaining an unused fallback.

## Product flows and installation integrity

- Settings downloads only the shared Speak engine; voices remain separate user-selected downloads.
- Home downloads the shared engine first and then starts the explicitly queued voice.
- Engine, voice, manifest, job, and staging locations remain unchanged.
- Completed artifacts continue through the existing manifest writing, validation, and final filesystem replacement paths.
- Install failures remain visible after task cleanup instead of being overwritten by a status refresh.

## Documentation

- Updates the iOS code map and engineering reference with the reusable transport boundary, Speak file ownership, lifecycle behavior, and existing product flows.

## Validation

- KeyVox iOS test suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pocket TTS model and voice downloads can continue in the background.
  * Downloads resume after interruptions and stay synchronized when the app reopens.
  * Installation progress and failures are tracked, with completed downloads finalized when the app is active.
  * Background download events are routed correctly for different model types.
  * Queued voice downloads can follow shared-model installation.

* **Bug Fixes**
  * Prevented conflicting downloads from overwriting one another.
  * Improved recovery from rate limits, failures, and interrupted downloads.
  * Improved cleanup when downloads or installations are deleted or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->