### PR TITLE
fix(mac-audio): defer input preparation until authorized

### DIFF
--- a/macOS/Core/Audio/AudioRecorder+Session.swift
+++ b/macOS/Core/Audio/AudioRecorder+Session.swift
@@ -4,6 +4,7 @@ import KeyVoxCore
 
 extension AudioRecorder {
     func prepareRecordingSession() {
+        guard AVCaptureDevice.authorizationStatus(for: .audio) == .authorized else { return }
         guard let device = resolvedRecordingDevice() else { return }
 
         captureQueue.async { [weak self] in


### PR DESCRIPTION
## Summary

- Prevent launch-time audio preparation from requesting microphone permission
- Preserve prepared first-capture behavior for previously authorized users

## Behavior

- New users reach the onboarding microphone step before macOS requests access
- Authorized users continue preparing the selected input during startup
- Existing microphone selection and capture behavior remain unchanged

## Coverage

- Launch with microphone permission undetermined
- Launch with microphone permission already authorized

## Validation

- Confirmed input preparation exits before device access when permission is not authorized
- Confirmed authorized startup preparation remains unchanged
- macOS app tests pass