### PR TITLE
fix(vibes): preserve question-shaped dotted times for iOS 27

### DIFF
--- a/Packages/KeyVoxStyleRewrite/CHANGELOG.md
+++ b/Packages/KeyVoxStyleRewrite/CHANGELOG.md
@@ -12,8 +12,9 @@ Deterministic dotted-time separator repair for Vibes rewrites.
 
 ### Includes
 
-- Corrected observed Whisper dotted-time output when a valid time-shaped value follows a grammatical preposition and ends its sentence or precedes an interjection.
-- Applied sentence-scoped detection so the correction works at any position in multi-sentence dictation.
+- Corrected observed Whisper dotted-time output in question-shaped sentences even when platform linguistic assets are unavailable.
+- Preserved a time separator already corrected by the Vibes model instead of restoring the original dotted form.
+- Applied sentence-scoped detection so the correction works at any position in multi-sentence dictation, including immediately before one trailing spoken word.
 - Preserved observed Whisper version numbers, decimals, and percentage decimals without hard-coded language vocabulary.
 - Added regression coverage for the observed Whisper outputs and multi-sentence placement.
 

--- a/Packages/KeyVoxStyleRewrite/Sources/KeyVoxStyleRewrite/OutputRepair/Repairs/NumberSeparatorEvidenceRepair.swift
+++ b/Packages/KeyVoxStyleRewrite/Sources/KeyVoxStyleRewrite/OutputRepair/Repairs/NumberSeparatorEvidenceRepair.swift
@@ -3,8 +3,12 @@ import NaturalLanguage
 
 struct NumberSeparatorEvidenceRepair {
     private static let dotSeparatedCandidatePattern = #"(?<![\w.])([1-9]|1[0-2])\.([0-5][0-9])(?![\w]|\.[\w])"#
+    private static let strongSentenceTerminalExpression = try? NSRegularExpression(
+        pattern: #"^\p{Sentence_Break=STerm}"#
+    )
 
     private static let maximumInterveningWordTokenCount = 4
+    private static let maximumTrailingWordTokenCount = 1
 
     private static let dateDetector: NSDataDetector? = try? NSDataDetector(
         types: NSTextCheckingResult.CheckingType.date.rawValue
@@ -24,7 +28,8 @@ struct NumberSeparatorEvidenceRepair {
             let hour = nsText.substring(with: match.range(at: 1))
             let minute = nsText.substring(with: match.range(at: 2))
             let decimal = "\(hour).\(minute)"
-            guard separatorEvidence.decimalSeparatedRuns.contains(decimal) else {
+            guard separatorEvidence.decimalSeparatedRuns.contains(decimal),
+                  !isStrongSentenceTerminatingCandidate(match: match, in: nsText as String) else {
                 return nil
             }
 
@@ -164,12 +169,16 @@ struct NumberSeparatorEvidenceRepair {
     }
 
     private func isTimeTerminatingAtCandidate(match: NSTextCheckingResult, in text: String) -> Bool {
-        guard let dateDetector = Self.dateDetector,
-              let candidateRange = Range(match.range, in: text) else {
+        guard let candidateRange = Range(match.range, in: text) else {
             return false
         }
 
-        if isDetectedTime(candidateRange: candidateRange, in: text, using: dateDetector) {
+        if let dateDetector = Self.dateDetector,
+           isDetectedTime(candidateRange: candidateRange, in: text, using: dateDetector) {
+            return true
+        }
+
+        if isStrongSentenceTerminatingCandidate(candidateRange: candidateRange, in: text) {
             return true
         }
 
@@ -180,11 +189,61 @@ struct NumberSeparatorEvidenceRepair {
             return true
         }
 
+        guard let dateDetector = Self.dateDetector else { return false }
         return isDetectedTimeAfterElidingInterveningWords(
             candidateRange: candidateRange,
             in: text,
             using: dateDetector
         )
+    }
+
+    private func isStrongSentenceTerminatingCandidate(
+        match: NSTextCheckingResult,
+        in text: String
+    ) -> Bool {
+        guard let candidateRange = Range(match.range, in: text) else {
+            return false
+        }
+
+        return isStrongSentenceTerminatingCandidate(candidateRange: candidateRange, in: text)
+    }
+
+    private func isStrongSentenceTerminatingCandidate(
+        candidateRange: Range<String.Index>,
+        in text: String
+    ) -> Bool {
+        let sentenceTokenizer = NLTokenizer(unit: .sentence)
+        sentenceTokenizer.string = text
+        let sentenceRange = sentenceTokenizer.tokenRange(at: candidateRange.lowerBound)
+
+        let trailingTokens = RepairTokenization.wordTokens(in: text).filter {
+            $0.range.lowerBound >= candidateRange.upperBound
+                && $0.range.lowerBound < sentenceRange.upperBound
+        }
+        guard trailingTokens.count <= Self.maximumTrailingWordTokenCount else {
+            return false
+        }
+
+        let terminalContextStart: String.Index
+        if let trailingToken = trailingTokens.first {
+            guard text[candidateRange.upperBound..<trailingToken.range.lowerBound].allSatisfy(\.isWhitespace) else {
+                return false
+            }
+            terminalContextStart = trailingToken.range.upperBound
+        } else {
+            terminalContextStart = candidateRange.upperBound
+        }
+
+        let terminalContext = String(text[terminalContextStart..<sentenceRange.upperBound])
+            .drop(while: \.isWhitespace)
+        guard !terminalContext.isEmpty,
+              let expression = Self.strongSentenceTerminalExpression else {
+            return false
+        }
+
+        let probe = String(terminalContext)
+        let probeRange = NSRange(probe.startIndex..<probe.endIndex, in: probe)
+        return expression.firstMatch(in: probe, options: [], range: probeRange) != nil
     }
 
     private func isPrepositionBoundTerminatingCandidate(

--- a/Packages/KeyVoxStyleRewrite/Tests/KeyVoxStyleRewriteTests/OutputRepair/NumberSeparatorEvidenceRepairTests.swift
+++ b/Packages/KeyVoxStyleRewrite/Tests/KeyVoxStyleRewriteTests/OutputRepair/NumberSeparatorEvidenceRepairTests.swift
@@ -48,6 +48,24 @@ final class NumberSeparatorEvidenceRepairTests: XCTestCase {
         XCTAssertEqual(output, "Can you meet me there at 5:30?")
     }
 
+    func testRewriteRepairRepairsObservedPolishedNoOpTerminalTime() {
+        let output = OutputRepair.repairModelOutput(
+            original: "Can you meet me there at 4.30?",
+            rewritten: "Can you meet me there at 4.30?"
+        )
+
+        XCTAssertEqual(output, "Can you meet me there at 4:30?")
+    }
+
+    func testRewriteRepairPreservesModelCorrectedObservedWhisperTerminalTime() {
+        let output = OutputRepair.repairModelOutput(
+            original: "Can you meet me there at 5.30?",
+            rewritten: "Can you meet me there at 5:30?"
+        )
+
+        XCTAssertEqual(output, "Can you meet me there at 5:30?")
+    }
+
     func testRewriteRepairRepairsObservedWhisperTimeAtAnySentencePosition() {
         let cases = [
             (


### PR DESCRIPTION
## Summary

- Preserve dotted time corrections produced by the Vibes model
- Deterministically correct question-shaped dotted times when linguistic evidence is unavailable
- Update the existing `KeyVoxStyleRewrite` `1.0.13` changelog entry with the resolved behavior

## Behavior

- A time-shaped dotted value in a strongly terminated question is corrected within its own sentence, including when followed by one trailing spoken word
- The correction works when the affected question appears first, in the middle, or last in multi-sentence dictation
- On iOS 27, the existing grammatical-evidence path did not reliably handle the observed TestFlight output. A standalone package-test reproduction also showed that linguistic assets can be unavailable to the test process, so question-shaped cases now use deterministic Unicode sentence structure instead.
- An inherently ambiguous question-shaped value, such as a terse version-number answer, may be interpreted as time; this previously reviewed edge remains intentionally accepted for the reversible Vibes feature until production evidence supports narrowing it
- Observed statement-form version numbers, measurements, and percentage decimals remain unchanged

## Investigation: iOS 27 NLTagger lexicalClass collapse

On-device instrumentation confirmed that iOS 27 (24A5430a) broke `NLTagger` `.lexicalClass` and `.lemma` for third-party apps on real hardware. A probe running inside the properly-signed KeyVox app on an iPhone Air produced the following results:

| Token | iOS 26.5 (23F77) | iOS 27.0 (24A5430a) |
|---|---|---|
| `at` | `Preposition` | `OtherWord` |
| `please` | `Interjection` | `OtherWord` |
| `uh` | `Interjection` | `OtherWord` |
| `running` (lemma) | `run` | `nil` |
| every other token | correct POS | `OtherWord` |

This is not selective preposition/interjection breakage — the entire model-backed tagging path returns `OtherWord` / `nil` on iOS 27. Rule-based schemes (`language`, `script`, sentence tokenization, punctuation) still work, which is why `NLTokenizer(unit: .sentence)` remains reliable.

`NLTagger.availableTagSchemes(for: .word, language: .english)` still reports `LexicalClass` and `Lemma` as available on iOS 27, so the standard availability guard cannot detect the failure. The schemes are reported as supported but produce no useful output.

`NSDataDetector` is unaffected and behaves identically across iOS 26.5, iOS 27, and macOS — it matches contextual phrases like "starts at 5.30" and "at 2.30 yesterday" but never bare "5.30?" in a question, so it was never the reliable signal for the question-shaped cases.

### Root cause

Runtime log capture on iOS 27 shows the `com.apple.linguisticdata` UnifiedAssetFramework sandbox-extension request denied with `SUCoreError 8113 "client is not entitled for specific message request"`. The POS model asset never resolves, so `.lexicalClass` and `.lemma` silently degrade. On iOS 26.5 the same app receives `getLocalPath ... exists: YES` and tags correctly.

`MobileAssetDaemon` in iOS 27 newly gates `com.apple.linguisticdata` behind `com.apple.MobileAsset.UAF.LinguisticData`, an entitlement string that does not exist in the iOS 26.5 `MobileAssetDaemon` and is not available to third-party developers. The NaturalLanguage framework version (114), the ContextualEmbeddingCatalog, and the linguistic-data model assets (`model.maxent`, `embedding.dat`) are byte-identical between iOS 26.5 and iOS 27, so the change is in the runtime asset-service gating layer, not the framework or assets.

Apple has not documented this change in any iOS 27 release note through Beta 8, has not provided a third-party entitlement, and has not flagged it as a known issue. This may be an iOS 27 beta bug rather than an intentional permanent change, but the deterministic fallback is required until Apple restores reliable model-backed tagging.

Tracked in #183.

## Coverage

- Casual output where the model already changes `5.30` to `5:30`
- Polished output where the model leaves `4.30` unchanged
- Terminal, trailing-word, and first/middle/last multi-sentence placement
- Regression cases for observed version, decimal measurement, and percentage outputs

## Validation

- iOS 27 `NumberSeparatorEvidenceRepairTests` pass with 11 tests and 0 failures
- Complete `KeyVoxStyleRewrite` package suite passes with 124 tests and 0 failures
- On-device probe confirmed the fallback is required on iOS 27 real hardware (iPhone Air, 24A5430a)
- `git diff --check` passes
