### PR TITLE
fix(ios-dictation): continue model downloads in background

### DIFF
--- a/iOS/Docs/CODEMAP.md
+++ b/iOS/Docs/CODEMAP.md
@@ -1,5 +1,5 @@
 # KeyVox iOS Code Map
-**Last Updated: 2026-09-03**
+**Last Updated: 2026-09-04**
 
 ## Project Overview
 
@@ -158,6 +158,9 @@ iOS/
 │   │   │   ├── DictationModelCatalog.swift
 │   │   │   ├── InstalledDictationModelLocator.swift
 │   │   │   ├── ModelBackgroundDownloadCoordinator.swift
+│   │   │   ├── ModelBackgroundDownloadCoordinator+State.swift
+│   │   │   ├── ModelBackgroundDownloadCoordinator+Transport.swift
+│   │   │   ├── ModelBackgroundDownloadCoordinator+TransportDelegate.swift
 │   │   │   ├── ModelBackgroundDownloadJob.swift
 │   │   │   ├── ModelBackgroundDownloadJobStore.swift
 │   │   │   ├── ModelDownloadBackgroundTasks.swift
@@ -484,6 +487,9 @@ iOS/
 │   │   │   └── KeyboardViewControllerTests.swift
 │   │   ├── LocalRewriteModel/
 │   │   │   └── LocalRewriteBackgroundDownloadJobTests.swift
+│   │   ├── ModelDownloader/
+│   │   │   ├── ModelBackgroundDownloadCoordinatorTests.swift
+│   │   │   └── ModelBackgroundDownloadJobTests.swift
 │   │   ├── TTS/
 │   │   │   ├── TTSManager/
 │   │   │   │   ├── TTSManagerLifecycleTests.swift
@@ -595,8 +601,8 @@ Packages/
   - SwiftUI app entry point.
   - Injects all app-wide environment objects.
   - Registers model-download background tasks.
-  - Handles scene activation/background callbacks for transcription recovery, model recovery, onboarding keyboard-tour arming, Dictation Shortcut intro scheduling, shortcut-route consumption, and Speak/Vibes download transport handoffs.
-  - Starts Speak and Vibes foreground-to-background handoffs during `.inactive`, while the app still has foreground execution time, and hands unfinished transfers back during `.active`.
+  - Handles scene activation/background callbacks for transcription recovery, model recovery, onboarding keyboard-tour arming, Dictation Shortcut intro scheduling, shortcut-route consumption, and Dictation/Speak/Vibes download transport handoffs.
+  - Starts Dictation, Speak, and Vibes foreground-to-background handoffs during `.inactive`, while the app still has foreground execution time, and hands unfinished transfers back during `.active`.
   - Consumes any cold-launch URL route that was captured before SwiftUI rendered and pre-presents `ReturnToHostView` without animation before routing `keyvoxios://record/start`.
 - `KeyVox iOS/App/Composition/SharedPaths.swift`
   - Centralizes rooted app-group, cache, and install filesystem locations used by app-owned services.
@@ -789,18 +795,25 @@ Packages/
   - The transport is reusable because model-specific persistence, installation, scheduling, and retry behavior stay behind its delegate boundary.
 
 - `KeyVox iOS/Core/ModelDownloader/ModelManager.swift`
-  - Observable owner of per-model install state, active-install gating, user-facing download/delete/repair actions, and relaunch recovery.
+  - Observable owner of per-model install state, active-install gating, user-facing download/delete/repair actions, relaunch recovery, and Dictation transport lifecycle handoffs.
   - Enforces one active download/install at a time and keeps provider selection persistence outside the model manager.
 - `KeyVox iOS/Core/ModelDownloader/DictationModelCatalog.swift`
   - iOS-local model descriptor catalog for `Whisper Base` and `Parakeet TDT v3`, including artifact metadata and rooted install layout rules.
 - `KeyVox iOS/Core/ModelDownloader/InstalledDictationModelLocator.swift`
   - Rooted install/staging locator plus legacy Whisper migration and lightweight installed-model resolution helpers for Whisper and Parakeet.
 - `KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator.swift`
-  - Background `URLSession` owner for staged model artifact downloads.
+  - Dictation-specific owner of the reusable foreground/background transport and the existing `com.cueit.keyvox.model-download.background-session` namespace.
+  - Reconciles the persisted Dictation job with both sessions, prepares staged artifact downloads, and limits cancellation and recovery to the active Dictation job.
+- `KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator+Transport.swift`
+  - Recreates every unfinished Dictation artifact in the destination session during foreground/background handoff.
+- `KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator+TransportDelegate.swift`
+  - Maps transport callbacks into Dictation artifact state, rejects non-2xx responses, and moves successful temporary downloads into the existing model staging location.
+- `KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator+State.swift`
+  - Serializes persisted Dictation job mutations, preserves monotonic per-artifact progress, and publishes state changes.
 - `KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadJob.swift`
-  - Durable representation of per-model, per-artifact progress and finalization state.
+  - Durable representation of the Dictation job UUID, per-model and per-artifact transfer state, monotonic aggregate progress floor, and finalization state.
 - `KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadJobStore.swift`
-  - Persistence seam for the background download job file.
+  - Persistence seam for the active Dictation job at `Models/model-download-job.json`.
 - `KeyVox iOS/Core/ModelDownloader/ModelManager+InstallLifecycle.swift`
   - Finalization, extraction, manifest writes, staged-file cleanup, model-specific warmup/preload sequencing, and safe delete/repair coordination after downloads complete.
 - `KeyVox iOS/Core/ModelDownloader/ModelManager+Validation.swift`

--- a/iOS/Docs/ENGINEERING.md
+++ b/iOS/Docs/ENGINEERING.md
@@ -2,7 +2,7 @@
 
 This document captures the current implementation rules and maintainer-facing architecture for the iOS app, keyboard extension, and widget extension.
 
-**Last Updated: 2026-09-03**
+**Last Updated: 2026-09-04**
 
 ## Design Philosophy
 
@@ -1079,7 +1079,7 @@ Primary owners:
 
 ### Background Download Rules
 
-Dictation, Speak, and Vibes have separate model-family coordinators. `ModelBackgroundDownloadCoordinator` owns Dictation’s existing background-only system. Speak and Vibes each use the reusable `ResumableDownloadTransport` through their own coordinator.
+Dictation, Speak, and Vibes have separate model-family coordinators. Each family uses the reusable `ResumableDownloadTransport` through its own coordinator while retaining its own catalog, persistence, staging, installation, retry, and public-state policies.
 
 #### Reusable Handoff Transport
 
@@ -1130,18 +1130,30 @@ Rules:
 - delete and repair cancel only Vibes-owned URLSession tasks, clear the Vibes job, and retain the existing user-facing install-state flow
 - there is no legacy foreground downloader: both foreground and background transfers use the reusable transport
 
-#### Dictation Background Downloads
+#### Dictation Download Policy
 
