### PR TITLE
fix(mac-overlay): match iOS audio response

### DIFF
--- a/macOS/Core/Audio/AudioEngineInputCapture.swift
+++ b/macOS/Core/Audio/AudioEngineInputCapture.swift
@@ -106,7 +106,7 @@ final class AudioEngineInputCapture {
         }
 
         let callbackGate = callbackGate
-        inputNode.installTap(onBus: 0, bufferSize: 1_024, format: inputFormat) { buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 512, format: inputFormat) { buffer, _ in
             callbackGate.performIfOpen {
                 guard let copiedBuffer = Self.copy(buffer) else { return }
                 deliveryQueue.async {

--- a/macOS/Core/Overlay/AudioIndicatorDriver.swift
+++ b/macOS/Core/Overlay/AudioIndicatorDriver.swift
@@ -47,8 +47,8 @@ final class AudioIndicatorDriver: ObservableObject {
         static let timerInterval: TimeInterval = AudioIndicatorDriver.animationFrameDuration
         static let meterPollInterval: TimeInterval = 1.0 / 30.0
         static let sampleFreshnessWindow: TimeInterval = 0.35
-        static let attackSmoothingRate: CGFloat = 15
-        static let decaySmoothingRate: CGFloat = 5
+        static let attackSmoothingRate: CGFloat = 25
+        static let decaySmoothingRate: CGFloat = 8
     }
 
     var sampleProvider: (() -> AudioIndicatorSample?)?


### PR DESCRIPTION
## Summary

- Makes the Mac recording overlay react to audio as quickly as the iOS indicator.
- Aligns Mac capture update density and visual response timing with iOS.

## Behavior

- Audio-level changes reach the Mac overlay in smaller capture intervals.
- Indicator bars rise and settle using the same response rates as iOS.
- Dictation capture and transcription behavior remain unchanged.

## Coverage

- Recording overlay response to incoming audio.
- Indicator attack and decay behavior.

## Validation

- Compared Mac capture and animation values directly with the iOS implementation.
- Focused Mac audio indicator suite passed: 6 tests, 0 failures.
- Verified the final two-file diff with no whitespace errors.