### PR TITLE
feat(ios-speak): show install progress and refine settings

### DIFF
--- a/iOS/KeyVox iOS.xcodeproj/project.pbxproj
+++ b/iOS/KeyVox iOS.xcodeproj/project.pbxproj
@@ -716,7 +716,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Share/KeyVoxShare.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Share/Info.plist";
@@ -751,7 +751,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Share/KeyVoxShare.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Share/Info.plist";
@@ -785,7 +785,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Keyboard/KeyVoxKeyboard.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Keyboard/Info.plist";
@@ -819,7 +819,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Keyboard/KeyVoxKeyboard.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Keyboard/Info.plist";
@@ -856,7 +856,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Widget/KeyVox Widget.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Widget/Info.plist";
@@ -893,7 +893,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox Widget/KeyVox Widget.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "KeyVox Widget/Info.plist";
@@ -1053,7 +1053,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox iOS/KeyVoxiOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1098,7 +1098,7 @@
 				CODE_SIGN_ENTITLEMENTS = "KeyVox iOS/KeyVoxiOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = U7YT4DBC54;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTS.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTS.swift
@@ -126,8 +126,8 @@ extension HomeTabView {
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                         .opacity(showsPrimaryTTSStatusRow ? 1 : 0)
 
-                                    if let preparationPercentageText = ttsPreparationPercentageText {
-                                        Text(preparationPercentageText)
+                                    if let percentageText = ttsPrimaryStatusPercentageText {
+                                        Text(percentageText)
                                             .font(.appFont(14, variant: .medium))
                                             .foregroundStyle(.yellow)
                                             .opacity(showsPrimaryTTSStatusRow ? 1 : 0)

--- a/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
+++ b/iOS/KeyVox iOS/Views/HomeTabView/TTS/HomeTabView+TTSPresentation.swift
@@ -173,6 +173,24 @@ extension HomeTabView {
         showsTTSPreparationProgress ? ttsPreparationProgressLabel : nil
     }
 
+    var ttsInstallPercentageText: String? {
+        guard let activeTTSInstallState else { return nil }
+
+        let progress: Double
+        switch activeTTSInstallState {
+        case .downloading(let currentProgress), .installing(let currentProgress):
+            progress = currentProgress
+        case .notInstalled, .ready, .failed:
+            return nil
+        }
+
+        return "\(Int((progress * 100).rounded()))%"
+    }
+
+    var ttsPrimaryStatusPercentageText: String? {
+        ttsInstallPercentageText ?? ttsPreparationPercentageText
+    }
+
     var activeTTSInstallState: PocketTTSInstallState? {
         if pocketTTSModelManager.isSharedModelReady() == false {
             switch pocketTTSModelManager.sharedModelInstallState {

--- a/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView.swift
+++ b/iOS/KeyVox iOS/Views/SettingsTabView/SettingsTabView.swift
@@ -104,11 +104,11 @@ struct SettingsTabView: View {
             AppScrollScreen(additionalTopContentInset: AppScreenContentInset.tabPageTop) {
                 VStack(alignment: .leading, spacing: 16) {
                     sessionSection
-                    speakTimeoutSection
                     keyboardSection
                     audioSection
                     activeModelSection
                     vibesAISection
+                    speakTimeoutSection
                     ttsSection
                     rateAndReviewSection
                     supportSection


### PR DESCRIPTION
## Summary

- Show Speak download and installation progress on the Home card
- Move Speak Timeout directly above the Speak download card in Settings
- Advance iOS build metadata

## Behavior

- Speak displays one continuous percentage through download and installation
- Existing playback preparation progress remains unchanged
- Settings content and controls remain unchanged while the two Speak sections are grouped together

## Coverage

- Shared Speak engine and voice installation progress
- Download-to-install progress presentation
- Speak section ordering in Settings

## Validation

- Confirmed the final branch contains exactly three responsibility-based commits
- Reviewed the complete branch diff and each changed file
- git diff --check passes