### PR TITLE
fix(core): preserve years in counterfactual clauses

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -6,7 +6,7 @@ The format loosely follows Keep a Changelog and the package uses semantic versio
 
 ---
 
-## [1.2.8] - 2026-09-04
+## [1.2.8] - 2026-09-05
 
 Split stylized dictionary terms now remain singular when their own ending resembles a possessive sound, and punctuation no longer makes ordinary text look like a stylized dictionary match.
 
@@ -17,6 +17,7 @@ Split stylized dictionary terms now remain singular when their own ending resemb
 - Added regression coverage for singular stylized terms followed by nouns.
 - Required actual Unicode uppercase characters before enabling the internal-capitalization fallback for stylized dictionary entries.
 - Added regression coverage ensuring punctuation is not treated as uppercase evidence.
+- Preserved year references in counterfactual temporal clauses without treating them as grouped quantities.
 
 ### Notes
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/ThousandsGroupingNormalizer.swift
@@ -199,7 +199,8 @@ public struct ThousandsGroupingNormalizer {
                         secondPrevious: context.secondPrevious,
                         previous: context.previous,
                         next: context.next,
-                        secondNext: context.secondNext
+                        secondNext: context.secondNext,
+                        thirdNext: context.thirdNext
                     ),
                     nextIndex: endIndex
                 )
@@ -435,7 +436,8 @@ public struct ThousandsGroupingNormalizer {
         secondPrevious: LexicalToken?,
         previous: LexicalToken?,
         next: LexicalToken?,
-        secondNext: LexicalToken?
+        secondNext: LexicalToken?,
+        thirdNext: LexicalToken?
     ) {
         let previousTokens = tokens.filter { NSMaxRange($0.range) <= range.location }
         let followingTokens = tokens.filter { $0.range.location >= NSMaxRange(range) }
@@ -445,7 +447,8 @@ public struct ThousandsGroupingNormalizer {
             secondPrevious: previousTokens.dropLast().last,
             previous: previousTokens.last,
             next: followingTokens.first,
-            secondNext: followingTokens.dropFirst().first
+            secondNext: followingTokens.dropFirst().first,
+            thirdNext: followingTokens.dropFirst(2).first
         )
     }
 
@@ -488,6 +491,7 @@ public struct ThousandsGroupingNormalizer {
         let previous = tokenIndex > 0 ? tokens[tokenIndex - 1] : nil
         let next = tokenIndex + 1 < tokens.count ? tokens[tokenIndex + 1] : nil
         let secondNext = tokenIndex + 2 < tokens.count ? tokens[tokenIndex + 2] : nil
+        let thirdNext = tokenIndex + 3 < tokens.count ? tokens[tokenIndex + 3] : nil
 
         if isLikelyYearReference(
             value: value,
@@ -496,7 +500,8 @@ public struct ThousandsGroupingNormalizer {
             secondPrevious: secondPrevious,
             previous: previous,
             next: next,
-            secondNext: secondNext
+            secondNext: secondNext,
+            thirdNext: thirdNext
         ) {
             return false
         }
@@ -523,7 +528,8 @@ public struct ThousandsGroupingNormalizer {
         secondPrevious: LexicalToken?,
         previous: LexicalToken?,
         next: LexicalToken?,
-        secondNext: LexicalToken?
+        secondNext: LexicalToken?,
+        thirdNext: LexicalToken?
     ) -> Bool {
         guard Self.plausibleYearRange.contains(value) else { return false }
 
@@ -562,7 +568,13 @@ public struct ThousandsGroupingNormalizer {
             return false
         }
 
-        let hasPartitiveComplement = nextTag == .preposition
+        let hasFollowingFiniteClause = previousTag == .preposition
+            && secondPreviousTag == .adverb
+            && nextTag == .preposition
+            && [.pronoun, .determiner].contains(secondNext?.tag)
+            && thirdNext?.tag == .verb
+        let hasPartitiveComplement = !hasFollowingFiniteClause
+            && nextTag == .preposition
             && [.pronoun, .determiner].contains(secondNext?.tag)
         let hasFiniteClauseLead = previousTag == .verb
             && secondPreviousTag == .pronoun
@@ -572,6 +584,7 @@ public struct ThousandsGroupingNormalizer {
 
         let yearEvidence = [
             hasAlphabeticOtherWordNeighbor,
+            hasFollowingFiniteClause,
             [.verb, .pronoun, .determiner, .conjunction].contains(nextTag),
             nextTag == .noun,
             previousTag == .preposition && !hasPartitiveComplement,

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+NumericGrouping.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+NumericGrouping.swift
@@ -88,6 +88,26 @@ extension TranscriptionPostProcessorTests {
         XCTAssertEqual(output, "Yeah, that came out in 2001, right?")
     }
 
+    func testPreservesYearInCounterfactualTemporalClause() {
+        let processor = TranscriptionPostProcessor()
+        let expected = "If somebody had told me back in 2001 that this would happen, I wouldn't have believed them."
+        let samples = [
+            expected,
+            "If somebody had told me back in two thousand one that this would happen, I wouldn't have believed them.",
+            "If somebody had told me back in two thousand and one that this would happen, I wouldn't have believed them.",
+        ]
+
+        for sample in samples {
+            let output = processor.process(
+                sample,
+                dictionaryEntries: [],
+                renderMode: .singleLineInline
+            )
+
+            XCTAssertEqual(output, expected)
+        }
+    }
+
     func testPreservesYearAfterSimplePrepositionWithoutGroupingSeparator() {
         let processor = TranscriptionPostProcessor()
 


### PR DESCRIPTION
## Summary

- Preserves year references in counterfactual temporal clauses instead of adding a thousands separator.
- Uses surrounding grammatical structure without hard-coded words or phrases.
- Documents the fix in the current KeyVoxCore changelog entry.

## Behavior

- Numeric and spoken year forms now remain 2001 in the reported sentence structure.
- Spoken forms with and without a conjunction normalize to the same year.
- Quantity complements continue to use thousands grouping.

## Coverage

- Covers 2001, two thousand one, and two thousand and one.
- Retains the existing year-versus-quantity regression coverage.

## Validation

- Reproduced the reported 2,001 output before the fix.
- Focused counterfactual year regression passes.
- KeyVoxCore package suite passes: 553 tests, 0 failures.
- git diff --check passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Years in counterfactual temporal phrases are now preserved without thousands separators.
  * Spoken year forms such as “two thousand one” are normalized to “2001” without grouping.

* **Documentation**
  * Updated the changelog date and documented the year-preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->