-`ModelBackgroundDownloadCoordinator` owns the Dictation background `URLSession`.
+`ModelBackgroundDownloadCoordinator` owns Dictation’s reusable foreground/background transport integration. Its responsibilities follow the same extension-file structure as Speak and Vibes:
+
+- `ModelBackgroundDownloadCoordinator.swift` owns Dictation job reconciliation, artifact preparation, cancellation, and the family-specific transport instance
+- `ModelBackgroundDownloadCoordinator+Transport.swift` adapts transport handoffs into Dictation artifact scheduling
+- `ModelBackgroundDownloadCoordinator+TransportDelegate.swift` handles transport events and claims completed temporary files into Dictation staging
+- `ModelBackgroundDownloadCoordinator+State.swift` serializes persisted job and artifact mutations and publishes state changes
 
 Rules:
 
-- each model download is tracked inside a single persisted background job that carries its `modelID`
-- rediscovered background tasks are resumed on relaunch, not just relabeled
+- each model download is tracked inside a single persisted job carrying a stable UUID, its `modelID`, per-artifact state, and a monotonic aggregate progress floor
+- the active job remains stored at `Models/model-download-job.json`; incomplete artifacts remain under `Models/.staging/<model-id>/`, and final Whisper and Parakeet locations are unchanged
+- every URLSession task uses the shared `jobID` plus artifact-relative-path descriptor so multi-artifact Dictation jobs can be reconciled independently
+- Dictation retains the existing `com.cueit.keyvox.model-download.background-session` namespace and never reuses or cancels Speak or Vibes tasks
+- an active-app request uses the foreground session, `.inactive` begins the handoff to the Dictation background session, and `.active` hands unfinished artifacts back to the foreground session before recovery continues
+- persisted per-artifact bytes and aggregate progress never decrease when recreated URLSession tasks initially report smaller task-local values
+- rediscovered foreground or background tasks are resumed on relaunch, not just relabeled
 - missing tasks are demoted back to `.pending` so the manager can restart them
+- completed temporary files are moved into Dictation staging during the delegate callback; non-2xx HTTP responses become download failures
 - finalization remains foreground-owned even when downloads finished in the background
 - app activation must attempt interrupted-download recovery on the first relaunch after a kill
 - only one model download/install may be active at a time on iOS
+- there is no legacy coordinator-owned downloader: both foreground and background transfers use the reusable transport
 
 Important force-quit nuance:
 

--- a/iOS/KeyVox iOS/App/Lifecycle/KeyVoxiOSApp.swift
+++ b/iOS/KeyVox iOS/App/Lifecycle/KeyVoxiOSApp.swift
@@ -157,6 +157,7 @@ struct KeyVoxApp: App {
                         ttsManager.handleAppWillResignActive()
                         pocketTTSModelManager.handleAppWillResignActive()
                         localRewriteModelManager.handleAppWillResignActive()
+                        modelManager.handleAppWillResignActive()
                     @unknown default:
                         break
                     }

--- a/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator+State.swift
+++ b/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator+State.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+extension ModelBackgroundDownloadCoordinator {
+    func withJobStoreLock<T>(_ operation: () throws -> T) rethrows -> T {
+        jobStoreLock.lock()
+        defer { jobStoreLock.unlock() }
+        return try operation()
+    }
+
+    func persist(_ job: ModelBackgroundDownloadJob) throws {
+        try withJobStoreLock {
+            try jobStore.save(job)
+        }
+        stateDidChange?(job)
+    }
+
+    func updateLoadedJob(
+        matching jobID: UUID? = nil,
+        _ mutate: (inout ModelBackgroundDownloadJob) -> Void
+    ) {
+        let job = withJobStoreLock { () -> ModelBackgroundDownloadJob? in
+            guard var job = jobStore.load(), jobID == nil || job.id == jobID else {
+                return nil
+            }
+            mutate(&job)
+            job.touch()
+            try? jobStore.save(job)
+            return job
+        }
+        guard let job else { return }
+        stateDidChange?(job)
+    }
+
+    func updateArtifact(
+        for descriptor: ResumableDownloadTaskDescriptor,
+        _ mutate: (inout ModelBackgroundDownloadJob, inout ModelBackgroundArtifactState) -> Void
+    ) {
+        let job = withJobStoreLock { () -> ModelBackgroundDownloadJob? in
+            guard var job = jobStore.load(), job.id == descriptor.jobID else { return nil }
+            var artifactState = job.artifactState(for: descriptor.artifactID)
+            mutate(&job, &artifactState)
+            job.setArtifactState(artifactState, for: descriptor.artifactID)
+            try? jobStore.save(job)
+            return job
+        }
+        guard let job else { return }
+        stateDidChange?(job)
+    }
+
+    func updateDownloadProgress(
+        for descriptor: ResumableDownloadTaskDescriptor,
+        taskIdentifier: Int,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard let job = loadJob(), job.id == descriptor.jobID else { return }
+        let artifact = DictationModelCatalog
+            .descriptor(for: job.modelID)
+            .artifacts
+            .first(where: { $0.relativePath == descriptor.artifactID })
+
+        updateArtifact(for: descriptor) { _, artifactState in
+            artifactState.phase = .downloading
+            artifactState.taskIdentifier = taskIdentifier
+            artifactState.completedBytes = max(artifactState.completedBytes, max(totalBytesWritten, 0))
+            let reportedExpectedBytes = totalBytesExpectedToWrite > 0
+                ? totalBytesExpectedToWrite
+                : artifact?.progressTotalBytes
+            if let reportedExpectedBytes {
+                artifactState.expectedBytes = max(
+                    artifactState.expectedBytes ?? 0,
+                    reportedExpectedBytes
+                )
+            }
+            artifactState.errorMessage = nil
+            artifactState.updatedAt = .now
+        }
+    }
+}

