### PR TITLE
fix(mac-audio): support multichannel input interfaces

### DIFF
--- a/macOS/Core/Audio/AudioEngineInputCapture.swift
+++ b/macOS/Core/Audio/AudioEngineInputCapture.swift
@@ -1,0 +1,142 @@
+import AVFoundation
+import AudioToolbox
+import CoreAudio
+
+final class AudioEngineInputCapture {
+    enum CaptureError: Error {
+        case deviceNotFound
+        case audioUnitUnavailable
+        case deviceSelectionFailed(OSStatus)
+        case streamFormatSelectionFailed(OSStatus)
+        case invalidInputFormat
+    }
+
+    private var engine: AVAudioEngine?
+    private var inputNode: AVAudioInputNode?
+
+    func start(
+        deviceUID: String,
+        deliveryQueue: DispatchQueue,
+        bufferHandler: @escaping (AVAudioPCMBuffer) -> Void
+    ) throws {
+        guard var deviceID = Self.audioDeviceID(forUID: deviceUID) else {
+            throw CaptureError.deviceNotFound
+        }
+
+        let engine = AVAudioEngine()
+        let inputNode = engine.inputNode
+        guard let audioUnit = inputNode.audioUnit else {
+            throw CaptureError.audioUnitUnavailable
+        }
+
+        let selectionStatus = AudioUnitSetProperty(
+            audioUnit,
+            kAudioOutputUnitProperty_CurrentDevice,
+            kAudioUnitScope_Global,
+            0,
+            &deviceID,
+            UInt32(MemoryLayout<AudioDeviceID>.size)
+        )
+        guard selectionStatus == noErr else {
+            throw CaptureError.deviceSelectionFailed(selectionStatus)
+        }
+
+        var hardwareInputFormat = inputNode.inputFormat(forBus: 0).streamDescription.pointee
+        let formatSelectionStatus = AudioUnitSetProperty(
+            audioUnit,
+            kAudioUnitProperty_StreamFormat,
+            kAudioUnitScope_Output,
+            1,
+            &hardwareInputFormat,
+            UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+        )
+        guard formatSelectionStatus == noErr else {
+            throw CaptureError.streamFormatSelectionFailed(formatSelectionStatus)
+        }
+
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+        guard inputFormat.sampleRate > 0, inputFormat.channelCount > 0 else {
+            throw CaptureError.invalidInputFormat
+        }
+
+        inputNode.installTap(onBus: 0, bufferSize: 1_024, format: inputFormat) { buffer, _ in
+            guard let copiedBuffer = Self.copy(buffer) else { return }
+            deliveryQueue.async {
+                bufferHandler(copiedBuffer)
+            }
+        }
+
+        engine.prepare()
+        try engine.start()
+
+        self.engine = engine
+        self.inputNode = inputNode
+    }
+
+    func stop() {
+        inputNode?.removeTap(onBus: 0)
+        engine?.stop()
+        inputNode = nil
+        engine = nil
+    }
+
+    private static func audioDeviceID(forUID deviceUID: String) -> AudioDeviceID? {
+        var uid = deviceUID as CFString
+        var deviceID = AudioDeviceID(kAudioObjectUnknown)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDeviceForUID,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        let status = withUnsafeMutablePointer(to: &uid) { uidPointer in
+            withUnsafeMutablePointer(to: &deviceID) { deviceIDPointer in
+                var translation = AudioValueTranslation(
+                    mInputData: uidPointer,
+                    mInputDataSize: UInt32(MemoryLayout<CFString>.size),
+                    mOutputData: deviceIDPointer,
+                    mOutputDataSize: UInt32(MemoryLayout<AudioDeviceID>.size)
+                )
+                var translationSize = UInt32(MemoryLayout<AudioValueTranslation>.size)
+                return AudioObjectGetPropertyData(
+                    AudioObjectID(kAudioObjectSystemObject),
+                    &address,
+                    0,
+                    nil,
+                    &translationSize,
+                    &translation
+                )
+            }
+        }
+
+        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+        return deviceID
+    }
+
+    private static func copy(_ source: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard let destination = AVAudioPCMBuffer(
+            pcmFormat: source.format,
+            frameCapacity: source.frameLength
+        ) else {
+            return nil
+        }
+
+        destination.frameLength = source.frameLength
+        let sourceBuffers = UnsafeMutableAudioBufferListPointer(source.mutableAudioBufferList)
+        let destinationBuffers = UnsafeMutableAudioBufferListPointer(destination.mutableAudioBufferList)
+
+        for (sourceBuffer, destinationBuffer) in zip(sourceBuffers, destinationBuffers) {
+            guard let sourceData = sourceBuffer.mData,
+                  let destinationData = destinationBuffer.mData else {
+                return nil
+            }
+            memcpy(
+                destinationData,
+                sourceData,
+                Int(min(sourceBuffer.mDataByteSize, destinationBuffer.mDataByteSize))
+            )
+        }
+
+        return destination
+    }
+}

