### PR TITLE
fix(vibes): preserve period-terminated time corrections on iOS 27

### DIFF
--- a/Packages/KeyVoxStyleRewrite/CHANGELOG.md
+++ b/Packages/KeyVoxStyleRewrite/CHANGELOG.md
@@ -14,6 +14,7 @@ Deterministic dotted-time separator repair for Vibes rewrites.
 
 - Corrected observed Whisper dotted-time output in question-shaped sentences even when platform linguistic assets are unavailable.
 - Preserved a time separator already corrected by the Vibes model instead of restoring the original dotted form.
+- Treated unavailable iOS 27 lexical tagging as ambiguous evidence instead of decimal evidence so period-terminated Vibes time corrections are not reverted.
 - Applied sentence-scoped detection so the correction works at any position in multi-sentence dictation, including immediately before one trailing spoken word.
 - Preserved observed Whisper version numbers, decimals, and percentage decimals without hard-coded language vocabulary.
 - Added regression coverage for the observed Whisper outputs and multi-sentence placement.

--- a/Packages/KeyVoxStyleRewrite/Sources/KeyVoxStyleRewrite/OutputRepair/Repairs/NumberSeparatorEvidenceRepair.swift
+++ b/Packages/KeyVoxStyleRewrite/Sources/KeyVoxStyleRewrite/OutputRepair/Repairs/NumberSeparatorEvidenceRepair.swift
@@ -2,6 +2,12 @@ import Foundation
 import NaturalLanguage
 
 struct NumberSeparatorEvidenceRepair {
+    private enum CandidateKind {
+        case time
+        case decimal
+        case ambiguous
+    }
+
     private static let dotSeparatedCandidatePattern = #"(?<![\w.])([1-9]|1[0-2])\.([0-5][0-9])(?![\w]|\.[\w])"#
     private static let strongSentenceTerminalExpression = try? NSRegularExpression(
         pattern: #"^\p{Sentence_Break=STerm}"#
@@ -13,6 +19,12 @@ struct NumberSeparatorEvidenceRepair {
     private static let dateDetector: NSDataDetector? = try? NSDataDetector(
         types: NSTextCheckingResult.CheckingType.date.rawValue
     )
+
+    private let taggedTokens: (String) -> [RepairTaggedToken]
+
+    init(taggedTokens: @escaping (String) -> [RepairTaggedToken] = RepairTokenization.taggedTokens(in:)) {
+        self.taggedTokens = taggedTokens
+    }
 
     func repair(original: String, rewritten: String) -> String {
         let separatorEvidence = numericSeparatorEvidence(in: original)
@@ -111,10 +123,13 @@ struct NumberSeparatorEvidenceRepair {
         ) { match, nsText in
             guard match.numberOfRanges == 3 else { return }
             let separatorRun = nsText.substring(with: match.range)
-            if isTimeTerminatingAtCandidate(match: match, in: nsText as String) {
+            switch candidateKind(match: match, in: nsText as String) {
+            case .time:
                 timeSeparatedRuns.insert(separatorRun)
-            } else {
+            case .decimal:
                 decimalSeparatedRuns.insert(separatorRun)
+            case .ambiguous:
+                break
             }
         }
 
@@ -168,33 +183,38 @@ struct NumberSeparatorEvidenceRepair {
         return decimalRuns
     }
 
-    private func isTimeTerminatingAtCandidate(match: NSTextCheckingResult, in text: String) -> Bool {
+    private func candidateKind(match: NSTextCheckingResult, in text: String) -> CandidateKind {
         guard let candidateRange = Range(match.range, in: text) else {
-            return false
+            return .decimal
         }
 
         if let dateDetector = Self.dateDetector,
            isDetectedTime(candidateRange: candidateRange, in: text, using: dateDetector) {
-            return true
+            return .time
         }
 
         if isStrongSentenceTerminatingCandidate(candidateRange: candidateRange, in: text) {
-            return true
+            return .time
         }
 
-        if isPrepositionBoundTerminatingCandidate(
+        let prepositionBound = isPrepositionBoundTerminatingCandidate(
             candidateRange: candidateRange,
             in: text
-        ) {
-            return true
+        )
+        if prepositionBound == true {
+            return .time
         }
 
-        guard let dateDetector = Self.dateDetector else { return false }
-        return isDetectedTimeAfterElidingInterveningWords(
-            candidateRange: candidateRange,
-            in: text,
-            using: dateDetector
-        )
+        if let dateDetector = Self.dateDetector,
+           isDetectedTimeAfterElidingInterveningWords(
+               candidateRange: candidateRange,
+               in: text,
+               using: dateDetector
+           ) {
+            return .time
+        }
+
+        return prepositionBound == nil ? .ambiguous : .decimal
     }
 
     private func isStrongSentenceTerminatingCandidate(
@@ -249,11 +269,16 @@ struct NumberSeparatorEvidenceRepair {
     private func isPrepositionBoundTerminatingCandidate(
         candidateRange: Range<String.Index>,
         in text: String
-    ) -> Bool {
+    ) -> Bool? {
         let sentenceTokenizer = NLTokenizer(unit: .sentence)
         sentenceTokenizer.string = text
         let sentenceRange = sentenceTokenizer.tokenRange(at: candidateRange.lowerBound)
-        let tokens = RepairTokenization.taggedTokens(in: text)
+        let tokens = taggedTokens(text)
+        guard tokens.contains(where: {
+            ($0.tag != nil && $0.tag != .otherWord) || $0.lemma != nil
+        }) else {
+            return nil
+        }
         guard let precedingToken = tokens.last(where: {
             $0.token.range.upperBound <= candidateRange.lowerBound
         }), precedingToken.tag == .preposition else {

--- a/Packages/KeyVoxStyleRewrite/Tests/KeyVoxStyleRewriteTests/OutputRepair/NumberSeparatorEvidenceRepairTests.swift
+++ b/Packages/KeyVoxStyleRewrite/Tests/KeyVoxStyleRewriteTests/OutputRepair/NumberSeparatorEvidenceRepairTests.swift
@@ -48,6 +48,16 @@ final class NumberSeparatorEvidenceRepairTests: XCTestCase {
         XCTAssertEqual(output, "Can you meet me there at 5:30?")
     }
 
+    func testRewriteRepairPreservesModelCorrectedPeriodTerminatedTimeWhenTaggingIsUnavailable() {
+        let repair = NumberSeparatorEvidenceRepair(taggedTokens: Self.unavailableTaggedTokens(in:))
+        let output = repair.repair(
+            original: "Tell John to meet me there at 5.30.",
+            rewritten: "Tell John to meet me there at 5:30."
+        )
+
+        XCTAssertEqual(output, "Tell John to meet me there at 5:30.")
+    }
+
     func testRewriteRepairRepairsObservedPolishedNoOpTerminalTime() {
         let output = OutputRepair.repairModelOutput(
             original: "Can you meet me there at 4.30?",
@@ -117,5 +127,11 @@ final class NumberSeparatorEvidenceRepairTests: XCTestCase {
         )
 
         XCTAssertEqual(output, "The rate is 5.30%.")
+    }
+
+    private static func unavailableTaggedTokens(in text: String) -> [RepairTaggedToken] {
+        RepairTokenization.wordTokens(in: text).map {
+            RepairTaggedToken(token: $0, tag: .otherWord, lemma: nil)
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Distinguish unavailable iOS 27 linguistic evidence from confirmed decimal evidence
- Preserve period-terminated time separators already corrected by the Vibes model
- Update the existing `KeyVoxStyleRewrite` `1.0.13` changelog entry with the follow-up compatibility behavior

## Behavior

- On iOS 27, `NLTagger` can return `OtherWord` for every lexical class and `nil` for every lemma while still reporting the schemes as available
- Dotted candidates are now classified as time, decimal, or ambiguous instead of treating every failed time classification as decimal evidence
- When linguistic tagging produces no useful evidence, a period-terminated source value such as `5.30` remains ambiguous, so deterministic output repair no longer reverts a model-corrected `5:30`
- Existing detector-backed, strong sentence-terminal, preposition-bound, elision, spoken-decimal, version, and percentage behavior remains unchanged

## Investigation: period-terminated correction reversal

Real-device logging showed Whisper and the deterministic post-processing pipeline retaining `Tell John to meet me there at 5.30.` before the Vibes rewrite. The Casual model correctly produced `Tell John to meet me there at 5:30.`, but output repair restored the dotted form because unavailable lexical evidence was represented as a negative time result and therefore recorded as decimal evidence.

The previous question-shaped fallback in #182 remains valid for `?` and `!`. This follow-up handles statement-form model corrections ending in `.` without broadening the Unicode terminal expression to `ATerm`, which would make ordinary period-terminated dotted values eligible as times.

The repair now detects the observed unusable tagging signature from actual token results rather than `availableTagSchemes`: if no token has a lexical class other than `OtherWord` and no token has a lemma, preposition evidence is unavailable. That unavailable state maps to ambiguous separator evidence and does not override the model.

Tracked in #183.

## Coverage

- Period-terminated Whisper source text where the Vibes model corrects `5.30` to `5:30`
- Injected iOS 27 tagging behavior where every token returns `OtherWord` and every lemma is unavailable
- Existing dotted-time, question-shaped, multi-sentence, version, decimal, and percentage regression coverage

## Validation

- Real-device validation confirmed the corrected `5:30` survives output repair on iOS 27
- Complete `KeyVoxStyleRewrite` package suite passes with 125 tests and 0 failures
- `git diff --check` passes

Generated with [Devin](https://devin.ai)