--- a/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator+Transport.swift
+++ b/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator+Transport.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+extension ModelBackgroundDownloadCoordinator {
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        prepareDownloadsFor sessionKind: ResumableDownloadSessionKind,
+        resumeDataByArtifactID: [String: Data]
+    ) async -> [String: Data] {
+        var remainingResumeData = resumeDataByArtifactID
+        guard let existingJob = loadJob() else { return [:] }
+
+        let sessionTasks = await transport.downloadTasks(in: sessionKind)
+        let existingTasks = transport.deduplicatedTasksByArtifactID(
+            from: sessionTasks,
+            jobID: existingJob.id
+        )
+
+        do {
+            try ensureStagingDirectoryExists(for: existingJob.modelID)
+            let job = try withJobStoreLock { () -> ModelBackgroundDownloadJob? in
+                guard var job = jobStore.load(), job.id == existingJob.id else { return nil }
+                prepareDownloads(
+                    in: &job,
+                    existingTasks: existingTasks,
+                    session: transport.session(for: sessionKind),
+                    resumeDataByArtifactID: &remainingResumeData
+                )
+                try jobStore.save(job)
+                return job
+            }
+            guard let job else { return remainingResumeData }
+            stateDidChange?(job)
+        } catch {
+            markJobFailed(jobID: existingJob.id, error: error)
+        }
+
+        return remainingResumeData
+    }
+
+    func prepareDownloads(
+        in job: inout ModelBackgroundDownloadJob,
+        existingTasks: [String: URLSessionDownloadTask],
+        session: URLSession,
+        resumeDataByArtifactID: inout [String: Data]
+    ) {
+        let descriptor = DictationModelCatalog.descriptor(for: job.modelID)
+
+        for artifact in descriptor.artifacts {
+            var artifactState = job.artifactState(for: artifact.relativePath)
+            if artifactState.phase == .downloaded {
+                resumeDataByArtifactID.removeValue(forKey: artifact.relativePath)
+                artifactState.taskIdentifier = nil
+                job.setArtifactState(artifactState, for: artifact.relativePath)
+                continue
+            }
+
+            let task: URLSessionDownloadTask
+            if let existingTask = existingTasks[artifact.relativePath] {
+                resumeDataByArtifactID.removeValue(forKey: artifact.relativePath)
+                task = existingTask
+                artifactState.completedBytes = max(
+                    artifactState.completedBytes,
+                    max(existingTask.countOfBytesReceived, 0)
+                )
+                if existingTask.countOfBytesExpectedToReceive > 0 {
+                    artifactState.expectedBytes = max(
+                        artifactState.expectedBytes ?? artifact.progressTotalBytes,
+                        existingTask.countOfBytesExpectedToReceive
+                    )
+                }
+            } else if let resumeData = resumeDataByArtifactID.removeValue(forKey: artifact.relativePath) {
+                task = session.downloadTask(withResumeData: resumeData)
+            } else {
+                task = session.downloadTask(with: artifact.remoteURL)
+            }
+
+            task.taskDescription = ResumableDownloadTaskDescriptor(
+                jobID: job.id,
+                artifactID: artifact.relativePath
+            ).encoded
+            artifactState.phase = .downloading
+            artifactState.taskIdentifier = task.taskIdentifier
+            artifactState.expectedBytes = max(
+                artifactState.expectedBytes ?? artifact.progressTotalBytes,
+                artifact.progressTotalBytes
+            )
+            artifactState.errorMessage = nil
+            artifactState.updatedAt = .now
+            job.setArtifactState(artifactState, for: artifact.relativePath)
+            task.resume()
+        }
+
+        job.lastErrorMessage = nil
+        job.finalizationState = job.isReadyForFinalization ? .pending : .awaitingDownloads
+    }
+}

--- a/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator+TransportDelegate.swift
+++ b/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator+TransportDelegate.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+extension ModelBackgroundDownloadCoordinator {
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didWriteDataFor descriptor: ResumableDownloadTaskDescriptor,
+        taskIdentifier: Int,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        updateDownloadProgress(
+            for: descriptor,
+            taskIdentifier: taskIdentifier,
+            totalBytesWritten: totalBytesWritten,
+            totalBytesExpectedToWrite: totalBytesExpectedToWrite
+        )
+    }
+
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didFinishDownloading descriptor: ResumableDownloadTaskDescriptor,
+        to location: URL,
+        response: URLResponse?
+    ) {
+        guard let job = loadJob(), job.id == descriptor.jobID,
+              let stagedURL = modelLocator.stagedArtifactURL(
+                for: job.modelID,
+                relativePath: descriptor.artifactID
+              ) else {
+            return
+        }
+
+        do {
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200 ... 299).contains(httpResponse.statusCode) {
+                throw URLError(.badServerResponse)
+            }
+
+            let parentDirectoryURL = stagedURL.deletingLastPathComponent()
+            if !fileManager.fileExists(atPath: parentDirectoryURL.path) {
+                try fileManager.createDirectory(at: parentDirectoryURL, withIntermediateDirectories: true)
+            }
+            if fileManager.fileExists(atPath: stagedURL.path) {
+                try fileManager.removeItem(at: stagedURL)
+            }
+            try fileManager.moveItem(at: location, to: stagedURL)
+
+            let fileSize = (
+                try? fileManager.attributesOfItem(atPath: stagedURL.path)[.size] as? NSNumber
+            )?.int64Value ?? 0
+            updateArtifact(for: descriptor) { job, artifactState in
+                artifactState.phase = .downloaded
+                artifactState.taskIdentifier = nil
+                artifactState.completedBytes = max(artifactState.completedBytes, fileSize)
+                artifactState.expectedBytes = max(artifactState.expectedBytes ?? 0, fileSize)
+                artifactState.errorMessage = nil
+                artifactState.updatedAt = .now
+                if job.isReadyForFinalization {
+                    job.finalizationState = .pending
+                    job.lastErrorMessage = nil
+                }
+            }
+        } catch {
+            markArtifactFailed(for: descriptor, error: error)
+        }
+    }
+
+    func resumableDownloadTransport(
+        _ transport: ResumableDownloadTransport,
+        didComplete descriptor: ResumableDownloadTaskDescriptor,
+        in sessionKind: ResumableDownloadSessionKind,
+        error: Error?
+    ) {
+        guard let error else { return }
+        let nsError = error as NSError
+        guard !(nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled) else {
+            return
+        }
+        markArtifactFailed(for: descriptor, error: error)
+    }
+
+    func markArtifactFailed(for descriptor: ResumableDownloadTaskDescriptor, error: Error) {
+        updateArtifact(for: descriptor) { job, artifactState in
+            artifactState.phase = .failed
+            artifactState.taskIdentifier = nil
+            artifactState.errorMessage = error.localizedDescription
+            artifactState.updatedAt = .now
+            job.lastErrorMessage = error.localizedDescription
+            job.finalizationState = .failed
+        }
+    }
+
+    func markJobFailed(jobID: UUID, error: Error) {
+        updateLoadedJob(matching: jobID) { job in
+            job.lastErrorMessage = error.localizedDescription
+            job.finalizationState = .failed
+        }
+    }
+}

--- a/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator.swift
@@ -11,11 +11,7 @@ final class ModelBackgroundDownloadCoordinator: ResumableDownloadTransportDelega
     let jobStore: ModelBackgroundDownloadJobStore
     let modelLocator: InstalledDictationModelLocator
     let jobStoreLock = NSLock()