--- a/macOS/Core/Audio/AudioEngineInputCapture.swift
+++ b/macOS/Core/Audio/AudioEngineInputCapture.swift
@@ -2,6 +2,38 @@ import AVFoundation
 import AudioToolbox
 import CoreAudio
 
+private final class AudioInputCallbackGate {
+    private let lock = NSLock()
+    private let group = DispatchGroup()
+    private var isOpen = false
+
+    func open() {
+        lock.lock()
+        isOpen = true
+        lock.unlock()
+    }
+
+    func performIfOpen(_ work: () -> Void) {
+        lock.lock()
+        guard isOpen else {
+            lock.unlock()
+            return
+        }
+        group.enter()
+        lock.unlock()
+
+        defer { group.leave() }
+        work()
+    }
+
+    func closeAndWait() {
+        lock.lock()
+        isOpen = false
+        lock.unlock()
+        group.wait()
+    }
+}
+
 final class AudioEngineInputCapture {
     enum CaptureError: Error {
         case deviceNotFound
@@ -13,12 +45,26 @@ final class AudioEngineInputCapture {
 
     private var engine: AVAudioEngine?
     private var inputNode: AVAudioInputNode?
+    private let callbackGate = AudioInputCallbackGate()
+    private(set) var deviceUID: String?
 
     func start(
         deviceUID: String,
         deliveryQueue: DispatchQueue,
         bufferHandler: @escaping (AVAudioPCMBuffer) -> Void
     ) throws {
+        if let engine, self.deviceUID == deviceUID {
+            callbackGate.open()
+            do {
+                engine.prepare()
+                try engine.start()
+                return
+            } catch {
+                callbackGate.closeAndWait()
+                throw error
+            }
+        }
+
         guard var deviceID = Self.audioDeviceID(forUID: deviceUID) else {
             throw CaptureError.deviceNotFound
         }
@@ -59,25 +105,34 @@ final class AudioEngineInputCapture {
             throw CaptureError.invalidInputFormat
         }
 
+        let callbackGate = callbackGate
         inputNode.installTap(onBus: 0, bufferSize: 1_024, format: inputFormat) { buffer, _ in
-            guard let copiedBuffer = Self.copy(buffer) else { return }
-            deliveryQueue.async {
-                bufferHandler(copiedBuffer)
+            callbackGate.performIfOpen {
+                guard let copiedBuffer = Self.copy(buffer) else { return }
+                deliveryQueue.async {
+                    bufferHandler(copiedBuffer)
+                }
             }
         }
 
-        engine.prepare()
-        try engine.start()
+        callbackGate.open()
+        do {
+            engine.prepare()
+            try engine.start()
+        } catch {
+            callbackGate.closeAndWait()
+            inputNode.removeTap(onBus: 0)
+            throw error
+        }
 
         self.engine = engine
         self.inputNode = inputNode
+        self.deviceUID = deviceUID
     }
 
     func stop() {
-        inputNode?.removeTap(onBus: 0)
+        callbackGate.closeAndWait()
         engine?.stop()
-        inputNode = nil
-        engine = nil
     }
 
     private static func audioDeviceID(forUID deviceUID: String) -> AudioDeviceID? {

--- a/macOS/Core/Audio/AudioRecorder+Session.swift
+++ b/macOS/Core/Audio/AudioRecorder+Session.swift
@@ -6,53 +6,19 @@ extension AudioRecorder {
     func startRecordingSession() {
         guard !isRecording, !isStopFinalizationPending else { return }
 
-        let session = AVCaptureSession()
-        session.beginConfiguration()
-
         // App-scoped input selection: selected mic -> built-in -> first available.
         guard let device = AudioDeviceManager.shared.resolvedCaptureDevice()
             ?? AudioDeviceManager.shared.builtInCaptureDevice()
             ?? AVCaptureDevice.default(for: .audio)
             ?? Self.captureAudioDevices().first else {
-            session.commitConfiguration()
             return
         }
-
-        let input: AVCaptureDeviceInput
-        do {
-            input = try AVCaptureDeviceInput(device: device)
-        } catch {
-            session.commitConfiguration()
-            return
-        }
-
-        guard session.canAddInput(input) else {
-            session.commitConfiguration()
-            return
-        }
-        session.addInput(input)
-
-        let output = AVCaptureAudioDataOutput()
-        output.setSampleBufferDelegate(self, queue: captureQueue)
-
-        guard session.canAddOutput(output) else {
-            session.commitConfiguration()
-            return
-        }
-        session.addOutput(output)
-
-        session.commitConfiguration()
-
-        captureSession = session
-        captureInput = input
-        audioCaptureOutput = output
 
         // Map current device kind for conditional logic upstream
         currentDeviceKind = AudioDeviceManager.shared.availableMicrophones.first(where: { $0.id == device.uniqueID })?.kind ?? .builtIn
         currentCaptureDeviceName = AudioSilenceGatePolicy.normalizedMicrophoneName(device.localizedName)
         configureSessionSilenceThresholds(for: device)
 
-        // Converter is rebuilt lazily when first buffer arrives (or source format changes).
         converter = nil
 
         audioDataQueue.sync {
@@ -79,7 +45,19 @@ extension AudioRecorder {
             self.liveInputSignalState = .dead
         }
 
-        session.startRunning()
+        let inputCapture = AudioEngineInputCapture()
+        do {
+            try inputCapture.start(
+                deviceUID: device.uniqueID,
+                deliveryQueue: captureQueue
+            ) { [weak self] buffer in
+                self?.processCapturedBuffer(buffer)
+            }
+        } catch {
+            return
+        }
+
+        audioInputCapture = inputCapture
         isRecording = true
     }
 
@@ -91,40 +69,14 @@ extension AudioRecorder {
         guard !isStopFinalizationPending else { return }
 
         isStopFinalizationPending = true
+        audioInputCapture?.stop()
         captureQueue.async { [weak self] in
             self?.finalizeStopRecordingSession(completion: completion)
         }
     }
 
-    private func drainPendingCaptureQueueWork() {
-        guard DispatchQueue.getSpecific(key: captureQueueSpecificKey) != captureQueueSpecificValue else {
-            return
-        }
-        captureQueue.sync {}
-    }
-
     private func finalizeStopRecordingSession(completion: @escaping ([Float]) -> Void) {
-        audioCaptureOutput?.setSampleBufferDelegate(nil, queue: nil)
-
-        // Finalize from the capture queue so anything already queued for delivery
-        // lands in the buffer before we tear the session down.
-        if let session = captureSession {
-            session.beginConfiguration()
-            if let input = captureInput {
-                session.removeInput(input)
-            }
-            if let output = audioCaptureOutput {
-                session.removeOutput(output)
-            }
-            session.commitConfiguration()
-            session.stopRunning()
-        }
-
-        drainPendingCaptureQueueWork()
-
-        captureSession = nil
-        captureInput = nil
-        audioCaptureOutput = nil
+        audioInputCapture = nil
         converter = nil
         isRecording = false
         isStopFinalizationPending = false

--- a/macOS/Core/Audio/AudioRecorder+Session.swift
+++ b/macOS/Core/Audio/AudioRecorder+Session.swift
@@ -3,15 +3,15 @@ import AVFoundation
 import KeyVoxCore
 
 extension AudioRecorder {
-    func startRecordingSession() {
-        guard !isRecording, !isStopFinalizationPending else { return }
+    func startRecordingSession() -> Bool {
+        guard !isRecording, !isStopFinalizationPending else { return false }
 
         // App-scoped input selection: selected mic -> built-in -> first available.
         guard let device = AudioDeviceManager.shared.resolvedCaptureDevice()
             ?? AudioDeviceManager.shared.builtInCaptureDevice()
             ?? AVCaptureDevice.default(for: .audio)
             ?? Self.captureAudioDevices().first else {
-            return
+            return false
         }
 
         // Map current device kind for conditional logic upstream
@@ -45,7 +45,14 @@ extension AudioRecorder {
             self.liveInputSignalState = .dead
         }
 
-        let inputCapture = AudioEngineInputCapture()
+        let inputCapture: AudioEngineInputCapture
+        if let existingCapture = audioInputCapture,
+           existingCapture.deviceUID == device.uniqueID {
+            inputCapture = existingCapture
+        } else {
+            audioInputCapture?.stop()
+            inputCapture = AudioEngineInputCapture()
+        }
         do {
             try inputCapture.start(
                 deviceUID: device.uniqueID,
@@ -54,11 +61,12 @@ extension AudioRecorder {
                 self?.processCapturedBuffer(buffer)
             }
         } catch {
-            return
+            return false
         }
 
         audioInputCapture = inputCapture
         isRecording = true
+        return true
     }
 
     func stopRecordingSession(completion: @escaping ([Float]) -> Void) {
@@ -76,7 +84,6 @@ extension AudioRecorder {
     }
 
     private func finalizeStopRecordingSession(completion: @escaping ([Float]) -> Void) {
-        audioInputCapture = nil
         converter = nil
         isRecording = false
         isStopFinalizationPending = false

--- a/macOS/Core/Audio/AudioRecorder+Streaming.swift
+++ b/macOS/Core/Audio/AudioRecorder+Streaming.swift
@@ -1,38 +1,48 @@
 import Foundation
 import AVFoundation
-import CoreMedia
 
-extension AudioRecorder: AVCaptureAudioDataOutputSampleBufferDelegate {
-    func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
-        let frameCount = CMSampleBufferGetNumSamples(sampleBuffer)
-        guard frameCount > 0 else { return }
-
-        guard let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer),
-              let asbdPointer = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription),
-              let sourceFormat = AVAudioFormat(streamDescription: asbdPointer),
-              let sourceBuffer = AVAudioPCMBuffer(pcmFormat: sourceFormat, frameCapacity: AVAudioFrameCount(frameCount)) else {
+extension AudioRecorder {
+    func processCapturedBuffer(_ sourceBuffer: AVAudioPCMBuffer) {
+        let frameCount = Int(sourceBuffer.frameLength)
+        let channelCount = Int(sourceBuffer.format.channelCount)
+        guard frameCount > 0,
+              channelCount > 0,
+              sourceBuffer.format.commonFormat == .pcmFormatFloat32,
+              !sourceBuffer.format.isInterleaved,
+              let sourceChannels = sourceBuffer.floatChannelData,
+              let monoFormat = AVAudioFormat(
+                  commonFormat: .pcmFormatFloat32,
+                  sampleRate: sourceBuffer.format.sampleRate,
+                  channels: 1,
+                  interleaved: false
+              ),
+              let monoBuffer = AVAudioPCMBuffer(
+                  pcmFormat: monoFormat,
+                  frameCapacity: sourceBuffer.frameLength
+              ),
+              let monoChannel = monoBuffer.floatChannelData?[0] else {
             return
         }
 
-        sourceBuffer.frameLength = AVAudioFrameCount(frameCount)
-
-        let copyStatus = CMSampleBufferCopyPCMDataIntoAudioBufferList(
-            sampleBuffer,
-            at: 0,
-            frameCount: Int32(frameCount),
-            into: sourceBuffer.mutableAudioBufferList
-        )
-
-        guard copyStatus == noErr else { return }
-
-        // Setup converter for real-time resampling.
-        if converter == nil || shouldRebuildConverter(for: sourceFormat) {
-            converter = AVAudioConverter(from: sourceFormat, to: outputFormat)
+        monoBuffer.frameLength = sourceBuffer.frameLength
+        for frameIndex in 0..<frameCount {
+            var mixedSample: Float = 0
+            for channelIndex in 0..<channelCount {
+                let sample = sourceChannels[channelIndex][frameIndex]
+                if sample.isFinite {
+                    mixedSample += sample
+                }
+            }
+            monoChannel[frameIndex] = min(max(mixedSample, -1), 1)
         }
 
-        guard let converter = converter else { return }
+        if converter == nil || shouldRebuildConverter(for: monoFormat) {
+            converter = AVAudioConverter(from: monoFormat, to: outputFormat)
+        }
 
-        let outputCapacity = AVAudioFrameCount(Double(sourceBuffer.frameLength) * outputFormat.sampleRate / sourceFormat.sampleRate) + 1
+        guard let converter else { return }
+
+        let outputCapacity = AVAudioFrameCount(Double(monoBuffer.frameLength) * outputFormat.sampleRate / monoFormat.sampleRate) + 1
         guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: outputCapacity) else { return }
 
         var conversionError: NSError?
@@ -44,7 +54,7 @@ extension AudioRecorder: AVCaptureAudioDataOutputSampleBufferDelegate {
             }
             providedInput = true
             outStatus.pointee = .haveData
-            return sourceBuffer
+            return monoBuffer
         }
 
         guard conversionStatus != .error, convertedBuffer.frameLength > 0,

--- a/macOS/Core/Audio/AudioRecorder.swift
+++ b/macOS/Core/Audio/AudioRecorder.swift
@@ -10,21 +10,13 @@ enum LiveInputSignalState: Equatable {
 }
 
 class AudioRecorder: NSObject, ObservableObject {
-    var captureSession: AVCaptureSession?
-    var captureInput: AVCaptureDeviceInput?
-    var audioCaptureOutput: AVCaptureAudioDataOutput?
+    var audioInputCapture: AudioEngineInputCapture?
     var converter: AVAudioConverter?
     var isStopFinalizationPending = false
 
     var audioData: [Float] = []
     let audioDataQueue = DispatchQueue(label: "AudioRecorder.audioDataQueue")
-    let captureQueueSpecificKey = DispatchSpecificKey<UInt8>()
-    let captureQueueSpecificValue: UInt8 = 1
-    lazy var captureQueue: DispatchQueue = {
-        let queue = DispatchQueue(label: "AudioRecorder.captureQueue")
-        queue.setSpecific(key: captureQueueSpecificKey, value: captureQueueSpecificValue)
-        return queue
-    }()
+    let captureQueue = DispatchQueue(label: "AudioRecorder.captureQueue")
     // Recorder contract is still mono Float32 @ 16kHz for downstream transcription.
     let outputFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)!
     let normalizationTargetPeak: Float = 0.9

--- a/macOS/Core/Audio/AudioRecorder.swift
+++ b/macOS/Core/Audio/AudioRecorder.swift
@@ -55,7 +55,8 @@ class AudioRecorder: NSObject, ObservableObject {
     var lastCaptureHadNonDeadSignal: Bool = false
     var captureStartedAt = Date.distantPast
 
-    func startRecording() {
+    @discardableResult
+    func startRecording() -> Bool {
         startRecordingSession()
     }
 

--- a/macOS/Core/Transcription/TranscriptionManager+RecordingSession.swift
+++ b/macOS/Core/Transcription/TranscriptionManager+RecordingSession.swift
@@ -83,7 +83,12 @@ extension TranscriptionManager {
             recorder: audioRecorder,
             selectedVibeTitle: selectedRecordingVibeTitle
         )
-        audioRecorder.startRecording()
+        guard audioRecorder.startRecording() else {
+            OverlayManager.shared.hide()
+            state = .idle
+            updateOverlayHandsFreeVisualState()
+            return
+        }
         vibesCoordinator.prewarmForUpcomingDictationIfNeeded()
     }
 

--- a/macOS/Docs/CODEMAP.md
+++ b/macOS/Docs/CODEMAP.md
@@ -55,6 +55,7 @@ KeyVox/
 │   │   ├── KeyboardMonitor.swift
 │   │   ├── AudioDeviceManager.swift
 │   │   ├── Audio/
+│   │   │   ├── AudioEngineInputCapture.swift
 │   │   │   └── AudioRecorder*.swift
 │   │   ├── ModelDownloader/
 │   │   ├── Transcription/
@@ -208,7 +209,7 @@ KeyVox/
 
 1. `Core/KeyboardMonitor.swift` publishes trigger/shift/escape/caps-lock state.
 2. `Core/Transcription/TranscriptionManager*.swift` drives app state: `idle -> recording -> transcribing -> idle`.
-3. `Core/Audio/AudioRecorder.swift` captures live audio as mono float frames at 16kHz.
+3. `Core/Audio/AudioEngineInputCapture.swift` binds the selected macOS input device to `AVAudioEngine`, exposes its complete hardware input stream, and hands every channel to `AudioRecorder`; `AudioRecorder+Streaming.swift` deterministically sums all exposed channels before converting the result to mono Float32 frames at 16kHz.
 4. `App/AppServiceRegistry.swift` routes dictation through `SwitchableDictationProvider`, normalizes active-provider selection, synchronizes the device-local Whisper language, and binds install-time Parakeet preloading to the downloader.
 5. For Whisper, `Packages/KeyVoxCore/Sources/KeyVoxCore/Services/Whisper/WhisperService+TranscriptionCore.swift` runs whole-capture voice-activity analysis through the package-owned Silero detector before decoding; Parakeet does not use this Whisper-specific gate.
 6. `Packages/KeyVoxCore/Sources/KeyVoxCore/Transcription/AudioParagraphChunker.swift` detects long internal silence and computes conservative chunk boundaries shared by both providers.
@@ -506,10 +507,13 @@ KeyVox/
   - Validates legacy Whisper installs and strict manifest-backed subdirectory installs before marking models available.
 - `Core/Audio/AudioRecorder.swift`
   - Audio-recorder state holder and public orchestration entrypoints (`startRecording`, `stopRecording`).
+- `Core/Audio/AudioEngineInputCapture.swift`
+  - Selected-device `AVAudioEngine` capture boundary for macOS input hardware.
+  - Resolves the selected capture UID to its CoreAudio device, binds that device to the engine input unit, and configures the input unit's client stream from the complete hardware input format before installing the tap.
 - `Core/Audio/AudioRecorder+Session.swift`
-  - Capture session/device lifecycle setup and teardown.
+  - Selected-device resolution plus capture-engine lifecycle setup and teardown.
 - `Core/Audio/AudioRecorder+Streaming.swift`
-  - Live sample conversion/downsampling, frame buffering, and quiet/dead/active waveform state updates.
+  - Deterministic all-channel summing with clipping protection, mono conversion/downsampling, frame buffering, and quiet/dead/active waveform state updates.
 - `Core/Audio/AudioRecorder+PostProcessing.swift`
   - Stop-time gap removal, normalization, capture classification, and final output frame selection.
 - `Core/Audio/AudioRecorder+Thresholds.swift`

--- a/macOS/Docs/ENGINEERING.md
+++ b/macOS/Docs/ENGINEERING.md
@@ -2,7 +2,7 @@
 
 This document contains implementation and maintainer-focused details that are intentionally kept out of the top-level README.
 
-**Last Updated: 2026-08-22**
+**Last Updated: 2026-09-05**
 
 ## Design Philosophy
 
@@ -32,7 +32,7 @@ KeyVox is organized by responsibility:
 - `Core/Transcription/`: Runtime state machine and macOS host-side transcription orchestration split across `TranscriptionManager.swift` plus focused extensions for bindings, recording sessions, and overlay/debug work. The reusable transcribe -> post-process -> paste boundary remains extracted into `Packages/KeyVoxCore/Sources/KeyVoxCore/Transcription/` (`DictationPipeline`, `TranscriptionPostProcessor`, `DictationPromptEchoGuard`). The macOS host owns capture/audio eligibility for dictionary hinting, while `KeyVoxCore` owns dictionary availability, prompt content, post-processing, and prompt-echo suppression for the persisted entries supplied by the host. The macOS host also persists the most recent successful transcription for Home-tab display after relaunch and publishes a per-successful-dictation revision for UI flows that must observe repeated identical dictations.
 - `Core/DictationTriggerController.swift`: Trigger-key orchestration that converts keyboard press/release/escape state into recording-session commands and hands consumed trigger+L/P chords to the formatting action controller without owning transcription or replacement behavior.
 - `Core/Vibes/`: Mac-owned KeyVox Vibes and latest-insertion change runtime. The Mac Vibes path uses a local GGUF rewrite model plus bundled LoRA adapters, not Foundation Models. `MacLocalRewriteModelManager` owns local model installation, `MacLocalRewriteInferenceService` owns cached local inference composition, `MacLocalStyleRewriteTextTransformer` bridges shared style rewrite requests to local inference, `MacVibesCoordinator` owns readiness-gated style resolution/prewarm/transform, `MacVibesIntroController` owns one-time intro eligibility, `MacVibesAccessMatrix` owns settings-state decisions, `MacDictationChangeController` owns latest untouched dictation Vibe and deterministic paragraph/list changes, `MacFormattingShortcutMonitor` owns safe chord interception, `MacFormattingTriggerActionController` owns formatting feedback/action orchestration, `MacVibesTriggerActionController` owns quick-tap orchestration and the Vibes trigger-key interaction toggle gate, and `MacTriggerTapClassifier` keeps single/double tap timing separate from recording orchestration.
-- `Core/Audio/`: Recording, stream processing, silence classification, and threshold policy.
+- `Core/Audio/`: Selected-device `AVAudioEngine` capture, deterministic multichannel-to-mono mixing, stream processing, silence classification, and threshold policy.
 - `Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/` and `Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/`: Deterministic dictionary correction and list parsing/rendering, with matcher evaluation strategies organized under `Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/` (`Helpers/`, `SplitJoin/`, and strategy files). `DictionaryMatcher+SpelledUppercaseGuard.swift` owns shared phonetic validation for uppercase dictionary sequences, while `DictionaryMatcher+ExactMultiTokenJoin.swift` owns exact three- and four-token joins into canonical single-entry replacements. `DictionaryInitialEntries.swift` defines the single `KeyVox` entry that a host may persist for a genuine fresh installation; matching itself uses only the entries supplied by the user dictionary.
 - `Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/`: Ordered pure normalization stages used by post-processing: early literal cleanup, pre-list normalization, late model-output cleanup, and final finishers. The individual passes remain small and composable, while the documented contract stays centered on stable ordering boundaries rather than every micro-pass. Shared normalization utilities (for example URL/domain/email-safe capitalization guards) also live here.
 - `Packages/KeyVoxTextComposition/`: Platform-neutral policy for composing finalized dictation with adjacent editor text. It owns leading capitalization, leading spacing, quote classification, sentence-boundary rules, adjacent terminal-punctuation decisions, and trailing-separator decisions, but never reads Accessibility state or performs insertion.
@@ -60,6 +60,15 @@ File-level ownership and locations are intentionally maintained in one place: [`
 - `TranscriptionManager+RecordingSession.swift` owns recording start/stop, formatting-chord recorder discard, transcription pipeline execution, paste insertion handoff, weekly word totals, and last-transcription persistence.
 - `TranscriptionManager+OverlayAndDebug.swift` owns overlay hands-free visual updates, playback sound effects, and debug-only transformation-speed logging.
 - `Core/DictationTriggerController.swift` owns trigger-key press/release handling, pending-stop behavior, deferred starts, hands-free toggles, and cancellation, and calls back into `TranscriptionManager` only for recording-session commands.
+
+### Audio Capture Contract
+
+- `AudioDeviceManager` remains the source of truth for microphone discovery, persisted selection, and the selected capture-device UID.
+- `AudioEngineInputCapture` resolves that UID to a CoreAudio device, binds it to the `AVAudioEngine` input unit, and configures output scope element 1 from the complete hardware input format before installing the tap. This prevents a multichannel interface from being reduced to an unrelated default channel before KeyVox receives audio.
+- Capture behavior is device-agnostic: there are no interface names, transport assumptions, fixed channel counts, or device-specific identifiers in the capture path.
+- `AudioRecorder+Streaming` sums every finite sample from every channel exposed by the selected input device into deterministic mono audio. The summed sample is clamped to the valid Float32 PCM range; KeyVox does not select, rank, or switch channels based on signal level.
+- Every simultaneously active input is therefore included. KeyVox intentionally treats the selected interface as one combined microphone instead of acting as an audio-routing application.
+- The combined stream is resampled to the existing mono Float32 16kHz recorder contract. Silence classification, normalization, transcription providers, and downstream text processing remain unchanged.
 
 ## Platform Compatibility
 

--- a/macOS/KeyVox.xcodeproj/project.pbxproj
+++ b/macOS/KeyVox.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		9D4000152F4E000100AA0001 /* AudioRecorder+Streaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4000062F4E000100AA0001 /* AudioRecorder+Streaming.swift */; };
 		9D4000162F4E000100AA0001 /* AudioRecorder+PostProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4000072F4E000100AA0001 /* AudioRecorder+PostProcessing.swift */; };
 		9D4000172F4E000100AA0001 /* AudioRecorder+Thresholds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4000082F4E000100AA0001 /* AudioRecorder+Thresholds.swift */; };
+		9D4000192F4E000100AA0001 /* AudioEngineInputCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4000092F4E000100AA0001 /* AudioEngineInputCapture.swift */; };
 		9E5000112F4F000100AA0001 /* AppSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5000012F4F000100AA0001 /* AppSettingsStore.swift */; };
 		A11000012FC1000100AA0001 /* WeeklyWordStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11000112FC1000100AA0001 /* WeeklyWordStatsStore.swift */; };
 		A11000022FC1000100AA0001 /* WeeklyWordStatsCloudSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11000122FC1000100AA0001 /* WeeklyWordStatsCloudSync.swift */; };
@@ -333,6 +334,7 @@
 		9D4000062F4E000100AA0001 /* AudioRecorder+Streaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioRecorder+Streaming.swift"; sourceTree = "<group>"; };
 		9D4000072F4E000100AA0001 /* AudioRecorder+PostProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioRecorder+PostProcessing.swift"; sourceTree = "<group>"; };
 		9D4000082F4E000100AA0001 /* AudioRecorder+Thresholds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioRecorder+Thresholds.swift"; sourceTree = "<group>"; };
+		9D4000092F4E000100AA0001 /* AudioEngineInputCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineInputCapture.swift; sourceTree = "<group>"; };
 		9E5000012F4F000100AA0001 /* AppSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStore.swift; sourceTree = "<group>"; };
 		A11000112FC1000100AA0001 /* WeeklyWordStatsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyWordStatsStore.swift; sourceTree = "<group>"; };
 		A11000122FC1000100AA0001 /* WeeklyWordStatsCloudSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyWordStatsCloudSync.swift; sourceTree = "<group>"; };
@@ -726,6 +728,7 @@
 		9D4000012F4E000100AA0001 /* Audio */ = {
 			isa = PBXGroup;
 			children = (
+				9D4000092F4E000100AA0001 /* AudioEngineInputCapture.swift */,
 				8E6D05CB2F3C51D6003BD458 /* AudioRecorder.swift */,
 				9D4000072F4E000100AA0001 /* AudioRecorder+PostProcessing.swift */,
 				9D4000052F4E000100AA0001 /* AudioRecorder+Session.swift */,
@@ -1293,6 +1296,7 @@
 				9D4000142F4E000100AA0001 /* AudioRecorder+Session.swift in Sources */,
 				9D4000152F4E000100AA0001 /* AudioRecorder+Streaming.swift in Sources */,
 				9D4000172F4E000100AA0001 /* AudioRecorder+Thresholds.swift in Sources */,
+				9D4000192F4E000100AA0001 /* AudioEngineInputCapture.swift in Sources */,
 				8EA1C1022F3D111100A1B2C3 /* AudioDeviceManager.swift in Sources */,
 				8E6D05DE2F3C523D003BD458 /* OnboardingView.swift in Sources */,
 				D50000112FF5000100AA0001 /* OnboardingWelcomeScreen.swift in Sources */,


### PR DESCRIPTION
## Summary

- Restore macOS dictation capture for multichannel audio interfaces
- Combine every exposed input channel into deterministic mono transcription audio
- Document the selected-device capture and mixing contract

## Behavior

- The selected microphone is bound to `AVAudioEngine` using its complete hardware input format
- Speech arriving on any channel exposed by the selected interface reaches the existing transcription pipeline
- All active channels are combined without channel ranking, switching, or device-specific routing

## Coverage

- Multichannel interfaces with speech on the first or another exposed channel
- Mono and stereo microphones through the same recorder path
- Silent multichannel input and clipping-safe combined input

## Validation

- Completed live capture and nonempty transcription through a connected 10-channel Thunderbolt interface
- Confirmed 78,208 accepted frames, speech RMS 0.10861, and no silence-rejection flags
- Verified deterministic ten-channel summing with multiple simultaneously active channels
- Passed focused `AudioRecorderStopRecordingTests`
- Built the macOS `KeyVox DEBUG` scheme successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated macOS audio capture to use the selected input device through the system audio engine.
  - Improved recording quality by combining multichannel input into a stable mono stream with clipping protection.
  - Audio recording can now restart cleanly when switching or reusing input devices.

- **Bug Fixes**
  - Recording failures are reported correctly, preventing the recording interface from proceeding when capture cannot start.
  - Improved shutdown handling prevents audio callbacks from continuing after recording stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->