### PR TITLE
fix(ios-vibes): continue model downloads in background

### DIFF
--- a/iOS/Docs/CODEMAP.md
+++ b/iOS/Docs/CODEMAP.md
@@ -168,9 +168,16 @@ iOS/
 │   │   │   ├── ModelManager+Support.swift
 │   │   │   └── ModelManager+Validation.swift
 │   │   ├── LocalRewriteModel/
+│   │   │   ├── LocalRewriteBackgroundDownloadCoordinator.swift
+│   │   │   ├── LocalRewriteBackgroundDownloadCoordinator+DownloadState.swift
+│   │   │   ├── LocalRewriteBackgroundDownloadCoordinator+Transport.swift
+│   │   │   ├── LocalRewriteBackgroundDownloadCoordinator+TransportDelegate.swift
+│   │   │   ├── LocalRewriteBackgroundDownloadJob.swift
+│   │   │   ├── LocalRewriteBackgroundDownloadJobStore.swift
 │   │   │   ├── LocalRewriteModelCatalog.swift
 │   │   │   ├── LocalRewriteModelInstallManifest.swift
 │   │   │   ├── LocalRewriteModelInstallState.swift
+│   │   │   ├── LocalRewriteModelManager+BackgroundLifecycle.swift
 │   │   │   └── LocalRewriteModelManager.swift
 │   │   ├── TTS/
 │   │   │   ├── AudioModeCoordinator.swift
@@ -475,6 +482,8 @@ iOS/
 │   │   │   ├── KeyboardToolbarModeTests.swift
 │   │   │   ├── KeyboardTextInputControllerTests.swift
 │   │   │   └── KeyboardViewControllerTests.swift
+│   │   ├── LocalRewriteModel/
+│   │   │   └── LocalRewriteBackgroundDownloadJobTests.swift
 │   │   ├── TTS/
 │   │   │   ├── TTSManager/
 │   │   │   │   ├── TTSManagerLifecycleTests.swift
@@ -586,8 +595,8 @@ Packages/
   - SwiftUI app entry point.
   - Injects all app-wide environment objects.
   - Registers model-download background tasks.
-  - Handles scene activation/background callbacks for transcription recovery, model recovery, onboarding keyboard-tour arming, Dictation Shortcut intro scheduling, shortcut-route consumption, and Speak download transport handoffs.
-  - Starts the Speak foreground-to-background handoff during `.inactive`, while the app still has foreground execution time, and hands the transfer back during `.active`.
+  - Handles scene activation/background callbacks for transcription recovery, model recovery, onboarding keyboard-tour arming, Dictation Shortcut intro scheduling, shortcut-route consumption, and Speak/Vibes download transport handoffs.
+  - Starts Speak and Vibes foreground-to-background handoffs during `.inactive`, while the app still has foreground execution time, and hands unfinished transfers back during `.active`.
   - Consumes any cold-launch URL route that was captured before SwiftUI rendered and pre-presents `ReturnToHostView` without animation before routing `keyvoxios://record/start`.
 - `KeyVox iOS/App/Composition/SharedPaths.swift`
   - Centralizes rooted app-group, cache, and install filesystem locations used by app-owned services.
@@ -612,7 +621,7 @@ Packages/
 - `KeyVox iOS/App/Shortcuts/KeyVoxSpeakShortcutsProvider.swift`
   - Registers the Toggle Dictation and KeyVox Speak App Shortcut phrases surfaced in the Shortcuts system.
 - `KeyVox iOS/App/Lifecycle/AppDelegate.swift`
-  - Receives background `URLSession` callbacks and routes each configured session identifier to its owning Dictation or Speak model manager.
+  - Receives background `URLSession` callbacks and routes each configured session identifier to its owning Dictation, Speak, or Vibes model manager.
 - `KeyVox iOS/App/Lifecycle/AppSceneDelegate.swift`
   - Captures cold-launch scene connection URLs before the first root render and forwards them into the launch-route store.
 - `KeyVox iOS/App/Routing/AppLaunchRouteStore.swift`
@@ -767,7 +776,7 @@ Packages/
 ### Model Installation and Recovery
 
 - `KeyVox iOS/Core/Downloads/ResumableDownloadTransport.swift`
-  - Reusable transport owner for paired foreground and background `URLSession` instances, per-family session configuration, task discovery and deduplication, pending resume data, cancellation, and background-session completion handlers.
+  - Reusable transport owner for paired foreground and background `URLSession` instances, synchronized per-family session creation, task discovery and deduplication, pending resume data, cancellation, and background-session completion handlers.
   - Contains no model catalog, installation path, retry policy, persisted job, or finalization logic. Each model family supplies those policies through `ResumableDownloadTransportDelegate`.
 - `KeyVox iOS/Core/Downloads/ResumableDownloadTransport+Lifecycle.swift`
   - Owns the reusable foreground/background handoff state machine.
@@ -806,9 +815,25 @@ Packages/
   - Current base model is `Qwen2.5-0.5B-Instruct` from `Qwen/Qwen2.5-0.5B-Instruct-GGUF`, artifact `qwen2.5-0.5b-instruct-q4_k_m.gguf`, with strict SHA-256 validation and a 491,400,032-byte expected size.
   - Current bundled adapters are provided by `KeyVoxVibesAdapters`: `polished-alpha-027-lora.gguf` and `casual-alpha-9-lora.gguf`.
 - `KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelManager.swift`
-  - Containing-app owner for local Vibes model install state, foreground download, staging/finalization, manifest validation, SHA-256 integrity checks, delete/repair-style cleanup, and adapter URL resolution.
+  - Containing-app owner for local Vibes model install state, lifecycle recovery, foreground-owned finalization, manifest validation, SHA-256 integrity checks, delete/repair-style cleanup, and adapter URL resolution.
   - Resolves LoRA adapters from the bundled `KeyVoxVibesAdapters` package first and falls back to the installed model directory only when needed.
   - Invalidates the local inference service when the installed base model is deleted or replaced.
+- `KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelManager+BackgroundLifecycle.swift`
+  - Starts or resumes the persisted Vibes job, serializes activation recovery, maps job progress into public install state, and finalizes completed downloads only while the app is active.
+  - Builds the artifact and manifest completely in the existing staging directory before replacing the installed model directory.
+- `KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJob.swift`
+  - Persisted single-artifact Vibes job containing download identity, byte progress, task identity, errors, and finalization state.
+- `KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJobStore.swift`
+  - Atomic JSON persistence seam for the active Vibes job at `Models/rewrite/background-download-job.json`.
+- `KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator.swift`
+  - Vibes-specific owner of the reusable foreground/background transport and the unique `com.cueit.keyvox.vibes-download.background-session` namespace.
+  - Reconciles persisted state with both sessions, prevents progress regression across handoffs, and limits cancellation and recovery to the active Vibes job.
+- `KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+Transport.swift`
+  - Recreates the active Vibes transfer in the destination session during a foreground/background handoff.
+- `KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+TransportDelegate.swift`
+  - Maps transport callbacks into Vibes state, rejects non-2xx responses, and moves successful temporary downloads into the existing Vibes staging location.
+- `KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+DownloadState.swift`
+  - Owns persisted Vibes progress and failure mutations plus state-change publication.
 - `KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelInstallManifest.swift`
   - Durable manifest for the installed local rewrite model identity, source repository, artifact filename, expected hash, installed hash, file size, and install date.
 - `KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelInstallState.swift`

--- a/iOS/Docs/ENGINEERING.md
+++ b/iOS/Docs/ENGINEERING.md
@@ -1079,7 +1079,7 @@ Primary owners:
 
 ### Background Download Rules
 
-Dictation and Speak currently have separate model-family coordinators. `ModelBackgroundDownloadCoordinator` owns Dictation’s existing background-only system. Speak uses the reusable `ResumableDownloadTransport` through `PocketTTSBackgroundDownloadCoordinator`.
+Dictation, Speak, and Vibes have separate model-family coordinators. `ModelBackgroundDownloadCoordinator` owns Dictation’s existing background-only system. Speak and Vibes each use the reusable `ResumableDownloadTransport` through their own coordinator.
 
 #### Reusable Handoff Transport
 
