### PR TITLE
fix(mac-vibes): preserve cursor for unchanged replacements

### DIFF
--- a/macOS/Core/Vibes/MacDictationChangeController.swift
+++ b/macOS/Core/Vibes/MacDictationChangeController.swift
@@ -115,14 +115,24 @@ final class MacDictationChangeController {
         }
 
         let displayedReplacementText = displayText(replacementText, for: session)
-        onReplacementStart(targetStyle)
-        guard await pasteService.replaceUntouchedInsertion(
-            session.currentText,
-            with: displayedReplacementText
-        ) else {
-            activeSession = nil
-            log("apply skipped reason=replace-failed")
-            return false
+        if displayedReplacementText != session.currentText {
+            onReplacementStart(targetStyle)
+            guard await pasteService.replaceUntouchedInsertion(
+                session.currentText,
+                with: displayedReplacementText
+            ) else {
+                activeSession = nil
+                log("apply skipped reason=replace-failed")
+                return false
+            }
+        } else {
+            guard await pasteService.currentTextMatchesUntouchedInsertion(session.currentText) else {
+                activeSession = nil
+                log("apply skipped reason=changed-before-no-op")
+                return false
+            }
+            onReplacementStart(targetStyle)
+            log("replacement skipped reason=unchanged")
         }
 
         session.currentText = displayedReplacementText


### PR DESCRIPTION
## Summary

- Preserve the cursor when applying or reverting Vibes produces unchanged text
- Keep Vibes style state and completion feedback synchronized

## Behavior

- Unchanged Vibes output no longer triggers a target-app text replacement
- The insertion is revalidated before committing the no-op style transition
- Changed Vibes output continues through the existing replacement path

## Coverage

- Vibes application and revert operations that resolve to identical displayed text
- Electron text editors that reposition the cursor after redundant accessibility replacement

## Validation

- Reviewed the no-op path against the established Lists and Paragraphs behavior
- Confirmed the staged diff contains only the Mac Vibes controller change
- `git diff --check` passes