### PR TITLE
fix(core): guard stylized matches at sentence starts

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -6,9 +6,9 @@ The format loosely follows Keep a Changelog and the package uses semantic versio
 
 ---
 
-## [1.2.8] - 2026-09-05
+## [1.2.8] - 2026-09-06
 
-Split stylized dictionary terms now remain singular when their own ending resembles a possessive sound, and punctuation no longer makes ordinary text look like a stylized dictionary match.
+Split stylized dictionary terms now remain singular when their own ending resembles a possessive sound, and sentence-start capitalization no longer makes ordinary text look like a stylized dictionary match.
 
 ### Includes
 
@@ -17,11 +17,12 @@ Split stylized dictionary terms now remain singular when their own ending resemb
 - Added regression coverage for singular stylized terms followed by nouns.
 - Required actual Unicode uppercase characters before enabling the internal-capitalization fallback for stylized dictionary entries.
 - Added regression coverage ensuring punctuation is not treated as uppercase evidence.
+- Recognized capitalization after every sentence boundary as sentence-start capitalization, preventing later sentences from enabling stylized dictionary fallback.
 - Preserved year references in counterfactual temporal clauses without treating them as grouped quantities.
 
 ### Notes
 
-- `1.2.8` tracks stricter possessive inference and internal-capitalization evidence for stylized dictionary matches in the shared Core engine.
+- `1.2.8` tracks stricter possessive inference and sentence-aware capitalization evidence for stylized dictionary matches in the shared Core engine.
 
 ---
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardCandidateScoring.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardCandidateScoring.swift
@@ -12,6 +12,7 @@ extension DictionaryMatcher {
         start: Int,
         tokenCount: Int,
         tokens: [Token],
+        text: String,
         candidates: [CompiledEntry],
         window: [Token],
         observedNormalized: String,
@@ -91,8 +92,11 @@ extension DictionaryMatcher {
                         || !isStylizedSingleTokenEntry(candidate)
                         || allowStylizedFallbackForCommonObservedToken(
                             token: window[0],
-                            tokenIndex: start,
-                            totalTokens: tokens.count
+                            isAtSentenceStartInMultiTokenText: isAtSentenceStartInMultiTokenText(
+                                tokenIndex: start,
+                                tokens: tokens,
+                                text: text
+                            )
                         )
                         || hasStrongStylizedTextEvidence(
                             observed: form.normalized,

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardEvaluation.swift
@@ -19,6 +19,7 @@ extension DictionaryMatcher {
             start: start,
             tokenCount: tokenCount,
             tokens: tokens,
+            text: text,
             candidates: candidates,
             window: window,
             observedNormalized: observedNormalized,
@@ -91,6 +92,7 @@ extension DictionaryMatcher {
             let commonWordGuardOutcome = requiresPeerSupportAfterStandardCommonWordGuard(
                 start: start,
                 tokens: tokens,
+                text: text,
                 window: window,
                 candidate: best,
                 candidatePhonetic: singleTokenEvaluation.candidatePhonetic,

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardSingleTokenEvaluation.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/DictionaryMatcher+StandardSingleTokenEvaluation.swift
@@ -52,8 +52,11 @@ extension DictionaryMatcher {
         let allowStylizedFallbackBySurface =
             allowStylizedFallbackForCommonObservedToken(
                 token: observedToken,
-                tokenIndex: start,
-                totalTokens: tokens.count
+                isAtSentenceStartInMultiTokenText: isAtSentenceStartInMultiTokenText(
+                    tokenIndex: start,
+                    tokens: tokens,
+                    text: text
+                )
             )
         let hasAdjacentTitlecaseContext = hasAdjacentTitlecasePhraseContext(
             tokenIndex: start,
@@ -222,6 +225,7 @@ extension DictionaryMatcher {
     func requiresPeerSupportAfterStandardCommonWordGuard(
         start: Int,
         tokens: [Token],
+        text: String,
         window: [Token],
         candidate: Candidate,
         candidatePhonetic: String,
@@ -236,8 +240,11 @@ extension DictionaryMatcher {
 
         let allowStylizedBySurface = allowStylizedFallbackForCommonObservedToken(
             token: window[0],
-            tokenIndex: start,
-            totalTokens: tokens.count
+            isAtSentenceStartInMultiTokenText: isAtSentenceStartInMultiTokenText(
+                tokenIndex: start,
+                tokens: tokens,
+                text: text
+            )
         )
         let hasStructuralContext = hasStructuralCommonWordBrandContext(
             tokenStart: start,

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationStylizedHelpers.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Language/Dictionary/Evaluation/Helpers/DictionaryMatcher+EvaluationStylizedHelpers.swift
@@ -175,8 +175,7 @@ extension DictionaryMatcher {
 
     func allowStylizedFallbackForCommonObservedToken(
         token: Token,
-        tokenIndex: Int,
-        totalTokens: Int
+        isAtSentenceStartInMultiTokenText: Bool
     ) -> Bool {
         guard let first = token.raw.unicodeScalars.first,
               first.properties.isUppercase else {
@@ -191,11 +190,21 @@ extension DictionaryMatcher {
         }
 
         // Avoid sentence-start capitalization false positives in prose.
-        if tokenIndex == 0, totalTokens > 1 {
+        if isAtSentenceStartInMultiTokenText {
             return false
         }
 
         return true
+    }
+
+    func isAtSentenceStartInMultiTokenText(
+        tokenIndex: Int,
+        tokens: [Token],
+        text: String
+    ) -> Bool {
+        guard tokens.count > 1 else { return false }
+        guard tokenIndex > 0 else { return true }
+        return hasSentenceBoundaryBetween(tokens[tokenIndex - 1], tokens[tokenIndex], in: text)
     }
 
     func hasStylizedLongPrefixTailGuardEvidence(

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherCoreLogicTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Language/Dictionary/DictionaryMatcherCoreLogicTests.swift
@@ -22,15 +22,76 @@ final class DictionaryMatcherCoreLogicTests: XCTestCase {
         XCTAssertFalse(
             matcher.allowStylizedFallbackForCommonObservedToken(
                 token: punctuationOnly,
-                tokenIndex: 0,
-                totalTokens: 2
+                isAtSentenceStartInMultiTokenText: true
             )
         )
         XCTAssertTrue(
             matcher.allowStylizedFallbackForCommonObservedToken(
                 token: actualInternalUppercase,
-                tokenIndex: 0,
-                totalTokens: 2
+                isAtSentenceStartInMultiTokenText: true
+            )
+        )
+    }
+
+    func testStylizedFallbackRejectsOrdinaryTitlecaseAtLaterSentenceStart() {
+        let matcher = makeMatcher()
+        let sentenceText = "Ζαζ. Α'α βαβ"
+        let tokens = [
+            DictionaryMatcher.Token(
+                raw: "Ζαζ",
+                normalized: "ζαζ",
+                range: NSRange(location: 0, length: 3),
+                phonetic: ""
+            ),
+            DictionaryMatcher.Token(
+                raw: "Α'α",
+                normalized: "α'α",
+                range: NSRange(location: 5, length: 3),
+                phonetic: ""
+            ),
+            DictionaryMatcher.Token(
+                raw: "βαβ",
+                normalized: "βαβ",
+                range: NSRange(location: 9, length: 3),
+                phonetic: ""
+            ),
+        ]
+
+        XCTAssertFalse(
+            matcher.allowStylizedFallbackForCommonObservedToken(
+                token: tokens[1],
+                isAtSentenceStartInMultiTokenText: matcher.isAtSentenceStartInMultiTokenText(
+                    tokenIndex: 1,
+                    tokens: tokens,
+                    text: sentenceText
+                )
+            )
+        )
+
+        let phraseText = "Ζαζ Α'α βαβ"
+        let phraseTokens = [
+            tokens[0],
+            DictionaryMatcher.Token(
+                raw: "Α'α",
+                normalized: "α'α",
+                range: NSRange(location: 4, length: 3),
+                phonetic: ""
+            ),
+            DictionaryMatcher.Token(
+                raw: "βαβ",
+                normalized: "βαβ",
+                range: NSRange(location: 8, length: 3),
+                phonetic: ""
+            ),
+        ]
+        XCTAssertTrue(
+            matcher.allowStylizedFallbackForCommonObservedToken(
+                token: phraseTokens[1],
+                isAtSentenceStartInMultiTokenText: matcher.isAtSentenceStartInMultiTokenText(
+                    tokenIndex: 1,
+                    tokens: phraseTokens,
+                    text: phraseText
+                )
             )
         )
     }
@@ -118,6 +179,7 @@ final class DictionaryMatcherCoreLogicTests: XCTestCase {
             start: 0,
             tokenCount: 1,
             tokens: tokens,
+            text: observed,
             candidates: candidates,
             window: [token],
             observedNormalized: token.normalized,


### PR DESCRIPTION
## Summary

- Recognize capitalization after every sentence boundary
- Prevent later sentence openings from enabling stylized dictionary fallback
- Preserve genuine mid-sentence stylized correction eligibility

## Behavior

- Ordinary title-cased words at the start of later sentences remain unchanged
- Internal-uppercase dictionary terms continue matching when supported by real casing evidence
- Existing single-token and mid-sentence matching behavior remains unchanged

## Coverage

- Stylized fallback at a sentence boundary after an earlier token
- Equivalent title-cased token inside a sentence
- Unicode uppercase and punctuation distinction

## Validation

- Confirmed the reported transcript remains unchanged with TORRAS present
- KeyVoxCore package suite passes: 554 tests
- git diff --check passes