@@ -1088,6 +1088,7 @@ Dictation and Speak currently have separate model-family coordinators. `ModelBac
 Rules:
 
 - each model family receives its own transport instance and unique background-session identifier; tasks from one family must never cancel, replace, or reconcile against another family
+- transport and underlying URL session creation must be serialized so one app process cannot create duplicate sessions for a family identifier
 - task identity is the universal `jobID` plus `artifactID` descriptor stored in `URLSessionTask.taskDescription`
 - the foreground session uses the default URLSession configuration so an active-app download follows the normal foreground network path
 - the background session enables launch events, waits for connectivity, uses the App Group container, and remains non-discretionary when started while the app still has foreground execution time
@@ -1113,6 +1114,21 @@ Rules:
 - shared-engine finalization writes and validates the existing manifest at the existing model root; voice finalization writes and validates the selected voice root
 - a Settings shared-engine request ends after engine finalization; a combined Home/setup request then starts its explicitly queued voice download
 - there is no legacy foreground fallback path: active downloads use the foreground side of the reusable transport and inactive downloads use its background side
+
+#### Vibes Download Policy
+
+- `LocalRewriteBackgroundDownloadJob` persists the fixed Vibes artifact identity, remote URL, expected byte count, transfer progress, task identity, error, and finalization state
+- the active job is stored as `Models/rewrite/background-download-job.json`
+- the installed model remains `Models/rewrite/qwen2-5-0-5b-instruct/`, and incomplete work remains under `Models/rewrite/.staging/qwen2-5-0-5b-instruct/`
+- Vibes owns a dedicated transport instance and background session named `com.cueit.keyvox.vibes-download.background-session`; it does not reuse or cancel Speak or Dictation tasks
+- an active-app request uses the foreground session, `.inactive` begins the handoff to the Vibes background session, and `.active` hands an unfinished transfer back to the foreground session
+- persisted completed bytes never decrease when a recreated URLSession task initially reports a smaller task-local byte count
+- app activation serializes job reconciliation and restart so repeated active events cannot schedule duplicate tasks for the same persisted job
+- a completed URLSession temporary file is moved into Vibes staging during the delegate callback; non-2xx HTTP responses become download failures instead of staged integrity failures
+- download completion is not installation completion: SHA-256 validation, manifest creation, and installation remain foreground-owned
+- finalization builds the complete artifact and manifest in staging before atomically replacing an existing installed model, preserving the current valid installation if replacement fails
+- delete and repair cancel only Vibes-owned URLSession tasks, clear the Vibes job, and retain the existing user-facing install-state flow
+- there is no legacy foreground downloader: both foreground and background transfers use the reusable transport
 
 #### Dictation Background Downloads
 

--- a/iOS/KeyVox iOS/App/Composition/AppServiceRegistry.swift
+++ b/iOS/KeyVox iOS/App/Composition/AppServiceRegistry.swift
@@ -129,7 +129,29 @@ final class AppServiceRegistry {
         let postProcessor = TranscriptionPostProcessor()
         let keyboardBridge = KeyVoxKeyboardBridge()
         let styleRewriteArtifactStore = StyleRewriteLatestArtifactStore(defaults: settingsDefaults)
-        let localRewriteModelManager = LocalRewriteModelManager(fileManager: fileManager)
+        let localRewriteBackgroundDownloadJobStore = LocalRewriteBackgroundDownloadJobStore(
+            fileManager: fileManager,
+            jobURLProvider: { SharedPaths.localRewriteDownloadJobURL(fileManager: fileManager) }
+        )
+        let localRewriteBackgroundDownloadCoordinator = LocalRewriteBackgroundDownloadCoordinator(
+            fileManager: fileManager,
+            jobStore: localRewriteBackgroundDownloadJobStore,
+            stagingArtifactURLProvider: {
+                guard let stagingRootURL = SharedPaths.localRewriteModelStagingDirectoryURL(
+                    fileManager: fileManager
+                ) else {
+                    throw LocalRewriteModelInstallError.appGroupUnavailable
+                }
+                return stagingRootURL.appendingPathComponent(
+                    LocalRewriteModelCatalog.descriptor.artifact.filename,
+                    isDirectory: false
+                )
+            }
+        )
+        let localRewriteModelManager = LocalRewriteModelManager(
+            fileManager: fileManager,
+            backgroundDownloadCoordinator: localRewriteBackgroundDownloadCoordinator
+        )
         let localRewriteInferenceService = LocalRewriteInferenceService(
             modelURLProvider: { [weak localRewriteModelManager] in
                 localRewriteModelManager?.installedModelURL()

--- a/iOS/KeyVox iOS/App/Composition/SharedPaths.swift
+++ b/iOS/KeyVox iOS/App/Composition/SharedPaths.swift
@@ -175,6 +175,11 @@ nonisolated enum SharedPaths {
             .appendingPathComponent("qwen2-5-0-5b-instruct", isDirectory: true)
     }
 
+    static func localRewriteDownloadJobURL(fileManager: FileManager = .default) -> URL? {
+        localRewriteRootDirectoryURL(fileManager: fileManager)?
+            .appendingPathComponent("background-download-job.json", isDirectory: false)
+    }
+
     static func ttsRequestURL(fileManager: FileManager = .default) -> URL? {
         ttsDirectoryURL(fileManager: fileManager)?
             .appendingPathComponent("request.json", isDirectory: false)

--- a/iOS/KeyVox iOS/App/Lifecycle/AppDelegate.swift
+++ b/iOS/KeyVox iOS/App/Lifecycle/AppDelegate.swift
@@ -18,6 +18,11 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                 identifier: identifier,
                 completionHandler: completionHandler
             )
+        case LocalRewriteBackgroundDownloadCoordinator.sessionIdentifier:
+            AppServiceRegistry.shared.localRewriteModelManager.handleBackgroundURLSessionEvents(
+                identifier: identifier,
+                completionHandler: completionHandler
+            )
         default:
             completionHandler()
         }

--- a/iOS/KeyVox iOS/App/Lifecycle/KeyVoxiOSApp.swift
+++ b/iOS/KeyVox iOS/App/Lifecycle/KeyVoxiOSApp.swift
@@ -115,6 +115,7 @@ struct KeyVoxApp: App {
                         transcriptionManager.handleAppDidBecomeActive()
                         ttsManager.handleAppDidBecomeActive()
                         pocketTTSModelManager.handleAppDidBecomeActive()
+                        localRewriteModelManager.handleAppDidBecomeActive()
                         modelManager.handleAppDidBecomeActive()
                         appUpdateCoordinator.handleAppDidBecomeActive()
                         promotionCenter.refresh()
@@ -155,6 +156,7 @@ struct KeyVoxApp: App {
                     case .inactive:
                         ttsManager.handleAppWillResignActive()
                         pocketTTSModelManager.handleAppWillResignActive()
+                        localRewriteModelManager.handleAppWillResignActive()
                     @unknown default:
                         break
                     }

--- a/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport.swift
+++ b/iOS/KeyVox iOS/Core/Downloads/ResumableDownloadTransport.swift
@@ -40,6 +40,7 @@ final class ResumableDownloadTransport: NSObject {
     private let sharedContainerIdentifier: String
     private let lifecycleLock = NSLock()
     private let completionHandlerLock = NSLock()
+    private let sessionLock = NSLock()
 
     weak var delegate: ResumableDownloadTransportDelegate?
     var appIsActive = false
@@ -48,42 +49,52 @@ final class ResumableDownloadTransport: NSObject {
     private var pendingResumeDataByArtifactID: [String: Data] = [:]
     private var backgroundSessionCompletionHandler: (() -> Void)?
 
-    private lazy var backgroundSession: URLSession = {
-        let configuration = URLSessionConfiguration.background(withIdentifier: sessionIdentifier)
-        configuration.sharedContainerIdentifier = sharedContainerIdentifier
-        configuration.sessionSendsLaunchEvents = true
-        configuration.waitsForConnectivity = true
-        configuration.isDiscretionary = false
-        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-    }()
-
-    private lazy var foregroundSession: URLSession = {
-        URLSession(configuration: .default, delegate: self, delegateQueue: nil)
-    }()
+    private var storedBackgroundSession: URLSession?
+    private var storedForegroundSession: URLSession?
 
     init(
         sessionIdentifier: String,
         sharedContainerIdentifier: String,
-        delegate: ResumableDownloadTransportDelegate
+        delegate: ResumableDownloadTransportDelegate?
     ) {
         self.sessionIdentifier = sessionIdentifier
         self.sharedContainerIdentifier = sharedContainerIdentifier
         self.delegate = delegate
+        super.init()
     }
 
     func registerBackgroundSessionCompletionHandler(_ completionHandler: @escaping () -> Void) {
         completionHandlerLock.lock()
         backgroundSessionCompletionHandler = completionHandler
         completionHandlerLock.unlock()
-        _ = backgroundSession
+        _ = session(for: .background)
     }
 
     func session(for kind: ResumableDownloadSessionKind) -> URLSession {
         switch kind {
         case .foreground:
-            foregroundSession
+            sessionLock.lock()
+            defer { sessionLock.unlock() }
+            if let storedForegroundSession {
+                return storedForegroundSession
+            }
+            let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+            storedForegroundSession = session
+            return session
         case .background:
-            backgroundSession
+            sessionLock.lock()
+            defer { sessionLock.unlock() }
+            if let storedBackgroundSession {
+                return storedBackgroundSession
+            }
+            let configuration = URLSessionConfiguration.background(withIdentifier: sessionIdentifier)
+            configuration.sharedContainerIdentifier = sharedContainerIdentifier
+            configuration.sessionSendsLaunchEvents = true
+            configuration.waitsForConnectivity = true
+            configuration.isDiscretionary = false
+            let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+            storedBackgroundSession = session
+            return session
         }
     }
 
@@ -161,10 +172,10 @@ final class ResumableDownloadTransport: NSObject {
     }
 
     func cancelAllTasksWithoutWaiting() {
-        backgroundSession.getAllTasks { tasks in
+        session(for: .background).getAllTasks { tasks in
             tasks.forEach { $0.cancel() }
         }
-        foregroundSession.getAllTasks { tasks in
+        session(for: .foreground).getAllTasks { tasks in
             tasks.forEach { $0.cancel() }
         }
         storePendingResumeData([:])

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+DownloadState.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+DownloadState.swift
@@ -55,4 +55,13 @@ extension LocalRewriteBackgroundDownloadCoordinator {
         guard let job else { return }
         stateDidChange?(job)
     }
+
+    func markDownloadFailed(message: String) {
+        updateLoadedJob {
+            $0.phase = .failed
+            $0.taskIdentifier = nil
+            $0.finalizationState = .failed
+            $0.lastErrorMessage = message
+        }
+    }
 }

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+DownloadState.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+DownloadState.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+extension LocalRewriteBackgroundDownloadCoordinator {
+    func updateDownloadProgress(
+        for descriptor: ResumableDownloadTaskDescriptor,
+        taskIdentifier: Int,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        let job = withJobStoreLock { () -> LocalRewriteBackgroundDownloadJob? in
+            guard var job = jobStore.load(),
+                  job.id == descriptor.jobID,
+                  job.artifactFilename == descriptor.artifactID else {
+                return nil
+            }
+
+            let previousProgress = job.downloadProgressFraction
+            job.phase = .downloading
+            job.taskIdentifier = taskIdentifier
+            job.completedBytes = max(job.completedBytes, max(totalBytesWritten, 0))
+            if totalBytesExpectedToWrite > 0 {
+                job.expectedBytes = max(
+                    job.expectedBytes ?? job.expectedByteCount,
+                    totalBytesExpectedToWrite
+                )
+            }
+            job.lastErrorMessage = nil
+            job.updatedAt = .now
+
+            guard job.downloadProgressFraction - previousProgress >= Self.minimumProgressPersistenceFraction else {
+                return nil
+            }
+            try? jobStore.save(job)
+            return job
+        }
+        guard let job else { return }
+        stateDidChange?(job)
+    }
+
+    func markDownloadFailed(for descriptor: ResumableDownloadTaskDescriptor) {
+        let job = withJobStoreLock { () -> LocalRewriteBackgroundDownloadJob? in
+            guard var job = jobStore.load(),
+                  job.id == descriptor.jobID,
+                  job.artifactFilename == descriptor.artifactID else {
+                return nil
+            }
+            job.phase = .failed
+            job.taskIdentifier = nil
+            job.finalizationState = .failed
+            job.lastErrorMessage = Self.downloadFailureMessage
+            job.updatedAt = .now
+            try? jobStore.save(job)
+            return job
+        }
+        guard let job else { return }
+        stateDidChange?(job)
+    }
+}

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+Transport.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+Transport.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+extension LocalRewriteBackgroundDownloadCoordinator {
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        prepareDownloadsFor sessionKind: ResumableDownloadSessionKind,
+        resumeDataByArtifactID: [String: Data]
+    ) async -> [String: Data] {
+        var remainingResumeData = resumeDataByArtifactID
+        guard let existingJob = loadJob() else { return [:] }
+
+        let sessionTasks = await transport.downloadTasks(in: sessionKind)
+        let existingTasks = transport.deduplicatedTasksByArtifactID(
+            from: sessionTasks,
+            jobID: existingJob.id
+        )
+        let job = withJobStoreLock { () -> LocalRewriteBackgroundDownloadJob? in
+            guard var job = jobStore.load(), job.id == existingJob.id else { return nil }
+            prepareDownload(
+                in: &job,
+                existingTask: existingTasks[job.artifactFilename],
+                session: transport.session(for: sessionKind),
+                resumeDataByArtifactID: &remainingResumeData
+            )
+            try? jobStore.save(job)
+            return job
+        }
+        guard let job else { return remainingResumeData }
+        stateDidChange?(job)
+        return remainingResumeData
+    }
+}

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+TransportDelegate.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+TransportDelegate.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+extension LocalRewriteBackgroundDownloadCoordinator {
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didWriteDataFor descriptor: ResumableDownloadTaskDescriptor,
+        taskIdentifier: Int,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        updateDownloadProgress(
+            for: descriptor,
+            taskIdentifier: taskIdentifier,
+            totalBytesWritten: totalBytesWritten,
+            totalBytesExpectedToWrite: totalBytesExpectedToWrite
+        )
+    }
+
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didFinishDownloading descriptor: ResumableDownloadTaskDescriptor,
+        to location: URL,
+        response: URLResponse?
+    ) {
+        do {
+            let updatedJob = try withJobStoreLock { () -> LocalRewriteBackgroundDownloadJob? in
+                guard var job = jobStore.load(),
+                      job.id == descriptor.jobID,
+                      job.artifactFilename == descriptor.artifactID else {
+                    return nil
+                }
+                let destinationURL = try stagingArtifactURLProvider()
+                try fileManager.createDirectory(
+                    at: destinationURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                if fileManager.fileExists(atPath: destinationURL.path) {
+                    try fileManager.removeItem(at: destinationURL)
+                }
+                try fileManager.moveItem(at: location, to: destinationURL)
+                let fileSize = (
+                    try fileManager.attributesOfItem(atPath: destinationURL.path)[.size] as? NSNumber
+                )?.int64Value ?? 0
+                job.phase = .downloaded
+                job.taskIdentifier = nil
+                job.completedBytes = max(job.completedBytes, fileSize)
+                job.expectedBytes = max(job.expectedBytes ?? job.expectedByteCount, fileSize)
+                job.finalizationState = .pending
+                job.lastErrorMessage = nil
+                job.updatedAt = .now
+                try jobStore.save(job)
+                return job
+            }
+            guard let updatedJob else { return }
+            stateDidChange?(updatedJob)
+        } catch {
+            markDownloadFailed(for: descriptor)
+        }
+    }
+
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didComplete descriptor: ResumableDownloadTaskDescriptor,
+        in sessionKind: ResumableDownloadSessionKind,
+        error: Error?
+    ) {
+        guard let error else { return }
+        let nsError = error as NSError
+        guard !(nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled) else {
+            return
+        }
+        markDownloadFailed(for: descriptor)
+    }
+}

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+TransportDelegate.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator+TransportDelegate.swift
@@ -23,6 +23,12 @@ extension LocalRewriteBackgroundDownloadCoordinator {
         response: URLResponse?
     ) {
         do {
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200...299).contains(httpResponse.statusCode) {
+                markDownloadFailed(for: descriptor)
+                return
+            }
+
             let updatedJob = try withJobStoreLock { () -> LocalRewriteBackgroundDownloadJob? in
                 guard var job = jobStore.load(),
                       job.id == descriptor.jobID,

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator.swift
@@ -1,0 +1,229 @@
+import Foundation
+
+final class LocalRewriteBackgroundDownloadCoordinator: ResumableDownloadTransportDelegate {
+    static let sessionIdentifier = "com.cueit.keyvox.vibes-download.background-session"
+    static let minimumProgressPersistenceFraction = 0.01
+    static let downloadFailureMessage = "Vibes model download failed. Check your network/storage and retry."
+
+    var stateDidChange: (@Sendable (LocalRewriteBackgroundDownloadJob?) -> Void)?
+
+    let fileManager: FileManager
+    let jobStore: LocalRewriteBackgroundDownloadJobStore
+    let stagingArtifactURLProvider: () throws -> URL
+    let jobStoreLock = NSLock()
+    lazy var transport = ResumableDownloadTransport(
+        sessionIdentifier: Self.sessionIdentifier,
+        sharedContainerIdentifier: SharedPaths.appGroupID,
+        delegate: self
+    )
+
+    init(
+        fileManager: FileManager = .default,
+        jobStore: LocalRewriteBackgroundDownloadJobStore,
+        stagingArtifactURLProvider: @escaping () throws -> URL
+    ) {
+        self.fileManager = fileManager
+        self.jobStore = jobStore
+        self.stagingArtifactURLProvider = stagingArtifactURLProvider
+    }
+
+    func loadJob() -> LocalRewriteBackgroundDownloadJob? {
+        withJobStoreLock {
+            jobStore.load()
+        }
+    }
+
+    func registerBackgroundSessionCompletionHandler(_ completionHandler: @escaping () -> Void) {
+        transport.registerBackgroundSessionCompletionHandler(completionHandler)
+    }
+
+    func handleAppDidBecomeActive() async {
+        await transport.handleAppDidBecomeActive()
+    }
+
+    func handleAppWillResignActive() {
+        transport.handleAppWillResignActive()
+    }
+
+    func startOrResumeJob(_ requestedJob: LocalRewriteBackgroundDownloadJob) async throws {
+        let stagingArtifactURL = try stagingArtifactURLProvider()
+        try fileManager.createDirectory(
+            at: stagingArtifactURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let initialJob = try withJobStoreLock {
+            let job = jobStore.load().flatMap { $0.id == requestedJob.id ? $0 : nil } ?? requestedJob
+            try jobStore.save(job)
+            return job
+        }
+        stateDidChange?(initialJob)
+
+        let backgroundTasks = await transport.downloadTasks(in: .background)
+        let foregroundTasks = await transport.downloadTasks(in: .foreground)
+        let allTasks = backgroundTasks + foregroundTasks
+        allTasks
+            .filter { transport.taskDescriptor(for: $0)?.jobID != requestedJob.id }
+            .forEach { $0.cancel() }
+
+        let useBackgroundSession = transport.shouldUseBackgroundSession(
+            jobID: requestedJob.id,
+            existingBackgroundTasks: backgroundTasks
+        )
+        if useBackgroundSession {
+            foregroundTasks
+                .filter { transport.taskDescriptor(for: $0)?.jobID == requestedJob.id }
+                .forEach { $0.cancel() }
+        }
+
+        let existingTasks = transport.deduplicatedTasksByArtifactID(
+            from: useBackgroundSession ? backgroundTasks : foregroundTasks,
+            jobID: requestedJob.id
+        )
+        let sessionKind: ResumableDownloadSessionKind = useBackgroundSession ? .background : .foreground
+        var resumeDataByArtifactID = useBackgroundSession ? [:] : transport.takePendingResumeData()
+        let job = try withJobStoreLock { () -> LocalRewriteBackgroundDownloadJob? in
+            guard var job = jobStore.load(), job.id == requestedJob.id else { return nil }
+            prepareDownload(
+                in: &job,
+                existingTask: existingTasks[job.artifactFilename],
+                session: transport.session(for: sessionKind),
+                resumeDataByArtifactID: &resumeDataByArtifactID
+            )
+            try jobStore.save(job)
+            return job
+        }
+
+        if !useBackgroundSession {
+            transport.storePendingResumeData(resumeDataByArtifactID)
+        }
+        guard let job else { return }
+        stateDidChange?(job)
+    }
+
+    func synchronizeWithSystemTasks() async -> LocalRewriteBackgroundDownloadJob? {
+        guard let jobID = loadJob()?.id else { return nil }
+        let backgroundTasks = await transport.downloadTasks(in: .background)
+        let foregroundTasks = await transport.downloadTasks(in: .foreground)
+        let tasks = backgroundTasks + foregroundTasks
+        let tasksByArtifactID = transport.deduplicatedTasksByArtifactID(from: tasks, jobID: jobID)
+        let job = withJobStoreLock { () -> LocalRewriteBackgroundDownloadJob? in
+            guard var job = jobStore.load(), job.id == jobID else { return nil }
+
+            if job.phase != .downloaded {
+                if let task = tasksByArtifactID[job.artifactFilename] {
+                    job.phase = .downloading
+                    job.taskIdentifier = task.taskIdentifier
+                    job.completedBytes = max(job.completedBytes, max(task.countOfBytesReceived, 0))
+                    if task.countOfBytesExpectedToReceive > 0 {
+                        job.expectedBytes = max(
+                            job.expectedBytes ?? job.expectedByteCount,
+                            task.countOfBytesExpectedToReceive
+                        )
+                    }
+                    job.lastErrorMessage = nil
+                    job.updatedAt = .now
+                } else if job.phase == .downloading {
+                    job.phase = .pending
+                    job.taskIdentifier = nil
+                    job.updatedAt = .now
+                }
+            }
+
+            if job.isReadyForFinalization, job.finalizationState != .inProgress {
+                job.finalizationState = .pending
+            }
+            try? jobStore.save(job)
+            return job
+        }
+        stateDidChange?(job)
+        return job
+    }
+
+    func markFinalizationInProgress() {
+        updateLoadedJob {
+            $0.finalizationState = .inProgress
+            $0.lastErrorMessage = nil
+        }
+    }
+
+    func markFinalizationFailed(message: String) {
+        updateLoadedJob {
+            $0.finalizationState = .failed
+            $0.lastErrorMessage = message
+        }
+    }
+
+    func clearJob() async {
+        await transport.cancelAllTasks()
+        withJobStoreLock {
+            try? jobStore.clear()
+        }
+        stateDidChange?(nil)
+    }
+
+    func cancelAndClearJob() {
+        transport.cancelAllTasksWithoutWaiting()
+        withJobStoreLock {
+            try? jobStore.clear()
+        }
+        stateDidChange?(nil)
+    }
+
+    func prepareDownload(
+        in job: inout LocalRewriteBackgroundDownloadJob,
+        existingTask: URLSessionDownloadTask?,
+        session: URLSession,
+        resumeDataByArtifactID: inout [String: Data]
+    ) {
+        guard job.phase != .downloaded else {
+            resumeDataByArtifactID.removeValue(forKey: job.artifactFilename)
+            return
+        }
+
+        let task: URLSessionDownloadTask
+        if let existingTask {
+            resumeDataByArtifactID.removeValue(forKey: job.artifactFilename)
+            task = existingTask
+            job.completedBytes = max(job.completedBytes, max(existingTask.countOfBytesReceived, 0))
+            if existingTask.countOfBytesExpectedToReceive > 0 {
+                job.expectedBytes = max(
+                    job.expectedBytes ?? job.expectedByteCount,
+                    existingTask.countOfBytesExpectedToReceive
+                )
+            }
+        } else if let resumeData = resumeDataByArtifactID.removeValue(forKey: job.artifactFilename) {
+            task = session.downloadTask(withResumeData: resumeData)
+        } else {
+            task = session.downloadTask(with: job.remoteURL)
+        }
+
+        task.taskDescription = ResumableDownloadTaskDescriptor(
+            jobID: job.id,
+            artifactID: job.artifactFilename
+        ).encoded
+        job.phase = .downloading
+        job.taskIdentifier = task.taskIdentifier
+        job.finalizationState = .awaitingDownload
+        job.lastErrorMessage = nil
+        job.updatedAt = .now
+        task.resume()
+    }
+
+    func withJobStoreLock<T>(_ operation: () throws -> T) rethrows -> T {
+        jobStoreLock.lock()
+        defer { jobStoreLock.unlock() }
+        return try operation()
+    }
+
+    func updateLoadedJob(_ mutate: (inout LocalRewriteBackgroundDownloadJob) -> Void) {
+        let job = withJobStoreLock { () -> LocalRewriteBackgroundDownloadJob? in
+            guard var job = jobStore.load() else { return nil }
+            mutate(&job)
+            job.updatedAt = .now
+            try? jobStore.save(job)
+            return job
+        }
+        guard let job else { return }
+        stateDidChange?(job)
+    }
+}

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadCoordinator.swift
@@ -11,11 +11,7 @@ final class LocalRewriteBackgroundDownloadCoordinator: ResumableDownloadTranspor
     let jobStore: LocalRewriteBackgroundDownloadJobStore
     let stagingArtifactURLProvider: () throws -> URL
     let jobStoreLock = NSLock()
-    lazy var transport = ResumableDownloadTransport(
-        sessionIdentifier: Self.sessionIdentifier,
-        sharedContainerIdentifier: SharedPaths.appGroupID,
-        delegate: self
-    )
+    let transport: ResumableDownloadTransport
 
     init(
         fileManager: FileManager = .default,
@@ -25,6 +21,12 @@ final class LocalRewriteBackgroundDownloadCoordinator: ResumableDownloadTranspor
         self.fileManager = fileManager
         self.jobStore = jobStore
         self.stagingArtifactURLProvider = stagingArtifactURLProvider
+        self.transport = ResumableDownloadTransport(
+            sessionIdentifier: Self.sessionIdentifier,
+            sharedContainerIdentifier: SharedPaths.appGroupID,
+            delegate: nil
+        )
+        self.transport.delegate = self
     }
 
     func loadJob() -> LocalRewriteBackgroundDownloadJob? {

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJob.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJob.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+enum LocalRewriteBackgroundDownloadPhase: String, Codable, Sendable {
+    case pending
+    case downloading
+    case downloaded
+    case failed
+}
+
+enum LocalRewriteBackgroundFinalizationState: String, Codable, Sendable {
+    case awaitingDownload
+    case pending
+    case inProgress
+    case failed
+}
+
+struct LocalRewriteBackgroundDownloadJob: Codable, Equatable, Sendable {
+    let id: UUID
+    let modelID: String
+    let artifactFilename: String
+    let remoteURL: URL
+    let expectedSHA256: String
+    let expectedByteCount: Int64
+    var phase: LocalRewriteBackgroundDownloadPhase
+    var taskIdentifier: Int?
+    var completedBytes: Int64
+    var expectedBytes: Int64?
+    var finalizationState: LocalRewriteBackgroundFinalizationState
+    var lastErrorMessage: String?
+    var updatedAt: Date
+
+    init(id: UUID = UUID(), descriptor: LocalRewriteModelDescriptor) {
+        self.id = id
+        self.modelID = descriptor.id
+        self.artifactFilename = descriptor.artifact.filename
+        self.remoteURL = descriptor.artifact.remoteURL
+        self.expectedSHA256 = descriptor.artifact.expectedSHA256
+        self.expectedByteCount = descriptor.artifact.progressTotalBytes
+        self.phase = .pending
+        self.taskIdentifier = nil
+        self.completedBytes = 0
+        self.expectedBytes = descriptor.artifact.progressTotalBytes
+        self.finalizationState = .awaitingDownload
+        self.lastErrorMessage = nil
+        self.updatedAt = .now
+    }
+
+    var downloadProgressFraction: Double {
+        let totalBytes = max(expectedBytes ?? expectedByteCount, expectedByteCount)
+        guard totalBytes > 0 else { return phase == .downloaded ? 1 : 0 }
+        return min(max(Double(min(completedBytes, totalBytes)) / Double(totalBytes), 0), 1)
+    }
+
+    var isReadyForFinalization: Bool {
+        phase == .downloaded
+    }
+
+    func matches(_ descriptor: LocalRewriteModelDescriptor) -> Bool {
+        modelID == descriptor.id
+            && artifactFilename == descriptor.artifact.filename
+            && remoteURL == descriptor.artifact.remoteURL
+            && expectedSHA256.lowercased() == descriptor.artifact.expectedSHA256.lowercased()
+            && expectedByteCount == descriptor.artifact.progressTotalBytes
+    }
+}

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJobStore.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJobStore.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct LocalRewriteBackgroundDownloadJobStore {
+    let fileManager: FileManager
+    let jobURLProvider: () -> URL?
+
+    func load() -> LocalRewriteBackgroundDownloadJob? {
+        guard let jobURL = jobURLProvider(),
+              fileManager.fileExists(atPath: jobURL.path),
+              let data = try? Data(contentsOf: jobURL) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(LocalRewriteBackgroundDownloadJob.self, from: data)
+    }
+
+    func save(_ job: LocalRewriteBackgroundDownloadJob) throws {
+        guard let jobURL = jobURLProvider() else {
+            throw LocalRewriteModelInstallError.appGroupUnavailable
+        }
+        try fileManager.createDirectory(
+            at: jobURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(job).write(to: jobURL, options: .atomic)
+    }
+
+    func clear() throws {
+        guard let jobURL = jobURLProvider(), fileManager.fileExists(atPath: jobURL.path) else {
+            return
+        }
+        try fileManager.removeItem(at: jobURL)
+    }
+}

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelManager+BackgroundLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelManager+BackgroundLifecycle.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+extension LocalRewriteModelManager {
+    func downloadModel() {
+        guard installTask == nil else { return }
+        installTask = Task { [weak self] in
+            await self?.startOrRepairDownload()
+        }
+    }
+
+    func deleteModel() {
+        onDidInvalidateInstalledModel?()
+        installTask?.cancel()
+        installTask = nil
+        backgroundDownloadCoordinator.cancelAndClearJob()
+        if let finalRootURL = finalRootURL() {
+            try? fileManager.removeItem(at: finalRootURL)
+        }
+        if let stagingRootURL = stagingRootURL() {
+            try? fileManager.removeItem(at: stagingRootURL)
+        }
+        refreshStatus()
+    }
+
+    func handleAppDidBecomeActive() {
+        appIsActive = true
+        Task { [weak self] in
+            guard let self else { return }
+            await self.backgroundDownloadCoordinator.handleAppDidBecomeActive()
+            guard self.appIsActive else { return }
+            let job = await self.backgroundDownloadCoordinator.synchronizeWithSystemTasks()
+            if let job,
+               job.matches(self.descriptor),
+               !job.isReadyForFinalization,
+               job.finalizationState != .failed {
+                try? await self.backgroundDownloadCoordinator.startOrResumeJob(job)
+            }
+            self.refreshStatus()
+            await self.resumeForegroundFinalizationIfNeeded()
+        }
+    }
+
+    func handleAppWillResignActive() {
+        appIsActive = false
+        backgroundDownloadCoordinator.handleAppWillResignActive()
+    }
+
+    func handleBackgroundURLSessionEvents(
+        identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        guard identifier == LocalRewriteBackgroundDownloadCoordinator.sessionIdentifier else {
+            completionHandler()
+            return
+        }
+        backgroundDownloadCoordinator.registerBackgroundSessionCompletionHandler(completionHandler)
+    }
+
+    func handleBackgroundDownloadStateChanged(_ job: LocalRewriteBackgroundDownloadJob?) async {
+        if let job {
+            guard backgroundDownloadCoordinator.loadJob()?.id == job.id else {
+                refreshStatus()
+                return
+            }
+            applyBackgroundJobState(job)
+        } else {
+            refreshStatus()
+        }
+        await resumeForegroundFinalizationIfNeeded()
+    }
+
+    func applyBackgroundJobState(_ job: LocalRewriteBackgroundDownloadJob) {
+        let state: LocalRewriteModelInstallState
+        if job.finalizationState == .failed {
+            state = .failed(
+                message: job.lastErrorMessage
+                    ?? LocalRewriteBackgroundDownloadCoordinator.downloadFailureMessage
+            )
+        } else if job.isReadyForFinalization || job.finalizationState == .inProgress {
+            state = .installing(progress: 0.93)
+        } else {
+            state = .downloading(progress: min(max(job.downloadProgressFraction * 0.92, 0), 0.92))
+        }
+        setState(state)
+    }
+
+    func resumeForegroundFinalizationIfNeeded() async {
+        guard appIsActive,
+              !isFinalizationInFlight,
+              let job = backgroundDownloadCoordinator.loadJob(),
+              job.isReadyForFinalization else {
+            return
+        }
+
+        isFinalizationInFlight = true
+        backgroundDownloadCoordinator.markFinalizationInProgress()
+        defer { isFinalizationInFlight = false }
+
+        do {
+            try finalizeBackgroundInstall(job)
+            if let stagingRootURL = stagingRootURL() {
+                try? fileManager.removeItem(at: stagingRootURL)
+            }
+            await backgroundDownloadCoordinator.clearJob()
+            refreshStatus()
+        } catch {
+            let message = Self.userFacingErrorMessage(for: error)
+            backgroundDownloadCoordinator.markFinalizationFailed(message: message)
+            setFailure(message)
+        }
+    }
+
+    private func startOrRepairDownload() async {
+        defer { installTask = nil }
+
+        do {
+            if let existingJob = backgroundDownloadCoordinator.loadJob(),
+               existingJob.matches(descriptor),
+               existingJob.finalizationState != .failed {
+                try await backgroundDownloadCoordinator.startOrResumeJob(existingJob)
+                refreshStatus()
+                return
+            }
+
+            await backgroundDownloadCoordinator.clearJob()
+            guard let stagingRootURL = stagingRootURL() else {
+                throw LocalRewriteModelInstallError.appGroupUnavailable
+            }
+            try prepareCleanDirectory(stagingRootURL)
+            let job = LocalRewriteBackgroundDownloadJob(descriptor: descriptor)
+            try await backgroundDownloadCoordinator.startOrResumeJob(job)
+            refreshStatus()
+        } catch is CancellationError {
+            setFailure("Vibes model download was cancelled.")
+        } catch {
+            setFailure(Self.userFacingErrorMessage(for: error))
+        }
+    }
+
+    private func finalizeBackgroundInstall(_ job: LocalRewriteBackgroundDownloadJob) throws {
+        guard job.matches(descriptor),
+              let stagingArtifactURL = stagingArtifactURL(),
+              let finalRootURL = finalRootURL(),
+              let finalArtifactURL = finalArtifactURL(),
+              let manifestURL = manifestURL() else {
+            throw LocalRewriteModelInstallError.appGroupUnavailable
+        }
+
+        setState(.installing(progress: 0.96))
+        let installedHash = try sha256Hex(forFileAt: stagingArtifactURL)
+        guard installedHash.lowercased() == descriptor.artifact.expectedSHA256.lowercased() else {
+            throw LocalRewriteModelInstallError.integrityCheckFailed
+        }
+
+        setState(.installing(progress: 0.98))
+        try prepareCleanDirectory(finalRootURL)
+        try fileManager.moveItem(at: stagingArtifactURL, to: finalArtifactURL)
+        let fileSize = try fileSize(at: finalArtifactURL)
+        let manifest = LocalRewriteModelInstallManifest(
+            modelID: descriptor.id,
+            artifactFilename: descriptor.artifact.filename,
+            sourceRepository: descriptor.sourceRepository,
+            expectedSHA256: descriptor.artifact.expectedSHA256,
+            installedSHA256: installedHash,
+            fileSize: fileSize,
+            installedAt: Date()
+        )
+        try writeManifest(manifest, to: manifestURL)
+        guard isModelReady() else {
+            throw LocalRewriteModelInstallError.integrityCheckFailed
+        }
+        setState(.ready)
+    }
+}

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelManager+BackgroundLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelManager+BackgroundLifecycle.swift
@@ -24,8 +24,10 @@ extension LocalRewriteModelManager {
 
     func handleAppDidBecomeActive() {
         appIsActive = true
-        Task { [weak self] in
+        guard activationRecoveryTask == nil else { return }
+        activationRecoveryTask = Task { [weak self] in
             guard let self else { return }
+            defer { self.activationRecoveryTask = nil }
             await self.backgroundDownloadCoordinator.handleAppDidBecomeActive()
             guard self.appIsActive else { return }
             let job = await self.backgroundDownloadCoordinator.synchronizeWithSystemTasks()
@@ -33,7 +35,14 @@ extension LocalRewriteModelManager {
                job.matches(self.descriptor),
                !job.isReadyForFinalization,
                job.finalizationState != .failed {
-                try? await self.backgroundDownloadCoordinator.startOrResumeJob(job)
+                do {
+                    try await self.backgroundDownloadCoordinator.startOrResumeJob(job)
+                } catch {
+                    let message = Self.userFacingErrorMessage(for: error)
+                    self.backgroundDownloadCoordinator.markDownloadFailed(message: message)
+                    self.setFailure(message)
+                    return
+                }
             }
             self.refreshStatus()
             await self.resumeForegroundFinalizationIfNeeded()
@@ -141,8 +150,7 @@ extension LocalRewriteModelManager {
         guard job.matches(descriptor),
               let stagingArtifactURL = stagingArtifactURL(),
               let finalRootURL = finalRootURL(),
-              let finalArtifactURL = finalArtifactURL(),
-              let manifestURL = manifestURL() else {
+              let stagingRootURL = stagingRootURL() else {
             throw LocalRewriteModelInstallError.appGroupUnavailable
         }
 
@@ -153,9 +161,7 @@ extension LocalRewriteModelManager {
         }
 
         setState(.installing(progress: 0.98))
-        try prepareCleanDirectory(finalRootURL)
-        try fileManager.moveItem(at: stagingArtifactURL, to: finalArtifactURL)
-        let fileSize = try fileSize(at: finalArtifactURL)
+        let fileSize = try fileSize(at: stagingArtifactURL)
         let manifest = LocalRewriteModelInstallManifest(
             modelID: descriptor.id,
             artifactFilename: descriptor.artifact.filename,
@@ -165,9 +171,16 @@ extension LocalRewriteModelManager {
             fileSize: fileSize,
             installedAt: Date()
         )
-        try writeManifest(manifest, to: manifestURL)
-        guard isModelReady() else {
-            throw LocalRewriteModelInstallError.integrityCheckFailed
+        let stagingManifestURL = stagingRootURL.appendingPathComponent(
+            LocalRewriteModelCatalog.manifestFilename,
+            isDirectory: false
+        )
+        try writeManifest(manifest, to: stagingManifestURL)
+
+        if fileManager.fileExists(atPath: finalRootURL.path) {
+            _ = try fileManager.replaceItemAt(finalRootURL, withItemAt: stagingRootURL)
+        } else {
+            try fileManager.moveItem(at: stagingRootURL, to: finalRootURL)
         }
         setState(.ready)
     }

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelManager.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelManager.swift
@@ -12,6 +12,7 @@ final class LocalRewriteModelManager: ObservableObject {
     let descriptor: LocalRewriteModelDescriptor
     let backgroundDownloadCoordinator: LocalRewriteBackgroundDownloadCoordinator
     var installTask: Task<Void, Never>?
+    var activationRecoveryTask: Task<Void, Never>?
     var onDidInvalidateInstalledModel: (() -> Void)?
     var appIsActive = false
     var isFinalizationInFlight = false

--- a/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelManager.swift
+++ b/iOS/KeyVox iOS/Core/LocalRewriteModel/LocalRewriteModelManager.swift
@@ -5,40 +5,38 @@ import KeyVoxVibesAdapters
 
 @MainActor
 final class LocalRewriteModelManager: ObservableObject {
-    private static let downloadProgressPublishInterval: Duration = .milliseconds(50)
-
-    typealias DownloadClosure = @Sendable (
-        URL,
-        @escaping @Sendable (LocalRewriteModelDownloadProgressSnapshot) -> Void
-    ) async throws -> URL
-
     @Published private(set) var installState: LocalRewriteModelInstallState = .notInstalled
     @Published private(set) var errorMessage: String?
 
     let fileManager: FileManager
-    let session: URLSession
     let descriptor: LocalRewriteModelDescriptor
-    let download: DownloadClosure
+    let backgroundDownloadCoordinator: LocalRewriteBackgroundDownloadCoordinator
     var installTask: Task<Void, Never>?
     var onDidInvalidateInstalledModel: (() -> Void)?
-    private var pendingDownloadProgress: Double?
-    private var downloadProgressPublishTask: Task<Void, Never>?
+    var appIsActive = false
+    var isFinalizationInFlight = false
 
     init(
         fileManager: FileManager = .default,
-        session: URLSession = .shared,
         descriptor: LocalRewriteModelDescriptor? = nil,
-        download: DownloadClosure? = nil
+        backgroundDownloadCoordinator: LocalRewriteBackgroundDownloadCoordinator
     ) {
         self.fileManager = fileManager
-        self.session = session
         self.descriptor = descriptor ?? LocalRewriteModelCatalog.descriptor
-        self.download = download ?? Self.defaultDownload(from:progress:)
+        self.backgroundDownloadCoordinator = backgroundDownloadCoordinator
+        self.backgroundDownloadCoordinator.stateDidChange = { [weak self] job in
+            Task { @MainActor [weak self] in
+                await self?.handleBackgroundDownloadStateChanged(job)
+            }
+        }
         refreshStatus()
     }
 
     func refreshStatus() {
-        guard installTask == nil else { return }
+        if let job = backgroundDownloadCoordinator.loadJob() {
+            applyBackgroundJobState(job)
+            return
+        }
         installState = isModelReady() ? .ready : .notInstalled
         errorMessage = nil
     }
@@ -91,112 +89,27 @@ final class LocalRewriteModelManager: ObservableObject {
             && manifest.installedSHA256.lowercased() == descriptor.artifact.expectedSHA256.lowercased()
     }
 
-    func downloadModel() {
-        guard installTask == nil else { return }
-        installTask = Task { [weak self] in
-            await self?.performDownloadModel()
-        }
-    }
-
-    func deleteModel() {
-        onDidInvalidateInstalledModel?()
-        installTask?.cancel()
-        installTask = nil
-        if let finalRootURL = finalRootURL() {
-            try? fileManager.removeItem(at: finalRootURL)
-        }
-        if let stagingRootURL = stagingRootURL() {
-            try? fileManager.removeItem(at: stagingRootURL)
-        }
-        refreshStatus()
-    }
-
-    private func performDownloadModel() async {
-        defer {
-            resetDownloadProgressPublishing()
-            installTask = nil
-        }
-
-        do {
-            guard let stagingRootURL = stagingRootURL(),
-                  let finalRootURL = finalRootURL(),
-                  let stagingArtifactURL = stagingArtifactURL(),
-                  let finalArtifactURL = finalArtifactURL(),
-                  let manifestURL = manifestURL() else {
-                throw LocalRewriteModelInstallError.appGroupUnavailable
-            }
-
-            resetDownloadProgressPublishing()
-            setState(.downloading(progress: 0))
-            try prepareCleanDirectory(stagingRootURL)
-            let temporaryURL = try await download(descriptor.artifact.remoteURL) { [weak self] snapshot in
-                Task { @MainActor [weak self] in
-                    let progress = Self.progressFraction(
-                        snapshot: snapshot,
-                        fallbackExpectedBytes: self?.descriptor.artifact.progressTotalBytes ?? 1
-                    )
-                    self?.publishDownloadProgress(progress)
-                }
-            }
-
-            flushDownloadProgress()
-            setState(.installing(progress: 0.93))
-            try fileManager.createDirectory(
-                at: stagingArtifactURL.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try replaceItem(at: stagingArtifactURL, with: temporaryURL)
-
-            setState(.installing(progress: 0.96))
-            let installedHash = try sha256Hex(forFileAt: stagingArtifactURL)
-            guard installedHash.lowercased() == descriptor.artifact.expectedSHA256.lowercased() else {
-                throw LocalRewriteModelInstallError.integrityCheckFailed
-            }
-
-            setState(.installing(progress: 0.98))
-            try prepareCleanDirectory(finalRootURL)
-            try fileManager.moveItem(at: stagingArtifactURL, to: finalArtifactURL)
-            let fileSize = try fileSize(at: finalArtifactURL)
-            let manifest = LocalRewriteModelInstallManifest(
-                modelID: descriptor.id,
-                artifactFilename: descriptor.artifact.filename,
-                sourceRepository: descriptor.sourceRepository,
-                expectedSHA256: descriptor.artifact.expectedSHA256,
-                installedSHA256: installedHash,
-                fileSize: fileSize,
-                installedAt: Date()
-            )
-            try writeManifest(manifest, to: manifestURL)
-            try? fileManager.removeItem(at: stagingRootURL)
-            setState(.ready)
-        } catch is CancellationError {
-            setFailure("Vibes model download was cancelled.")
-        } catch {
-            setFailure(Self.userFacingErrorMessage(for: error))
-        }
-    }
-
-    private func finalRootURL() -> URL? {
+    func finalRootURL() -> URL? {
         SharedPaths.localRewriteModelDirectoryURL(fileManager: fileManager)
     }
 
-    private func stagingRootURL() -> URL? {
+    func stagingRootURL() -> URL? {
         SharedPaths.localRewriteModelStagingDirectoryURL(fileManager: fileManager)
     }
 
-    private func finalArtifactURL() -> URL? {
+    func finalArtifactURL() -> URL? {
         finalRootURL()?.appendingPathComponent(descriptor.artifact.filename, isDirectory: false)
     }
 
-    private func stagingArtifactURL() -> URL? {
+    func stagingArtifactURL() -> URL? {
         stagingRootURL()?.appendingPathComponent(descriptor.artifact.filename, isDirectory: false)
     }
 
-    private func manifestURL() -> URL? {
+    func manifestURL() -> URL? {
         finalRootURL()?.appendingPathComponent(LocalRewriteModelCatalog.manifestFilename, isDirectory: false)
     }
 
-    private func setState(_ state: LocalRewriteModelInstallState) {
+    func setState(_ state: LocalRewriteModelInstallState) {
         installState = state
         if case .failed(let message) = state {
             errorMessage = message
@@ -205,68 +118,30 @@ final class LocalRewriteModelManager: ObservableObject {
         }
     }
 
-    private func setFailure(_ message: String) {
+    func setFailure(_ message: String) {
         setState(.failed(message: message))
     }
 
-    private func publishDownloadProgress(_ progress: Double) {
-        pendingDownloadProgress = min(max(progress, 0), 0.92)
-
-        guard downloadProgressPublishTask == nil else { return }
-        downloadProgressPublishTask = Task { @MainActor [weak self] in
-            while let self, let progress = self.pendingDownloadProgress {
-                self.pendingDownloadProgress = nil
-                self.setState(.downloading(progress: progress))
-                try? await Task.sleep(for: Self.downloadProgressPublishInterval)
-            }
-
-            self?.downloadProgressPublishTask = nil
-        }
-    }
-
-    private func flushDownloadProgress() {
-        if let pendingDownloadProgress {
-            self.pendingDownloadProgress = nil
-            setState(.downloading(progress: pendingDownloadProgress))
-        }
-
-        downloadProgressPublishTask?.cancel()
-        downloadProgressPublishTask = nil
-    }
-
-    private func resetDownloadProgressPublishing() {
-        pendingDownloadProgress = nil
-        downloadProgressPublishTask?.cancel()
-        downloadProgressPublishTask = nil
-    }
-
-    private func prepareCleanDirectory(_ url: URL) throws {
+    func prepareCleanDirectory(_ url: URL) throws {
         if fileManager.fileExists(atPath: url.path) {
             try fileManager.removeItem(at: url)
         }
         try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
     }
 
-    private func replaceItem(at destinationURL: URL, with sourceURL: URL) throws {
-        if fileManager.fileExists(atPath: destinationURL.path) {
-            try fileManager.removeItem(at: destinationURL)
-        }
-        try fileManager.moveItem(at: sourceURL, to: destinationURL)
-    }
-
-    private func writeManifest(_ manifest: LocalRewriteModelInstallManifest, to url: URL) throws {
+    func writeManifest(_ manifest: LocalRewriteModelInstallManifest, to url: URL) throws {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(manifest)
         try data.write(to: url, options: .atomic)
     }
 
-    private func readManifest(from url: URL) throws -> LocalRewriteModelInstallManifest {
+    func readManifest(from url: URL) throws -> LocalRewriteModelInstallManifest {
         let data = try Data(contentsOf: url)
         return try JSONDecoder().decode(LocalRewriteModelInstallManifest.self, from: data)
     }
 
-    private func sha256Hex(forFileAt url: URL) throws -> String {
+    func sha256Hex(forFileAt url: URL) throws -> String {
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
 
@@ -283,80 +158,18 @@ final class LocalRewriteModelManager: ObservableObject {
         return hasher.finalize().map { String(format: "%02x", $0) }.joined()
     }
 
-    private func fileSize(at url: URL) throws -> Int64 {
+    func fileSize(at url: URL) throws -> Int64 {
         let attributes = try fileManager.attributesOfItem(atPath: url.path)
         return (attributes[.size] as? NSNumber)?.int64Value ?? 0
     }
 
-    nonisolated private static func progressFraction(
-        snapshot: LocalRewriteModelDownloadProgressSnapshot,
-        fallbackExpectedBytes: Int64
-    ) -> Double {
-        let expectedBytes = max(snapshot.expectedBytes ?? fallbackExpectedBytes, fallbackExpectedBytes)
-        guard expectedBytes > 0 else { return 0 }
-        return Double(min(snapshot.completedBytes, expectedBytes)) / Double(expectedBytes)
-    }
-
-    nonisolated private static func userFacingErrorMessage(for error: Error) -> String {
+    nonisolated static func userFacingErrorMessage(for error: Error) -> String {
         if let installError = error as? LocalRewriteModelInstallError {
             return installError.localizedDescription
         }
         return "Vibes model download failed. Check your network/storage and retry."
     }
 
-    nonisolated static func defaultDownload(
-        from url: URL,
-        progress: @escaping @Sendable (LocalRewriteModelDownloadProgressSnapshot) -> Void
-    ) async throws -> URL {
-        progress(.zero)
-        let downloadTaskBox = LocalRewriteModelDownloadTaskBox()
-        return try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                let delegate = LocalRewriteModelDownloadDelegate(
-                    sourceURL: url,
-                    progress: progress
-                ) { result in
-                    continuation.resume(with: result)
-                }
-                let session = URLSession(
-                    configuration: .default,
-                    delegate: delegate,
-                    delegateQueue: nil
-                )
-                delegate.session = session
-                let task = session.downloadTask(with: url)
-                Task {
-                    await downloadTaskBox.set(task)
-                    task.resume()
-                }
-            }
-        } onCancel: {
-            Task {
-                await downloadTaskBox.cancel()
-            }
-        }
-    }
-}
-
-private actor LocalRewriteModelDownloadTaskBox {
-    private var task: URLSessionDownloadTask?
-    private var isCancelled = false
-
-    func set(_ task: URLSessionDownloadTask) {
-        self.task = task
-        let shouldCancel = isCancelled
-
-        if shouldCancel {
-            task.cancel()
-        }
-    }
-
-    func cancel() {
-        isCancelled = true
-        let currentTask = task
-
-        currentTask?.cancel()
-    }
 }
 
 enum LocalRewriteModelInstallError: LocalizedError {
@@ -370,108 +183,5 @@ enum LocalRewriteModelInstallError: LocalizedError {
         case .integrityCheckFailed:
             return "Downloaded Vibes model did not match the expected SHA-256."
         }
-    }
-}
-
-struct LocalRewriteModelDownloadProgressSnapshot: Sendable {
-    let fractionCompleted: Double
-    let completedBytes: Int64
-    let expectedBytes: Int64?
-
-    nonisolated init(
-        fractionCompleted: Double,
-        completedBytes: Int64,
-        expectedBytes: Int64?
-    ) {
-        self.fractionCompleted = fractionCompleted
-        self.completedBytes = completedBytes
-        self.expectedBytes = expectedBytes
-    }
-
-    nonisolated static let zero = LocalRewriteModelDownloadProgressSnapshot(
-        fractionCompleted: 0,
-        completedBytes: 0,
-        expectedBytes: nil
-    )
-
-    nonisolated static let complete = LocalRewriteModelDownloadProgressSnapshot(
-        fractionCompleted: 1,
-        completedBytes: 1,
-        expectedBytes: 1
-    )
-}
-
-final class LocalRewriteModelDownloadDelegate: NSObject, URLSessionDownloadDelegate {
-    private let sourceURL: URL
-    private let progressHandler: @Sendable (LocalRewriteModelDownloadProgressSnapshot) -> Void
-    private let completion: @Sendable (Result<URL, Error>) -> Void
-    private let lock = NSLock()
-    private var hasCompleted = false
-    weak var session: URLSession?
-
-    init(
-        sourceURL: URL,
-        progress: @escaping @Sendable (LocalRewriteModelDownloadProgressSnapshot) -> Void,
-        completion: @escaping @Sendable (Result<URL, Error>) -> Void
-    ) {
-        self.sourceURL = sourceURL
-        self.progressHandler = progress
-        self.completion = completion
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didWriteData bytesWritten: Int64,
-        totalBytesWritten: Int64,
-        totalBytesExpectedToWrite: Int64
-    ) {
-        let expectedBytes = totalBytesExpectedToWrite > 0 ? totalBytesExpectedToWrite : nil
-        let fractionCompleted = expectedBytes.map { Double(totalBytesWritten) / Double($0) } ?? 0
-        progressHandler(
-            LocalRewriteModelDownloadProgressSnapshot(
-                fractionCompleted: min(max(fractionCompleted, 0), 1),
-                completedBytes: max(totalBytesWritten, 0),
-                expectedBytes: expectedBytes
-            )
-        )
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didFinishDownloadingTo location: URL
-    ) {
-        do {
-            let stableURL = FileManager.default.temporaryDirectory
-                .appendingPathComponent(UUID().uuidString, isDirectory: true)
-                .appendingPathComponent(sourceURL.lastPathComponent, isDirectory: false)
-            try FileManager.default.createDirectory(
-                at: stableURL.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try FileManager.default.moveItem(at: location, to: stableURL)
-            progressHandler(.complete)
-            finish(.success(stableURL))
-        } catch {
-            finish(.failure(error))
-        }
-    }
-
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        if let error {
-            finish(.failure(error))
-        }
-    }
-
-    private func finish(_ result: Result<URL, Error>) {
-        lock.lock()
-        let shouldComplete = !hasCompleted
-        hasCompleted = true
-        lock.unlock()
-
-        guard shouldComplete else { return }
-        session?.finishTasksAndInvalidate()
-        completion(result)
     }
 }

--- a/iOS/KeyVoxiOSTests/App/SharedPathsTests.swift
+++ b/iOS/KeyVoxiOSTests/App/SharedPathsTests.swift
@@ -11,12 +11,14 @@ struct SharedPathsTests {
         let coreMLZipURL = SharedPaths.coreMLEncoderZipURL(fileManager: fileManager)
         let coreMLDirectoryURL = SharedPaths.coreMLEncoderDirectoryURL(fileManager: fileManager)
         let manifestURL = SharedPaths.modelInstallManifestURL(fileManager: fileManager)
+        let localRewriteDownloadJobURL = SharedPaths.localRewriteDownloadJobURL(fileManager: fileManager)
 
         #expect(modelURL?.path == "/tmp/KeyVoxGroup/Models/whisper/ggml-base.bin")
         #expect(modelsDirectoryURL?.path == "/tmp/KeyVoxGroup/Models")
         #expect(coreMLZipURL?.path == "/tmp/KeyVoxGroup/Models/whisper/ggml-base-encoder.mlmodelc.zip")
         #expect(coreMLDirectoryURL?.path == "/tmp/KeyVoxGroup/Models/whisper/ggml-base-encoder.mlmodelc")
         #expect(manifestURL?.path == "/tmp/KeyVoxGroup/Models/whisper/install-manifest.json")
+        #expect(localRewriteDownloadJobURL?.path == "/tmp/KeyVoxGroup/Models/rewrite/background-download-job.json")
     }
 
     @Test func dictionaryBaseDirectoryAppendsExpectedPath() {

--- a/iOS/KeyVoxiOSTests/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJobTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJobTests.swift
@@ -93,6 +93,49 @@ struct LocalRewriteBackgroundDownloadJobTests {
         #expect(store.load()?.finalizationState == .pending)
     }
 
+    @Test func unsuccessfulHTTPResponseDoesNotStageDownloadedFile() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let jobURL = rootURL.appendingPathComponent("background-download-job.json")
+        let stagingURL = rootURL.appendingPathComponent("staging/model.gguf")
+        let temporaryURL = rootURL.appendingPathComponent("download.tmp")
+        try Data("Not found".utf8).write(to: temporaryURL)
+        let store = LocalRewriteBackgroundDownloadJobStore(
+            fileManager: .default,
+            jobURLProvider: { jobURL }
+        )
+        let coordinator = LocalRewriteBackgroundDownloadCoordinator(
+            fileManager: .default,
+            jobStore: store,
+            stagingArtifactURLProvider: { stagingURL }
+        )
+        let job = LocalRewriteBackgroundDownloadJob(descriptor: LocalRewriteModelCatalog.descriptor)
+        try store.save(job)
+        let descriptor = ResumableDownloadTaskDescriptor(
+            jobID: job.id,
+            artifactID: job.artifactFilename
+        )
+        let response = HTTPURLResponse(
+            url: job.remoteURL,
+            statusCode: 404,
+            httpVersion: nil,
+            headerFields: nil
+        )
+
+        coordinator.resumableDownloadTransport(
+            coordinator.transport,
+            didFinishDownloading: descriptor,
+            to: temporaryURL,
+            response: response
+        )
+
+        #expect(!FileManager.default.fileExists(atPath: stagingURL.path))
+        #expect(store.load()?.phase == .failed)
+        #expect(store.load()?.finalizationState == .failed)
+    }
+
     @Test func VibesAndSpeakUseIndependentBackgroundSessionIdentifiers() {
         #expect(
             LocalRewriteBackgroundDownloadCoordinator.sessionIdentifier

--- a/iOS/KeyVoxiOSTests/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJobTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJobTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+@testable import KeyVox_iOS
+
+struct LocalRewriteBackgroundDownloadJobTests {
+    @Test func jobRoundTripsThroughPersistentStore() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let jobURL = rootURL.appendingPathComponent("background-download-job.json")
+        let store = LocalRewriteBackgroundDownloadJobStore(
+            fileManager: .default,
+            jobURLProvider: { jobURL }
+        )
+        var job = LocalRewriteBackgroundDownloadJob(descriptor: LocalRewriteModelCatalog.descriptor)
+        job.phase = .downloading
+        job.completedBytes = 123_456_789
+
+        try store.save(job)
+
+        #expect(store.load() == job)
+    }
+
+    @Test func persistedProgressDoesNotRegressWhenDestinationTaskStartsLower() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let jobURL = rootURL.appendingPathComponent("background-download-job.json")
+        let stagingURL = rootURL.appendingPathComponent("staging/model.gguf")
+        let store = LocalRewriteBackgroundDownloadJobStore(
+            fileManager: .default,
+            jobURLProvider: { jobURL }
+        )
+        let coordinator = LocalRewriteBackgroundDownloadCoordinator(
+            fileManager: .default,
+            jobStore: store,
+            stagingArtifactURLProvider: { stagingURL }
+        )
+        var job = LocalRewriteBackgroundDownloadJob(descriptor: LocalRewriteModelCatalog.descriptor)
+        job.phase = .downloading
+        job.completedBytes = 200_000_000
+        try store.save(job)
+        let descriptor = ResumableDownloadTaskDescriptor(
+            jobID: job.id,
+            artifactID: job.artifactFilename
+        )
+
+        coordinator.updateDownloadProgress(
+            for: descriptor,
+            taskIdentifier: 42,
+            totalBytesWritten: 10_000,
+            totalBytesExpectedToWrite: job.expectedByteCount
+        )
+
+        #expect(store.load()?.completedBytes == 200_000_000)
+    }
+
+    @Test func completedTransportFileMovesIntoExistingVibesStagingLocation() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let jobURL = rootURL.appendingPathComponent("background-download-job.json")
+        let stagingURL = rootURL.appendingPathComponent("staging/model.gguf")
+        let temporaryURL = rootURL.appendingPathComponent("download.tmp")
+        let downloadedData = Data(repeating: 7, count: 32)
+        try downloadedData.write(to: temporaryURL)
+        let store = LocalRewriteBackgroundDownloadJobStore(
+            fileManager: .default,
+            jobURLProvider: { jobURL }
+        )
+        let coordinator = LocalRewriteBackgroundDownloadCoordinator(
+            fileManager: .default,
+            jobStore: store,
+            stagingArtifactURLProvider: { stagingURL }
+        )
+        let job = LocalRewriteBackgroundDownloadJob(descriptor: LocalRewriteModelCatalog.descriptor)
+        try store.save(job)
+        let descriptor = ResumableDownloadTaskDescriptor(
+            jobID: job.id,
+            artifactID: job.artifactFilename
+        )
+
+        coordinator.resumableDownloadTransport(
+            coordinator.transport,
+            didFinishDownloading: descriptor,
+            to: temporaryURL,
+            response: nil
+        )
+
+        #expect(try Data(contentsOf: stagingURL) == downloadedData)
+        #expect(store.load()?.phase == .downloaded)
+        #expect(store.load()?.finalizationState == .pending)
+    }
+
+    @Test func VibesAndSpeakUseIndependentBackgroundSessionIdentifiers() {
+        #expect(
+            LocalRewriteBackgroundDownloadCoordinator.sessionIdentifier
+                != PocketTTSBackgroundDownloadCoordinator.sessionIdentifier
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Moves KeyVox Vibes AI model downloads onto the reusable resumable download transport introduced for Speak.
- Keeps the normal foreground network path while the app is active and hands the same transfer to a dedicated Vibes background session when the app becomes inactive.
- Preserves the existing Vibes model catalog, staging and installed locations, manifest, SHA-256 validation, repair behavior, and UI flow.

## Foreground and background handoff

- Gives Vibes an independent `ResumableDownloadTransport` with `com.cueit.keyvox.vibes-download.background-session`.
- Starts foreground-to-background handoff during `.inactive` and returns the transfer to the foreground session during `.active`.
- Recreates tasks from resume data without resetting persisted completed bytes.
- Reconciles restored URL session tasks after launch and waits for lifecycle transitions to settle before foreground scheduling.
- Keeps displayed progress monotonic when a resumed task initially reports fewer session-local bytes.

## Vibes download ownership

- Adds a persisted single-artifact Vibes job under `Models/rewrite/background-download-job.json`.
- Keeps Vibes scheduling, persistence, staging, errors, and finalization outside the reusable transport.
- Moves completed URLSession files into the existing Vibes staging location before background callbacks finish.
- Defers hashing, installation, manifest writing, and readiness validation until the app is active.
- Removes the replaced foreground-only Vibes URLSession delegate and task-box path.

## Product behavior and installation integrity

- Keeps the installed model at `Models/rewrite/qwen2-5-0-5b-instruct/`.
- Keeps staging at `Models/rewrite/.staging/qwen2-5-0-5b-instruct/`.
- Preserves Settings and Vibes-sheet download, failure, repair, delete, and progress states.
- Cancels and clears only Vibes-owned tasks and metadata during deletion or repair.
- Allows Vibes and Speak downloads to run concurrently through separate transport instances and background-session namespaces.

## Validation

- KeyVox iOS test suite passes on an iPhone 17 Pro simulator.
- Focused coverage verifies persisted job recovery, monotonic progress, staging completion, shared path ownership, and Speak/Vibes session isolation.
- `git diff --check`

Closes #162 