-    lazy var transport = ResumableDownloadTransport(
-        sessionIdentifier: Self.sessionIdentifier,
-        sharedContainerIdentifier: SharedPaths.appGroupID,
-        delegate: self
-    )
+    let transport: ResumableDownloadTransport
 
     init(
         fileManager: FileManager = .default,
@@ -25,6 +21,12 @@ final class ModelBackgroundDownloadCoordinator: ResumableDownloadTransportDelega
         self.fileManager = fileManager
         self.jobStore = jobStore
         self.modelLocator = modelLocator
+        self.transport = ResumableDownloadTransport(
+            sessionIdentifier: Self.sessionIdentifier,
+            sharedContainerIdentifier: SharedPaths.appGroupID,
+            delegate: nil
+        )
+        self.transport.delegate = self
     }
 
     func loadJob() -> ModelBackgroundDownloadJob? {

--- a/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator.swift
@@ -1,25 +1,21 @@
 import Foundation
 
-final class ModelBackgroundDownloadCoordinator: NSObject {
+final class ModelBackgroundDownloadCoordinator: ResumableDownloadTransportDelegate {
     typealias StateChangeHandler = @Sendable (ModelBackgroundDownloadJob?) -> Void
 
     static let sessionIdentifier = "com.cueit.keyvox.model-download.background-session"
 
     var stateDidChange: StateChangeHandler?
 
-    private let fileManager: FileManager
-    private let jobStore: ModelBackgroundDownloadJobStore
-    private let modelLocator: InstalledDictationModelLocator
-    private let completionHandlerLock = NSLock()
-    private var backgroundSessionCompletionHandler: (() -> Void)?
-    private lazy var session: URLSession = {
-        let configuration = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
-        configuration.sharedContainerIdentifier = SharedPaths.appGroupID
-        configuration.sessionSendsLaunchEvents = true
-        configuration.waitsForConnectivity = true
-        configuration.isDiscretionary = false
-        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-    }()
+    let fileManager: FileManager
+    let jobStore: ModelBackgroundDownloadJobStore
+    let modelLocator: InstalledDictationModelLocator
+    let jobStoreLock = NSLock()
+    lazy var transport = ResumableDownloadTransport(
+        sessionIdentifier: Self.sessionIdentifier,
+        sharedContainerIdentifier: SharedPaths.appGroupID,
+        delegate: self
+    )
 
     init(
         fileManager: FileManager = .default,
@@ -32,169 +28,165 @@ final class ModelBackgroundDownloadCoordinator: NSObject {
     }
 
     func loadJob() -> ModelBackgroundDownloadJob? {
-        jobStore.load()
+        withJobStoreLock {
+            jobStore.load()
+        }
     }
 
     func registerBackgroundSessionCompletionHandler(_ completionHandler: @escaping () -> Void) {
-        completionHandlerLock.lock()
-        backgroundSessionCompletionHandler = completionHandler
-        completionHandlerLock.unlock()
+        transport.registerBackgroundSessionCompletionHandler(completionHandler)
+    }
+
+    func handleAppDidBecomeActive() async {
+        await transport.handleAppDidBecomeActive()
+    }
+
+    func handleAppWillResignActive() {
+        transport.handleAppWillResignActive()
     }
 
     func startOrResumeJob(for modelID: DictationModelID) async throws -> ModelBackgroundDownloadJob {
         try ensureStagingDirectoryExists(for: modelID)
 
-        var job = synchronizedJob(for: modelID)
-        let descriptor = DictationModelCatalog.descriptor(for: modelID)
-        let tasks = await allDownloadTasks()
-        tasks
-            .filter {
-                guard let description = $0.taskDescription,
-                      let taskDescriptor = ModelBackgroundTaskDescriptor(taskDescription: description) else {
-                    return false
-                }
-                return taskDescriptor.modelID != modelID
-            }
+        let initialJob = synchronizedJob(for: modelID)
+        try persist(initialJob)
+
+        let backgroundTasks = await transport.downloadTasks(in: .background)
+        let foregroundTasks = await transport.downloadTasks(in: .foreground)
+        let allTasks = backgroundTasks + foregroundTasks
+        allTasks
+            .filter { transport.taskDescriptor(for: $0)?.jobID != initialJob.id }
             .forEach { $0.cancel() }
-        let existingTasksByRelativePath = deduplicatedTasksByRelativePath(from: tasks, for: modelID)
 
-        for artifact in descriptor.artifacts {
-            var artifactState = job.artifactState(for: artifact.relativePath)
-            if artifactState.phase == .downloaded {
-                artifactState.taskIdentifier = nil
-                artifactState.errorMessage = nil
-                job.setArtifactState(artifactState, for: artifact.relativePath)
-                continue
-            }
-
-            if let existingTask = existingTasksByRelativePath[artifact.relativePath] {
-                existingTask.resume()
-                artifactState.phase = .downloading
-                artifactState.taskIdentifier = existingTask.taskIdentifier
-                artifactState.completedBytes = max(existingTask.countOfBytesReceived, 0)
-                artifactState.expectedBytes = existingTask.countOfBytesExpectedToReceive > 0
-                    ? existingTask.countOfBytesExpectedToReceive
-                    : artifact.progressTotalBytes
-                artifactState.errorMessage = nil
-                artifactState.updatedAt = .now
-                job.setArtifactState(artifactState, for: artifact.relativePath)
-                continue
-            }
-
-            let taskDescriptor = ModelBackgroundTaskDescriptor(
-                modelID: modelID,
-                relativePath: artifact.relativePath
-            )
-            let task = session.downloadTask(with: artifact.remoteURL)
-            task.taskDescription = taskDescriptor.taskDescription
-            task.resume()
-
-            artifactState.phase = .downloading
-            artifactState.taskIdentifier = task.taskIdentifier
-            artifactState.completedBytes = 0
-            artifactState.expectedBytes = artifact.progressTotalBytes
-            artifactState.errorMessage = nil
-            artifactState.updatedAt = .now
-            job.setArtifactState(artifactState, for: artifact.relativePath)
+        let useBackgroundSession = transport.shouldUseBackgroundSession(
+            jobID: initialJob.id,
+            existingBackgroundTasks: backgroundTasks
+        )
+        if useBackgroundSession {
+            foregroundTasks
+                .filter { transport.taskDescriptor(for: $0)?.jobID == initialJob.id }
+                .forEach { $0.cancel() }
         }
 
-        job.lastErrorMessage = nil
-        job.finalizationState = job.isReadyForFinalization ? .pending : .awaitingDownloads
-        try persist(job)
+        let sessionTasks = useBackgroundSession ? backgroundTasks : foregroundTasks
+        let existingTasks = transport.deduplicatedTasksByArtifactID(
+            from: sessionTasks,
+            jobID: initialJob.id
+        )
+        let sessionKind: ResumableDownloadSessionKind = useBackgroundSession ? .background : .foreground
+        var resumeDataByArtifactID = useBackgroundSession ? [:] : transport.takePendingResumeData()
+        let job = try withJobStoreLock { () -> ModelBackgroundDownloadJob in
+            var job = jobStore.load().flatMap { $0.id == initialJob.id ? $0 : nil } ?? initialJob
+            prepareDownloads(
+                in: &job,
+                existingTasks: existingTasks,
+                session: transport.session(for: sessionKind),
+                resumeDataByArtifactID: &resumeDataByArtifactID
+            )
+            try jobStore.save(job)
+            return job
+        }
+
+        if !useBackgroundSession {
+            transport.storePendingResumeData(resumeDataByArtifactID)
+        }
+        stateDidChange?(job)
         return job
     }
 
     func synchronizeWithSystemTasks() async -> ModelBackgroundDownloadJob? {
-        guard var job = loadJob() else {
-            return nil
-        }
+        guard let existingJob = loadJob() else { return nil }
 
-        let tasks = await allDownloadTasks()
-        let descriptor = DictationModelCatalog.descriptor(for: job.modelID)
-        let tasksByRelativePath = deduplicatedTasksByRelativePath(from: tasks, for: job.modelID)
-        let activeRelativePaths = Set(tasksByRelativePath.keys)
+        let backgroundTasks = await transport.downloadTasks(in: .background)
+        let foregroundTasks = await transport.downloadTasks(in: .foreground)
+        let tasks = backgroundTasks + foregroundTasks
+        let tasksByRelativePath = transport.deduplicatedTasksByArtifactID(
+            from: tasks,
+            jobID: existingJob.id
+        )
+        let job = withJobStoreLock { () -> ModelBackgroundDownloadJob? in
+            guard var job = jobStore.load(), job.id == existingJob.id else { return nil }
+            let descriptor = DictationModelCatalog.descriptor(for: job.modelID)
 
-        for artifact in descriptor.artifacts {
-            var artifactState = job.artifactState(for: artifact.relativePath)
-            if artifactState.phase == .downloaded {
-                artifactState.taskIdentifier = nil
+            for artifact in descriptor.artifacts {
+                var artifactState = job.artifactState(for: artifact.relativePath)
+                if artifactState.phase == .downloaded {
+                    artifactState.taskIdentifier = nil
+                    job.setArtifactState(artifactState, for: artifact.relativePath)
+                    continue
+                }
+
+                if let task = tasksByRelativePath[artifact.relativePath] {
+                    artifactState.phase = .downloading
+                    artifactState.taskIdentifier = task.taskIdentifier
+                    artifactState.completedBytes = max(
+                        artifactState.completedBytes,
+                        max(task.countOfBytesReceived, 0)
+                    )
+                    if task.countOfBytesExpectedToReceive > 0 {
+                        artifactState.expectedBytes = max(
+                            artifactState.expectedBytes ?? artifact.progressTotalBytes,
+                            task.countOfBytesExpectedToReceive
+                        )
+                    }
+                    artifactState.errorMessage = nil
+                    artifactState.updatedAt = .now
+                } else if artifactState.phase == .downloading {
+                    artifactState.phase = .pending
+                    artifactState.taskIdentifier = nil
+                    artifactState.errorMessage = nil
+                    artifactState.updatedAt = .now
+                }
+
                 job.setArtifactState(artifactState, for: artifact.relativePath)
-                continue
             }
 
-            if let task = tasksByRelativePath[artifact.relativePath] {
-                artifactState.phase = .downloading
-                artifactState.taskIdentifier = task.taskIdentifier
-                artifactState.completedBytes = max(task.countOfBytesReceived, 0)
-                artifactState.expectedBytes = task.countOfBytesExpectedToReceive > 0
-                    ? task.countOfBytesExpectedToReceive
-                    : artifact.progressTotalBytes
-                artifactState.errorMessage = nil
-                artifactState.updatedAt = .now
-            } else if artifactState.phase == .downloading && !activeRelativePaths.contains(artifact.relativePath) {
-                artifactState.phase = .pending
-                artifactState.taskIdentifier = nil
-                artifactState.errorMessage = nil
-                artifactState.updatedAt = .now
+            if job.isReadyForFinalization, job.finalizationState != .inProgress {
+                job.finalizationState = .pending
             }
 
-            job.setArtifactState(artifactState, for: artifact.relativePath)
-        }
-
-        if job.isReadyForFinalization, job.finalizationState != .inProgress {
-            job.finalizationState = .pending
-        }
-
-        do {
-            try persist(job)
-            return job
-        } catch {
+            try? jobStore.save(job)
             return job
         }
+        stateDidChange?(job)
+        return job
     }
 
     func markFinalizationInProgress() {
-        guard var job = loadJob() else { return }
-        job.finalizationState = .inProgress
-        job.lastErrorMessage = nil
-        try? persist(job)
+        updateLoadedJob {
+            $0.finalizationState = .inProgress
+            $0.lastErrorMessage = nil
+        }
     }
 
     func markFinalizationPending() {
-        guard var job = loadJob() else { return }
-        job.finalizationState = .pending
-        job.lastErrorMessage = nil
-        try? persist(job)
+        updateLoadedJob {
+            $0.finalizationState = .pending
+            $0.lastErrorMessage = nil
+        }
     }
 
     func markFinalizationFailed(message: String) {
-        guard var job = loadJob() else { return }
-        job.finalizationState = .failed
-        job.lastErrorMessage = message
-        try? persist(job)
+        updateLoadedJob {
+            $0.finalizationState = .failed
+            $0.lastErrorMessage = message
+        }
     }
 
     func clearJob() async {
-        let tasks = await allDownloadTasks()
-        tasks.forEach { $0.cancel() }
+        await transport.cancelAllTasks()
         if let job = loadJob() {
             clearStagingArtifacts(for: job.modelID)
         }
-        try? jobStore.clear()
+        withJobStoreLock {
+            try? jobStore.clear()
+        }
         notifyStateChange(with: nil)
     }
 
     func cancelJob(for modelID: DictationModelID) async {
-        let tasks = await allDownloadTasks()
-        tasks
-            .filter {
-                guard let description = $0.taskDescription,
-                      let taskDescriptor = ModelBackgroundTaskDescriptor(taskDescription: description) else {
-                    return false
-                }
-                return taskDescriptor.modelID == modelID
-            }
-            .forEach { $0.cancel() }
+        guard loadJob()?.modelID == modelID else { return }
+        await transport.cancelAllTasks()
     }
 
     private func synchronizedJob(for modelID: DictationModelID) -> ModelBackgroundDownloadJob {
@@ -205,12 +197,7 @@ final class ModelBackgroundDownloadCoordinator: NSObject {
         return ModelBackgroundDownloadJob(modelID: modelID)
     }
 
-    private func persist(_ job: ModelBackgroundDownloadJob) throws {
-        try jobStore.save(job)
-        notifyStateChange(with: job)
-    }
-
-    private func ensureStagingDirectoryExists(for modelID: DictationModelID) throws {
+    func ensureStagingDirectoryExists(for modelID: DictationModelID) throws {
         guard let modelsDirectoryURL = modelLocator.modelsDirectoryURL else {
             throw CocoaError(.fileNoSuchFile)
         }
@@ -239,163 +226,5 @@ final class ModelBackgroundDownloadCoordinator: NSObject {
 
     private func notifyStateChange(with job: ModelBackgroundDownloadJob?) {
         stateDidChange?(job)
-    }
-
-    private func allDownloadTasks() async -> [URLSessionDownloadTask] {
-        await withCheckedContinuation { continuation in
-            session.getAllTasks { tasks in
-                continuation.resume(returning: tasks.compactMap { $0 as? URLSessionDownloadTask })
-            }
-        }
-    }
-
-    private func deduplicatedTasksByRelativePath(
-        from tasks: [URLSessionDownloadTask],
-        for modelID: DictationModelID
-    ) -> [String: URLSessionDownloadTask] {
-        var tasksByRelativePath: [String: URLSessionDownloadTask] = [:]
-
-        for task in tasks {
-            guard let description = task.taskDescription,
-                  let taskDescriptor = ModelBackgroundTaskDescriptor(taskDescription: description),
-                  taskDescriptor.modelID == modelID else {
-                continue
-            }
-
-            if tasksByRelativePath[taskDescriptor.relativePath] == nil {
-                tasksByRelativePath[taskDescriptor.relativePath] = task
-            } else {
-                task.cancel()
-            }
-        }
-
-        return tasksByRelativePath
-    }
-
-    private func finishBackgroundSessionEventsIfNeeded() {
-        completionHandlerLock.lock()
-        let completionHandler = backgroundSessionCompletionHandler
-        backgroundSessionCompletionHandler = nil
-        completionHandlerLock.unlock()
-        completionHandler?()
-    }
-
-    private func updateJob(
-        for taskDescriptor: ModelBackgroundTaskDescriptor,
-        mutate: (inout ModelBackgroundDownloadJob, inout ModelBackgroundArtifactState) -> Void
-    ) {
-        var job = loadJob() ?? ModelBackgroundDownloadJob(modelID: taskDescriptor.modelID)
-        guard job.modelID == taskDescriptor.modelID else { return }
-        var artifactState = job.artifactState(for: taskDescriptor.relativePath)
-        mutate(&job, &artifactState)
-        job.setArtifactState(artifactState, for: taskDescriptor.relativePath)
-        try? persist(job)
-    }
-}
-
-extension ModelBackgroundDownloadCoordinator: URLSessionDownloadDelegate {
-    func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didWriteData bytesWritten: Int64,
-        totalBytesWritten: Int64,
-        totalBytesExpectedToWrite: Int64
-    ) {
-        guard let description = downloadTask.taskDescription,
-              let taskDescriptor = ModelBackgroundTaskDescriptor(taskDescription: description) else {
-            return
-        }
-
-        let fallbackExpectedBytes = DictationModelCatalog
-            .descriptor(for: taskDescriptor.modelID)
-            .artifacts
-            .first(where: { $0.relativePath == taskDescriptor.relativePath })?
-            .progressTotalBytes
-
-        updateJob(for: taskDescriptor) { _, artifactState in
-            artifactState.phase = .downloading
-            artifactState.taskIdentifier = downloadTask.taskIdentifier
-            artifactState.completedBytes = max(totalBytesWritten, 0)
-            artifactState.expectedBytes = totalBytesExpectedToWrite > 0
-                ? totalBytesExpectedToWrite
-                : fallbackExpectedBytes
-            artifactState.errorMessage = nil
-            artifactState.updatedAt = .now
-        }
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didFinishDownloadingTo location: URL
-    ) {
-        guard let description = downloadTask.taskDescription,
-              let taskDescriptor = ModelBackgroundTaskDescriptor(taskDescription: description),
-              let stagedURL = modelLocator.stagedArtifactURL(
-                for: taskDescriptor.modelID,
-                relativePath: taskDescriptor.relativePath
-              ) else {
-            return
-        }
-
-        do {
-            let parentDirectoryURL = stagedURL.deletingLastPathComponent()
-            if !fileManager.fileExists(atPath: parentDirectoryURL.path) {
-                try fileManager.createDirectory(at: parentDirectoryURL, withIntermediateDirectories: true)
-            }
-            if fileManager.fileExists(atPath: stagedURL.path) {
-                try fileManager.removeItem(at: stagedURL)
-            }
-            try fileManager.moveItem(at: location, to: stagedURL)
-
-            let fileSize = (try? fileManager.attributesOfItem(atPath: stagedURL.path)[.size] as? NSNumber)?.int64Value ?? 0
-            updateJob(for: taskDescriptor) { job, artifactState in
-                artifactState.phase = .downloaded
-                artifactState.taskIdentifier = nil
-                artifactState.completedBytes = fileSize
-                artifactState.expectedBytes = max(artifactState.expectedBytes ?? 0, fileSize)
-                artifactState.errorMessage = nil
-                artifactState.updatedAt = .now
-                if job.isReadyForFinalization {
-                    job.finalizationState = .pending
-                    job.lastErrorMessage = nil
-                }
-            }
-        } catch {
-            updateJob(for: taskDescriptor) { job, artifactState in
-                artifactState.phase = .failed
-                artifactState.taskIdentifier = nil
-                artifactState.errorMessage = error.localizedDescription
-                artifactState.updatedAt = .now
-                job.lastErrorMessage = error.localizedDescription
-                job.finalizationState = .failed
-            }
-        }
-    }
-
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        guard let error,
-              let description = task.taskDescription,
-              let taskDescriptor = ModelBackgroundTaskDescriptor(taskDescription: description) else {
-            return
-        }
-
-        let nsError = error as NSError
-        guard !(nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled) else {
-            return
-        }
-
-        updateJob(for: taskDescriptor) { job, artifactState in
-            artifactState.phase = .failed
-            artifactState.taskIdentifier = nil
-            artifactState.errorMessage = error.localizedDescription
-            artifactState.updatedAt = .now
-            job.lastErrorMessage = error.localizedDescription
-            job.finalizationState = .failed
-        }
-    }
-
-    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
-        finishBackgroundSessionEventsIfNeeded()
     }
 }

--- a/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadJob.swift
+++ b/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadJob.swift
@@ -1,33 +1,5 @@
 import Foundation
 
-struct ModelBackgroundTaskDescriptor: Equatable, Sendable {
-    let modelID: DictationModelID
-    let relativePath: String
-
-    var taskDescription: String {
-        "\(modelID.rawValue)::\(relativePath)"
-    }
-
-    init(modelID: DictationModelID, relativePath: String) {
-        self.modelID = modelID
-        self.relativePath = relativePath
-    }
-
-    init?(taskDescription: String) {
-        guard let separatorRange = taskDescription.range(of: "::") else {
-            return nil
-        }
-
-        let modelIDRawValue = String(taskDescription[..<separatorRange.lowerBound])
-        guard let modelID = DictationModelID(rawValue: modelIDRawValue) else {
-            return nil
-        }
-
-        self.modelID = modelID
-        self.relativePath = String(taskDescription[separatorRange.upperBound...])
-    }
-}
-
 enum ModelBackgroundArtifactPhase: String, Codable, Sendable {
     case pending
     case downloading
@@ -76,19 +48,24 @@ struct ModelBackgroundArtifactState: Codable, Sendable {
 }
 
 struct ModelBackgroundDownloadJob: Codable, Sendable {
+    var id: UUID
     var modelID: DictationModelID
     var artifactStatesByRelativePath: [String: ModelBackgroundArtifactState]
+    var highestObservedDownloadProgressFraction: Double
     var finalizationState: ModelBackgroundFinalizationState
     var lastErrorMessage: String?
     var updatedAt: Date
 
     init(
+        id: UUID = UUID(),
         modelID: DictationModelID,
         artifactStatesByRelativePath: [String: ModelBackgroundArtifactState]? = nil,
+        highestObservedDownloadProgressFraction: Double = 0,
         finalizationState: ModelBackgroundFinalizationState = .awaitingDownloads,
         lastErrorMessage: String? = nil,
         updatedAt: Date = .now
     ) {
+        self.id = id
         self.modelID = modelID
         if let artifactStatesByRelativePath {
             self.artifactStatesByRelativePath = artifactStatesByRelativePath
@@ -99,6 +76,7 @@ struct ModelBackgroundDownloadJob: Codable, Sendable {
                 }
             )
         }
+        self.highestObservedDownloadProgressFraction = highestObservedDownloadProgressFraction
         self.finalizationState = finalizationState
         self.lastErrorMessage = lastErrorMessage
         self.updatedAt = updatedAt
@@ -116,11 +94,20 @@ struct ModelBackgroundDownloadJob: Codable, Sendable {
         _ state: ModelBackgroundArtifactState,
         for relativePath: String
     ) {
+        let previousProgress = downloadProgressFraction
         artifactStatesByRelativePath[relativePath] = state
+        highestObservedDownloadProgressFraction = max(
+            highestObservedDownloadProgressFraction,
+            max(previousProgress, calculatedDownloadProgressFraction)
+        )
         touch()
     }
 
     var downloadProgressFraction: Double {
+        max(highestObservedDownloadProgressFraction, calculatedDownloadProgressFraction)
+    }
+
+    private var calculatedDownloadProgressFraction: Double {
         let descriptor = DictationModelCatalog.descriptor(for: modelID)
         let expectedBytes = descriptor.artifacts.reduce(into: Int64(0)) { total, artifact in
             let state = artifactState(for: artifact.relativePath)

--- a/iOS/KeyVox iOS/Core/ModelDownloader/ModelManager.swift
+++ b/iOS/KeyVox iOS/Core/ModelDownloader/ModelManager.swift
@@ -163,8 +163,14 @@ final class ModelManager: ObservableObject {
         appIsActive = true
         Task { [weak self] in
             guard let self else { return }
+            await self.backgroundDownloadCoordinator?.handleAppDidBecomeActive()
             await self.recoverInterruptedDownloadIfNeeded()
         }
+    }
+
+    func handleAppWillResignActive() {
+        appIsActive = false
+        backgroundDownloadCoordinator?.handleAppWillResignActive()
     }
 
     func handleAppDidEnterBackground() {

--- a/iOS/KeyVoxiOSTests/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJobTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/LocalRewriteModel/LocalRewriteBackgroundDownloadJobTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import KeyVox_iOS
 
+@MainActor
 struct LocalRewriteBackgroundDownloadJobTests {
     @Test func jobRoundTripsThroughPersistentStore() throws {
         let rootURL = FileManager.default.temporaryDirectory

--- a/iOS/KeyVoxiOSTests/Core/ModelDownloader/ModelBackgroundDownloadCoordinatorTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/ModelDownloader/ModelBackgroundDownloadCoordinatorTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import KeyVox_iOS
 
+@MainActor
 @Suite(.serialized)
 struct ModelBackgroundDownloadCoordinatorTests {
     @Test func dictationUsesIndependentBackgroundSessionNamespace() {

--- a/iOS/KeyVoxiOSTests/Core/ModelDownloader/ModelBackgroundDownloadCoordinatorTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/ModelDownloader/ModelBackgroundDownloadCoordinatorTests.swift
@@ -51,7 +51,7 @@ struct ModelBackgroundDownloadCoordinatorTests {
             artifactID: artifact.relativePath
         ).encoded
         task.resume()
-        await waitForTask(task, in: harness.coordinator.transport)
+        try await waitForTask(task, in: harness.coordinator.transport)
 
         let recoveredJob = await harness.coordinator.synchronizeWithSystemTasks()
 
@@ -75,7 +75,7 @@ struct ModelBackgroundDownloadCoordinatorTests {
             artifactID: artifact.relativePath
         ).encoded
         task.resume()
-        await waitForTask(task, in: harness.coordinator.transport)
+        try await waitForTask(task, in: harness.coordinator.transport)
 
         await harness.coordinator.cancelJob(for: job.modelID)
 
@@ -111,15 +111,22 @@ struct ModelBackgroundDownloadCoordinatorTests {
     private func waitForTask(
         _ task: URLSessionDownloadTask,
         in transport: ResumableDownloadTransport
-    ) async {
-        for _ in 0 ..< 1_000 {
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+        while ContinuousClock.now < deadline {
             let tasks = await transport.downloadTasks(in: .foreground)
             if tasks.contains(where: { $0.taskIdentifier == task.taskIdentifier }) {
                 return
             }
-            await Task.yield()
+            try await Task.sleep(for: .milliseconds(10))
         }
+
+        throw CoordinatorTestError.timedOutWaitingForTask
     }
+}
+
+private enum CoordinatorTestError: Error {
+    case timedOutWaitingForTask
 }
 
 private struct CoordinatorHarness {

--- a/iOS/KeyVoxiOSTests/Core/ModelDownloader/ModelBackgroundDownloadCoordinatorTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/ModelDownloader/ModelBackgroundDownloadCoordinatorTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+@testable import KeyVox_iOS
+
+@Suite(.serialized)
+struct ModelBackgroundDownloadCoordinatorTests {
+    @Test func dictationUsesIndependentBackgroundSessionNamespace() {
+        #expect(
+            ModelBackgroundDownloadCoordinator.sessionIdentifier
+                != PocketTTSBackgroundDownloadCoordinator.sessionIdentifier
+        )
+        #expect(
+            ModelBackgroundDownloadCoordinator.sessionIdentifier
+                != LocalRewriteBackgroundDownloadCoordinator.sessionIdentifier
+        )
+    }
+
+    @Test func lifecycleEntryPointsSettleTransportInRequestedSessionMode() async {
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+
+        await harness.coordinator.handleAppDidBecomeActive()
+
+        #expect(harness.coordinator.transport.appIsActive)
+        #expect(!harness.coordinator.transport.isTransitioning)
+
+        harness.coordinator.handleAppWillResignActive()
+        await waitForLifecycleTransition(in: harness.coordinator.transport)
+
+        #expect(!harness.coordinator.transport.appIsActive)
+        #expect(!harness.coordinator.transport.isTransitioning)
+    }
+
+    @Test func synchronizationRecoversPersistedArtifactFromTransportTask() async throws {
+        URLProtocol.registerClass(BlockingDownloadURLProtocol.self)
+        defer { URLProtocol.unregisterClass(BlockingDownloadURLProtocol.self) }
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+        let modelID = DictationModelID.parakeetTdtV3
+        let artifact = try #require(DictationModelCatalog.descriptor(for: modelID).artifacts.first)
+        var job = ModelBackgroundDownloadJob(modelID: modelID)
+        job.setArtifactState(
+            .init(phase: .downloading, completedBytes: 123, expectedBytes: artifact.progressTotalBytes),
+            for: artifact.relativePath
+        )
+        try harness.store.save(job)
+        let task = harness.coordinator.transport.session(for: .foreground).downloadTask(with: artifact.remoteURL)
+        task.taskDescription = ResumableDownloadTaskDescriptor(
+            jobID: job.id,
+            artifactID: artifact.relativePath
+        ).encoded
+        task.resume()
+        await waitForTask(task, in: harness.coordinator.transport)
+
+        let recoveredJob = await harness.coordinator.synchronizeWithSystemTasks()
+
+        #expect(recoveredJob?.artifactState(for: artifact.relativePath).phase == .downloading)
+        #expect(recoveredJob?.artifactState(for: artifact.relativePath).taskIdentifier == task.taskIdentifier)
+        #expect(recoveredJob?.artifactState(for: artifact.relativePath).completedBytes == 123)
+        task.cancel()
+    }
+
+    @Test func cancelJobCancelsEveryArtifactTaskInDictationNamespace() async throws {
+        URLProtocol.registerClass(BlockingDownloadURLProtocol.self)
+        defer { URLProtocol.unregisterClass(BlockingDownloadURLProtocol.self) }
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+        let job = ModelBackgroundDownloadJob(modelID: .whisperBase)
+        try harness.store.save(job)
+        let artifact = try #require(DictationModelCatalog.descriptor(for: job.modelID).artifacts.first)
+        let task = harness.coordinator.transport.session(for: .foreground).downloadTask(with: artifact.remoteURL)
+        task.taskDescription = ResumableDownloadTaskDescriptor(
+            jobID: job.id,
+            artifactID: artifact.relativePath
+        ).encoded
+        task.resume()
+        await waitForTask(task, in: harness.coordinator.transport)
+
+        await harness.coordinator.cancelJob(for: job.modelID)
+
+        #expect(task.state == .canceling || task.state == .completed)
+    }
+
+    private func makeHarness() -> CoordinatorHarness {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let modelsURL = rootURL.appendingPathComponent("Models", isDirectory: true)
+        let store = ModelBackgroundDownloadJobStore(
+            fileManager: .default,
+            jobURLProvider: { modelsURL.appendingPathComponent("model-download-job.json") }
+        )
+        let locator = InstalledDictationModelLocator(
+            fileManager: .default,
+            modelsDirectoryURL: modelsURL
+        )
+        let coordinator = ModelBackgroundDownloadCoordinator(
+            fileManager: .default,
+            jobStore: store,
+            modelLocator: locator
+        )
+        return CoordinatorHarness(rootURL: rootURL, store: store, coordinator: coordinator)
+    }
+
+    private func waitForLifecycleTransition(in transport: ResumableDownloadTransport) async {
+        for _ in 0 ..< 1_000 where transport.isTransitioning {
+            await Task.yield()
+        }
+    }
+
+    private func waitForTask(
+        _ task: URLSessionDownloadTask,
+        in transport: ResumableDownloadTransport
+    ) async {
+        for _ in 0 ..< 1_000 {
+            let tasks = await transport.downloadTasks(in: .foreground)
+            if tasks.contains(where: { $0.taskIdentifier == task.taskIdentifier }) {
+                return
+            }
+            await Task.yield()
+        }
+    }
+}
+
+private struct CoordinatorHarness {
+    let rootURL: URL
+    let store: ModelBackgroundDownloadJobStore
+    let coordinator: ModelBackgroundDownloadCoordinator
+
+    func cleanup() {
+        coordinator.transport.cancelAllTasksWithoutWaiting()
+        try? FileManager.default.removeItem(at: rootURL)
+    }
+}
+
+private final class BlockingDownloadURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {}
+
+    override func stopLoading() {}
+}

--- a/iOS/KeyVoxiOSTests/Core/ModelDownloader/ModelBackgroundDownloadJobTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/ModelDownloader/ModelBackgroundDownloadJobTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import KeyVox_iOS
+
+struct ModelBackgroundDownloadJobTests {
+    @Test func jobIdentityRoundTripsThroughPersistentStore() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        let store = ModelBackgroundDownloadJobStore(
+            fileManager: .default,
+            jobURLProvider: { rootURL.appendingPathComponent("model-download-job.json") }
+        )
+        let job = ModelBackgroundDownloadJob(modelID: .parakeetTdtV3)
+
+        try store.save(job)
+
+        #expect(store.load()?.id == job.id)
+        #expect(store.load()?.modelID == job.modelID)
+    }
+
+    @Test func multiArtifactProgressDoesNotRegressWhenExpectedBytesGrowDuringHandoff() throws {
+        let descriptor = DictationModelCatalog.descriptor(for: .parakeetTdtV3)
+        let firstArtifact = try #require(descriptor.artifacts.first)
+        let secondArtifact = try #require(descriptor.artifacts.dropFirst().first)
+        var job = ModelBackgroundDownloadJob(modelID: .parakeetTdtV3)
+
+        job.setArtifactState(
+            .init(
+                phase: .downloading,
+                completedBytes: firstArtifact.progressTotalBytes,
+                expectedBytes: firstArtifact.progressTotalBytes
+            ),
+            for: firstArtifact.relativePath
+        )
+        job.setArtifactState(
+            .init(
+                phase: .downloading,
+                completedBytes: secondArtifact.progressTotalBytes / 2,
+                expectedBytes: secondArtifact.progressTotalBytes
+            ),
+            for: secondArtifact.relativePath
+        )
+        let progressBeforeHandoff = job.downloadProgressFraction
+
+        job.setArtifactState(
+            .init(
+                phase: .downloading,
+                completedBytes: secondArtifact.progressTotalBytes / 4,
+                expectedBytes: secondArtifact.progressTotalBytes * 2
+            ),
+            for: secondArtifact.relativePath
+        )
+
+        #expect(job.downloadProgressFraction >= progressBeforeHandoff)
+    }
+}


### PR DESCRIPTION
## Summary

- Moves Dictation model downloads onto the reusable resumable download transport already used by Speak and Vibes.
- Keeps the normal foreground network path while the app is active and hands unfinished artifacts to the existing Dictation background session when the app becomes inactive.
- Preserves the current Whisper and Parakeet catalogs, staging and installed locations, finalization behavior, repair flow, and user-facing install state.

## Foreground and background handoff

- Gives Dictation its own `ResumableDownloadTransport` using the existing `com.cueit.keyvox.model-download.background-session` namespace.
- Starts foreground-to-background handoff during `.inactive` and returns unfinished work to the foreground session during `.active`.
- Recreates each artifact from resume data under a stable persisted job UUID.
- Reconciles tasks from both sessions after launch before restarting missing work.
- Preserves per-artifact byte counts and aggregate displayed progress when recreated tasks initially report smaller session-local values.
- Keeps Dictation, Speak, and Vibes transfers isolated through independent transport instances and background-session identifiers.

## Dictation download ownership

- Keeps the Dictation catalog, artifact scheduling, persisted job, staging, failure handling, cancellation, and finalization outside the reusable transport.
- Uses the shared `jobID` and `artifactID` task descriptor for every Whisper and Parakeet artifact.
- Stores the active job at `Models/model-download-job.json` and incomplete artifacts under the existing `Models/.staging/<model-id>/` path.
- Moves completed URLSession temporary files into Dictation staging before background callbacks finish.
- Rejects non-success HTTP responses before an artifact can enter the downloaded state.
- Defers extraction, validation, manifest writing, installation, warmup, and readiness publication until the app is active.

## Coordinator structure

- Splits the Dictation coordinator into responsibility-specific state, transport scheduling, and transport delegate extensions following the established Speak and Vibes structure.
- Serializes persisted job mutations so lifecycle reconciliation and URLSession callbacks cannot overwrite one another.
- Removes the replaced coordinator-owned URLSession delegate and legacy Dictation task descriptor.
- Adds focused coverage for session isolation, lifecycle transitions, task recovery, cancellation, persisted job identity, and monotonic multi-artifact progress.
- Updates the iOS code map and engineering notes with the new ownership and lifecycle rules.

## Product behavior and installation integrity

- Keeps one active Dictation model download or install at a time.
- Preserves foreground-only finalization after background transfer completion.
- Restarts missing persisted work after relaunch, including the expected force-quit recovery path.
- Cancels only the active Dictation job and leaves Speak and Vibes tasks untouched.
- Keeps existing delete, repair, model selection, and progress presentation behavior.

## Validation

- KeyVox iOS test suite passes on an iPhone 17 Pro simulator.
- Focused Dictation coordinator and persisted-job coverage passes.
- Release simulator build succeeds.
- `git diff --check`

Closes #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model downloads now transition more reliably between foreground and background activity.
  - Interrupted downloads can recover from existing system tasks and resume without losing progress.
  - Download progress is preserved across multi-artifact handoffs and changing size estimates.
  - App lifecycle handling now coordinates model downloads when entering or leaving the active state.

- **Documentation**
  - Updated engineering documentation and code maps to reflect the download lifecycle, recovery behavior, and testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->