### PR TITLE
fix(ios-downloads): make recovery reconciliation deterministic

### DIFF
--- a/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/ModelDownloader/ModelBackgroundDownloadCoordinator.swift
@@ -1,7 +1,14 @@
 import Foundation
 
+struct ModelBackgroundDownloadTaskSnapshot: Sendable {
+    let taskIdentifier: Int
+    let completedBytes: Int64
+    let expectedBytes: Int64
+}
+
 final class ModelBackgroundDownloadCoordinator: ResumableDownloadTransportDelegate {
     typealias StateChangeHandler = @Sendable (ModelBackgroundDownloadJob?) -> Void
+    typealias TaskSnapshotProvider = @MainActor (UUID) async -> [String: ModelBackgroundDownloadTaskSnapshot]
 
     static let sessionIdentifier = "com.cueit.keyvox.model-download.background-session"
 
@@ -12,15 +19,18 @@ final class ModelBackgroundDownloadCoordinator: ResumableDownloadTransportDelega
     let modelLocator: InstalledDictationModelLocator
     let jobStoreLock = NSLock()
     let transport: ResumableDownloadTransport
+    private let taskSnapshotProvider: TaskSnapshotProvider?
 
     init(
         fileManager: FileManager = .default,
         jobStore: ModelBackgroundDownloadJobStore,
-        modelLocator: InstalledDictationModelLocator
+        modelLocator: InstalledDictationModelLocator,
+        taskSnapshotProvider: TaskSnapshotProvider? = nil
     ) {
         self.fileManager = fileManager
         self.jobStore = jobStore
         self.modelLocator = modelLocator
+        self.taskSnapshotProvider = taskSnapshotProvider
         self.transport = ResumableDownloadTransport(
             sessionIdentifier: Self.sessionIdentifier,
             sharedContainerIdentifier: SharedPaths.appGroupID,
@@ -99,13 +109,7 @@ final class ModelBackgroundDownloadCoordinator: ResumableDownloadTransportDelega
     func synchronizeWithSystemTasks() async -> ModelBackgroundDownloadJob? {
         guard let existingJob = loadJob() else { return nil }
 
-        let backgroundTasks = await transport.downloadTasks(in: .background)
-        let foregroundTasks = await transport.downloadTasks(in: .foreground)
-        let tasks = backgroundTasks + foregroundTasks
-        let tasksByRelativePath = transport.deduplicatedTasksByArtifactID(
-            from: tasks,
-            jobID: existingJob.id
-        )
+        let taskSnapshotsByRelativePath = await taskSnapshots(for: existingJob.id)
         let job = withJobStoreLock { () -> ModelBackgroundDownloadJob? in
             guard var job = jobStore.load(), job.id == existingJob.id else { return nil }
             let descriptor = DictationModelCatalog.descriptor(for: job.modelID)
@@ -118,17 +122,17 @@ final class ModelBackgroundDownloadCoordinator: ResumableDownloadTransportDelega
                     continue
                 }
 
-                if let task = tasksByRelativePath[artifact.relativePath] {
+                if let taskSnapshot = taskSnapshotsByRelativePath[artifact.relativePath] {
                     artifactState.phase = .downloading
-                    artifactState.taskIdentifier = task.taskIdentifier
+                    artifactState.taskIdentifier = taskSnapshot.taskIdentifier
                     artifactState.completedBytes = max(
                         artifactState.completedBytes,
-                        max(task.countOfBytesReceived, 0)
+                        max(taskSnapshot.completedBytes, 0)
                     )
-                    if task.countOfBytesExpectedToReceive > 0 {
+                    if taskSnapshot.expectedBytes > 0 {
                         artifactState.expectedBytes = max(
                             artifactState.expectedBytes ?? artifact.progressTotalBytes,
-                            task.countOfBytesExpectedToReceive
+                            taskSnapshot.expectedBytes
                         )
                     }
                     artifactState.errorMessage = nil
@@ -152,6 +156,30 @@ final class ModelBackgroundDownloadCoordinator: ResumableDownloadTransportDelega
         }
         stateDidChange?(job)
         return job
+    }
+
+    private func taskSnapshots(
+        for jobID: UUID
+    ) async -> [String: ModelBackgroundDownloadTaskSnapshot] {
+        if let taskSnapshotProvider {
+            return await taskSnapshotProvider(jobID)
+        }
+
+        let backgroundTasks = await transport.downloadTasks(in: .background)
+        let foregroundTasks = await transport.downloadTasks(in: .foreground)
+        let tasks = backgroundTasks + foregroundTasks
+        let tasksByRelativePath = transport.deduplicatedTasksByArtifactID(
+            from: tasks,
+            jobID: jobID
+        )
+
+        return tasksByRelativePath.mapValues { task in
+            ModelBackgroundDownloadTaskSnapshot(
+                taskIdentifier: task.taskIdentifier,
+                completedBytes: task.countOfBytesReceived,
+                expectedBytes: task.countOfBytesExpectedToReceive
+            )
+        }
     }
 
     func markFinalizationInProgress() {

--- a/iOS/KeyVoxiOSTests/Core/ModelDownloader/ModelBackgroundDownloadCoordinatorTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/ModelDownloader/ModelBackgroundDownloadCoordinatorTests.swift
@@ -32,14 +32,11 @@ struct ModelBackgroundDownloadCoordinatorTests {
         #expect(!harness.coordinator.transport.isTransitioning)
     }
 
-    @Test func synchronizationRecoversPersistedArtifactFromTransportTask() async throws {
-        URLProtocol.registerClass(BlockingDownloadURLProtocol.self)
-        defer { URLProtocol.unregisterClass(BlockingDownloadURLProtocol.self) }
-        let harness = makeHarness()
-        defer { harness.cleanup() }
+    @Test func synchronizationRecoversPersistedArtifactFromTaskSnapshot() async throws {
         let modelID = DictationModelID.parakeetTdtV3
         let artifact = try #require(DictationModelCatalog.descriptor(for: modelID).artifacts.first)
         let persistedCompletedBytes: Int64 = 123
+        let taskIdentifier = 1
         var job = ModelBackgroundDownloadJob(modelID: modelID)
         job.setArtifactState(
             .init(
@@ -49,26 +46,28 @@ struct ModelBackgroundDownloadCoordinatorTests {
             ),
             for: artifact.relativePath
         )
+        let jobID = job.id
+        let harness = makeHarness { requestedJobID in
+            guard requestedJobID == jobID else { return [:] }
+            return [
+                artifact.relativePath: ModelBackgroundDownloadTaskSnapshot(
+                    taskIdentifier: taskIdentifier,
+                    completedBytes: 0,
+                    expectedBytes: artifact.progressTotalBytes
+                )
+            ]
+        }
+        defer { harness.cleanup() }
         try harness.store.save(job)
-        let task = harness.coordinator.transport.session(for: .foreground).downloadTask(with: artifact.remoteURL)
-        task.taskDescription = ResumableDownloadTaskDescriptor(
-            jobID: job.id,
-            artifactID: artifact.relativePath
-        ).encoded
-        task.resume()
-        try await waitForTask(task, in: harness.coordinator.transport)
-        task.suspend()
-        try #require(task.state == .suspended)
 
         let recoveredJob = await harness.coordinator.synchronizeWithSystemTasks()
 
         #expect(recoveredJob?.artifactState(for: artifact.relativePath).phase == .downloading)
-        #expect(recoveredJob?.artifactState(for: artifact.relativePath).taskIdentifier == task.taskIdentifier)
+        #expect(recoveredJob?.artifactState(for: artifact.relativePath).taskIdentifier == taskIdentifier)
         #expect(
             recoveredJob?.artifactState(for: artifact.relativePath).completedBytes ?? 0
                 >= persistedCompletedBytes
         )
-        task.cancel()
     }
 
     @Test func cancelJobCancelsEveryArtifactTaskInDictationNamespace() async throws {
@@ -92,7 +91,9 @@ struct ModelBackgroundDownloadCoordinatorTests {
         #expect(task.state == .canceling || task.state == .completed)
     }
 
-    private func makeHarness() -> CoordinatorHarness {
+    private func makeHarness(
+        taskSnapshotProvider: ModelBackgroundDownloadCoordinator.TaskSnapshotProvider? = nil
+    ) -> CoordinatorHarness {
         let rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         let modelsURL = rootURL.appendingPathComponent("Models", isDirectory: true)
@@ -107,9 +108,15 @@ struct ModelBackgroundDownloadCoordinatorTests {
         let coordinator = ModelBackgroundDownloadCoordinator(
             fileManager: .default,
             jobStore: store,
-            modelLocator: locator
+            modelLocator: locator,
+            taskSnapshotProvider: taskSnapshotProvider
         )
-        return CoordinatorHarness(rootURL: rootURL, store: store, coordinator: coordinator)
+        return CoordinatorHarness(
+            rootURL: rootURL,
+            store: store,
+            coordinator: coordinator,
+            cancelsTransportTasksOnCleanup: taskSnapshotProvider == nil
+        )
     }
 
     private func waitForLifecycleTransition(in transport: ResumableDownloadTransport) async {
@@ -143,9 +150,12 @@ private struct CoordinatorHarness {
     let rootURL: URL
     let store: ModelBackgroundDownloadJobStore
     let coordinator: ModelBackgroundDownloadCoordinator
+    let cancelsTransportTasksOnCleanup: Bool
 
     func cleanup() {
-        coordinator.transport.cancelAllTasksWithoutWaiting()
+        if cancelsTransportTasksOnCleanup {
+            coordinator.transport.cancelAllTasksWithoutWaiting()
+        }
         try? FileManager.default.removeItem(at: rootURL)
     }
 }


### PR DESCRIPTION
## Summary

- Reconciles persisted Dictation download jobs from immutable task snapshots while keeping the existing system-task discovery path for production downloads.
- Adds an injectable snapshot provider so recovery behavior uses controlled task identity and progress inputs.
- Removes live URL session scheduling, polling, and suspension from recovery coverage while preserving phase, task identifier, and monotonic progress checks.

## Validation

- `git diff --check` passes.