### PR TITLE
fix(mac-audio): prevent stalls after device changes

### DIFF
--- a/macOS/Core/Audio/AudioEngineInputCapture.swift
+++ b/macOS/Core/Audio/AudioEngineInputCapture.swift
@@ -68,9 +68,20 @@ final class AudioEngineInputCapture {
         guard var deviceID = Self.audioDeviceID(forUID: deviceUID) else {
             throw CaptureError.deviceNotFound
         }
-
-        let engine = AVAudioEngine()
-        let inputNode = engine.inputNode
+        let engine: AVAudioEngine
+        let inputNode: AVAudioInputNode
+        if let retainedEngine = self.engine, let retainedInputNode = self.inputNode {
+            callbackGate.closeAndWait()
+            retainedEngine.stop()
+            retainedInputNode.removeTap(onBus: 0)
+            retainedEngine.reset()
+            self.deviceUID = nil
+            engine = retainedEngine
+            inputNode = retainedInputNode
+        } else {
+            engine = AVAudioEngine()
+            inputNode = engine.inputNode
+        }
         guard let audioUnit = inputNode.audioUnit else {
             throw CaptureError.audioUnitUnavailable
         }

--- a/macOS/Core/Audio/AudioRecorder+Session.swift
+++ b/macOS/Core/Audio/AudioRecorder+Session.swift
@@ -45,14 +45,7 @@ extension AudioRecorder {
             self.liveInputSignalState = .dead
         }
 
-        let inputCapture: AudioEngineInputCapture
-        if let existingCapture = audioInputCapture,
-           existingCapture.deviceUID == device.uniqueID {
-            inputCapture = existingCapture
-        } else {
-            audioInputCapture?.stop()
-            inputCapture = AudioEngineInputCapture()
-        }
+        let inputCapture = audioInputCapture ?? AudioEngineInputCapture()
         do {
             try inputCapture.start(
                 deviceUID: device.uniqueID,


### PR DESCRIPTION
## Summary

- Prevent intermittent recording stalls after selecting a different microphone.
- Preserve multichannel interface capture and deterministic channel mixing.

## Behavior

- Device changes now rebind the existing stopped audio engine instead of creating a competing audio unit.
- Consecutive recordings on the same microphone continue to reuse the configured engine.
- Input selection and channel-mixing behavior remain unchanged.

## Coverage

- Repeated transitions between connected microphones.
- Consecutive stop-and-start recording sessions.
- Existing microphone discovery, ordering, and persisted-selection behavior.

## Validation

- Reproduced the original Core Audio device-binding failure with connected hardware.
- Completed two consecutive 24-transition hardware capture runs with audio buffers received on every recording.
- Passed 10 focused audio lifecycle and device-manager tests.
- Verified the macOS 13.5 deployment target remains unchanged.
