### PR TITLE
fix(mac-cloud-sync): remove obsolete throwing call

### DIFF
--- a/macOS/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
+++ b/macOS/KeyVoxTests/App/KeyVoxiCloudSyncCoordinatorTests.swift
@@ -31,7 +31,7 @@ final class KeyVoxiCloudSyncCoordinatorTests: XCTestCase {
             hasExistingLocalInstallation: false
         )
         _ = initialCoordinator
-        try harness.dictionaryStore.delete(id: DictionaryInitialEntries.keyVox.id)
+        harness.dictionaryStore.delete(id: DictionaryInitialEntries.keyVox.id)
 
         let laterCoordinator = makeCoordinator(
             harness: harness,


### PR DESCRIPTION
## Summary

- Updates the macOS iCloud sync coordinator coverage for the non-throwing dictionary deletion API.
- Removes the stale try expression that prevented the test target from compiling.

## Validation

- Focused KeyVoxiCloudSyncCoordinatorTests suite passes: 23 tests, 0 failures.
- git diff --check passes.