### PR TITLE
fix(mac-audio): stabilize Bluetooth microphone startup

### DIFF
--- a/macOS/Core/Audio/AudioEngineInputCapture.swift
+++ b/macOS/Core/Audio/AudioEngineInputCapture.swift
@@ -46,7 +46,6 @@ final class AudioEngineInputCapture {
     private var engine: AVAudioEngine?
     private var inputNode: AVAudioInputNode?
     private let callbackGate = AudioInputCallbackGate()
-    private(set) var deviceUID: String?
 
     func start(
         deviceUID: String,
@@ -74,11 +73,6 @@ final class AudioEngineInputCapture {
         deliveryQueue: DispatchQueue,
         bufferHandler: @escaping (AVAudioPCMBuffer) -> Void
     ) throws {
-        if let engine, self.deviceUID == deviceUID {
-            engine.prepare()
-            return
-        }
-
         guard var deviceID = Self.audioDeviceID(forUID: deviceUID) else {
             throw CaptureError.deviceNotFound
         }
@@ -89,7 +83,6 @@ final class AudioEngineInputCapture {
             retainedEngine.stop()
             retainedInputNode.removeTap(onBus: 0)
             retainedEngine.reset()
-            self.deviceUID = nil
             engine = retainedEngine
             inputNode = retainedInputNode
         } else {
@@ -142,7 +135,6 @@ final class AudioEngineInputCapture {
 
         self.engine = engine
         self.inputNode = inputNode
-        self.deviceUID = deviceUID
         engine.prepare()
     }
 

--- a/macOS/Core/Audio/AudioRecorder+Session.swift
+++ b/macOS/Core/Audio/AudioRecorder+Session.swift
@@ -6,6 +6,8 @@ extension AudioRecorder {
     func prepareRecordingSession() {
         guard AVCaptureDevice.authorizationStatus(for: .audio) == .authorized else { return }
         guard let device = resolvedRecordingDevice() else { return }
+        let deviceKind = AudioDeviceManager.shared.availableMicrophones.first(where: { $0.id == device.uniqueID })?.kind ?? .builtIn
+        guard deviceKind == .wiredOrOther else { return }
 
         captureQueue.async { [weak self] in
             self?.prepareInputCapture(for: device)
@@ -66,19 +68,13 @@ extension AudioRecorder {
             self.liveInputSignalState = .dead
         }
 
-        let didStartCapture = captureQueue.sync {
-            let inputCapture = audioInputCapture ?? AudioEngineInputCapture()
-            do {
-                try inputCapture.start(
-                    deviceUID: device.uniqueID,
-                    deliveryQueue: captureQueue
-                ) { [weak self] buffer in
-                    self?.processCapturedBuffer(buffer)
-                }
-                audioInputCapture = inputCapture
-                return true
-            } catch {
-                return false
+        let didStartCapture: Bool
+        switch currentDeviceKind {
+        case .builtIn, .airPods, .bluetooth:
+            didStartCapture = startAVCaptureSession(device: device)
+        case .wiredOrOther:
+            didStartCapture = captureQueue.sync {
+                startAudioEngineCapture(device: device)
             }
         }
         guard didStartCapture else {
@@ -97,13 +93,33 @@ extension AudioRecorder {
         guard !isStopFinalizationPending else { return }
 
         isStopFinalizationPending = true
-        audioInputCapture?.stop()
+        if captureSession == nil {
+            audioInputCapture?.stop()
+        }
         captureQueue.async { [weak self] in
             self?.finalizeStopRecordingSession(completion: completion)
         }
     }
 
     private func finalizeStopRecordingSession(completion: @escaping ([Float]) -> Void) {
+        if let captureSession {
+            audioCaptureOutput?.setSampleBufferDelegate(nil, queue: nil)
+            captureSession.beginConfiguration()
+            if let captureInput {
+                captureSession.removeInput(captureInput)
+            }
+            if let audioCaptureOutput {
+                captureSession.removeOutput(audioCaptureOutput)
+            }
+            captureSession.commitConfiguration()
+            captureSession.stopRunning()
+            self.captureSession = nil
+            captureInput = nil
+            audioCaptureOutput = nil
+        }
+
+        drainPendingCaptureQueueWork()
+
         converter = nil
         isRecording = false
         isStopFinalizationPending = false
@@ -114,10 +130,69 @@ extension AudioRecorder {
         }
     }
 
+    private func drainPendingCaptureQueueWork() {
+        guard DispatchQueue.getSpecific(key: captureQueueSpecificKey) != captureQueueSpecificValue else {
+            return
+        }
+        captureQueue.sync {}
+    }
+
     private func resolvedRecordingDevice() -> AVCaptureDevice? {
         AudioDeviceManager.shared.resolvedCaptureDevice()
             ?? AudioDeviceManager.shared.builtInCaptureDevice()
             ?? AVCaptureDevice.default(for: .audio)
             ?? Self.captureAudioDevices().first
+    }
+
+    private func startAVCaptureSession(device: AVCaptureDevice) -> Bool {
+        audioInputCapture?.stop()
+        audioInputCapture = nil
+
+        let session = AVCaptureSession()
+        session.beginConfiguration()
+
+        do {
+            let input = try AVCaptureDeviceInput(device: device)
+            guard session.canAddInput(input) else {
+                session.commitConfiguration()
+                return false
+            }
+            session.addInput(input)
+
+            let output = AVCaptureAudioDataOutput()
+            output.setSampleBufferDelegate(self, queue: captureQueue)
+            guard session.canAddOutput(output) else {
+                output.setSampleBufferDelegate(nil, queue: nil)
+                session.commitConfiguration()
+                return false
+            }
+            session.addOutput(output)
+            session.commitConfiguration()
+
+            captureSession = session
+            captureInput = input
+            audioCaptureOutput = output
+            session.startRunning()
+            return true
+        } catch {
+            session.commitConfiguration()
+            return false
+        }
+    }
+
+    private func startAudioEngineCapture(device: AVCaptureDevice) -> Bool {
+        let inputCapture = audioInputCapture ?? AudioEngineInputCapture()
+        do {
+            try inputCapture.start(
+                deviceUID: device.uniqueID,
+                deliveryQueue: captureQueue
+            ) { [weak self] buffer in
+                self?.processCapturedBuffer(buffer)
+            }
+            audioInputCapture = inputCapture
+            return true
+        } catch {
+            return false
+        }
     }
 }

--- a/macOS/Core/Audio/AudioRecorder+Streaming.swift
+++ b/macOS/Core/Audio/AudioRecorder+Streaming.swift
@@ -1,48 +1,53 @@
 import Foundation
 import AVFoundation
+import CoreMedia
 
-extension AudioRecorder {
+extension AudioRecorder: AVCaptureAudioDataOutputSampleBufferDelegate {
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        let frameCount = CMSampleBufferGetNumSamples(sampleBuffer)
+        guard frameCount > 0,
+              let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer),
+              let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription),
+              let sourceFormat = AVAudioFormat(streamDescription: streamDescription),
+              let sourceBuffer = AVAudioPCMBuffer(
+                  pcmFormat: sourceFormat,
+                  frameCapacity: AVAudioFrameCount(frameCount)
+              ) else {
+            return
+        }
+
+        sourceBuffer.frameLength = AVAudioFrameCount(frameCount)
+        let copyStatus = CMSampleBufferCopyPCMDataIntoAudioBufferList(
+            sampleBuffer,
+            at: 0,
+            frameCount: Int32(frameCount),
+            into: sourceBuffer.mutableAudioBufferList
+        )
+        guard copyStatus == noErr else { return }
+        processCapturedBuffer(sourceBuffer)
+    }
+
     func processCapturedBuffer(_ sourceBuffer: AVAudioPCMBuffer) {
         let frameCount = Int(sourceBuffer.frameLength)
         let channelCount = Int(sourceBuffer.format.channelCount)
         guard frameCount > 0,
               channelCount > 0,
-              sourceBuffer.format.commonFormat == .pcmFormatFloat32,
-              !sourceBuffer.format.isInterleaved,
-              let sourceChannels = sourceBuffer.floatChannelData,
-              let monoFormat = AVAudioFormat(
-                  commonFormat: .pcmFormatFloat32,
-                  sampleRate: sourceBuffer.format.sampleRate,
-                  channels: 1,
-                  interleaved: false
-              ),
-              let monoBuffer = AVAudioPCMBuffer(
-                  pcmFormat: monoFormat,
-                  frameCapacity: sourceBuffer.frameLength
-              ),
-              let monoChannel = monoBuffer.floatChannelData?[0] else {
+              let conversionInput = monoConversionInput(from: sourceBuffer) else {
             return
         }
 
-        monoBuffer.frameLength = sourceBuffer.frameLength
-        for frameIndex in 0..<frameCount {
-            var mixedSample: Float = 0
-            for channelIndex in 0..<channelCount {
-                let sample = sourceChannels[channelIndex][frameIndex]
-                if sample.isFinite {
-                    mixedSample += sample
-                }
-            }
-            monoChannel[frameIndex] = min(max(mixedSample, -1), 1)
-        }
-
-        if converter == nil || shouldRebuildConverter(for: monoFormat) {
-            converter = AVAudioConverter(from: monoFormat, to: outputFormat)
+        let inputFormat = conversionInput.format
+        if converter == nil || shouldRebuildConverter(for: inputFormat) {
+            converter = AVAudioConverter(from: inputFormat, to: outputFormat)
         }
 
         guard let converter else { return }
 
-        let outputCapacity = AVAudioFrameCount(Double(monoBuffer.frameLength) * outputFormat.sampleRate / monoFormat.sampleRate) + 1
+        let outputCapacity = AVAudioFrameCount(Double(conversionInput.frameLength) * outputFormat.sampleRate / inputFormat.sampleRate) + 1
         guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: outputCapacity) else { return }
 
         var conversionError: NSError?
@@ -54,7 +59,7 @@ extension AudioRecorder {
             }
             providedInput = true
             outStatus.pointee = .haveData
-            return monoBuffer
+            return conversionInput
         }
 
         guard conversionStatus != .error, convertedBuffer.frameLength > 0,
@@ -135,6 +140,44 @@ extension AudioRecorder {
                 self.liveInputSignalState = signalState
             }
         }
+    }
+
+    private func monoConversionInput(from sourceBuffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        let frameCount = Int(sourceBuffer.frameLength)
+        let channelCount = Int(sourceBuffer.format.channelCount)
+        if channelCount == 1 {
+            return sourceBuffer
+        }
+
+        guard sourceBuffer.format.commonFormat == .pcmFormatFloat32,
+              !sourceBuffer.format.isInterleaved,
+              let sourceChannels = sourceBuffer.floatChannelData,
+              let monoFormat = AVAudioFormat(
+                  commonFormat: .pcmFormatFloat32,
+                  sampleRate: sourceBuffer.format.sampleRate,
+                  channels: 1,
+                  interleaved: false
+              ),
+              let monoBuffer = AVAudioPCMBuffer(
+                  pcmFormat: monoFormat,
+                  frameCapacity: sourceBuffer.frameLength
+              ),
+              let monoChannel = monoBuffer.floatChannelData?[0] else {
+            return nil
+        }
+
+        monoBuffer.frameLength = sourceBuffer.frameLength
+        for frameIndex in 0..<frameCount {
+            var mixedSample: Float = 0
+            for channelIndex in 0..<channelCount {
+                let sample = sourceChannels[channelIndex][frameIndex]
+                if sample.isFinite {
+                    mixedSample += sample
+                }
+            }
+            monoChannel[frameIndex] = min(max(mixedSample, -1), 1)
+        }
+        return monoBuffer
     }
 
     private func shouldRebuildConverter(for inputFormat: AVAudioFormat) -> Bool {

--- a/macOS/Core/Audio/AudioRecorder.swift
+++ b/macOS/Core/Audio/AudioRecorder.swift
@@ -10,13 +10,22 @@ enum LiveInputSignalState: Equatable {
 }
 
 class AudioRecorder: NSObject, ObservableObject {
+    var captureSession: AVCaptureSession?
+    var captureInput: AVCaptureDeviceInput?
+    var audioCaptureOutput: AVCaptureAudioDataOutput?
     var audioInputCapture: AudioEngineInputCapture?
     var converter: AVAudioConverter?
     var isStopFinalizationPending = false
 
     var audioData: [Float] = []
     let audioDataQueue = DispatchQueue(label: "AudioRecorder.audioDataQueue")
-    let captureQueue = DispatchQueue(label: "AudioRecorder.captureQueue")
+    let captureQueueSpecificKey = DispatchSpecificKey<UInt8>()
+    let captureQueueSpecificValue: UInt8 = 1
+    lazy var captureQueue: DispatchQueue = {
+        let queue = DispatchQueue(label: "AudioRecorder.captureQueue")
+        queue.setSpecific(key: captureQueueSpecificKey, value: captureQueueSpecificValue)
+        return queue
+    }()
     // Recorder contract is still mono Float32 @ 16kHz for downstream transcription.
     let outputFormat = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)!
     let normalizationTargetPeak: Float = 0.9

--- a/macOS/Core/Audio/MacSoundCuePlayer.swift
+++ b/macOS/Core/Audio/MacSoundCuePlayer.swift
@@ -1,0 +1,45 @@
+import AVFoundation
+import Foundation
+
+@MainActor
+final class MacSoundCuePlayer: NSObject, AVAudioPlayerDelegate {
+    private var activePlayers: [ObjectIdentifier: AVAudioPlayer] = [:]
+
+    func play(named name: String, volume: Float) {
+        let url = URL(fileURLWithPath: "/System/Library/Sounds")
+            .appendingPathComponent(name)
+            .appendingPathExtension("aiff")
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return
+        }
+
+        let player: AVAudioPlayer
+        do {
+            player = try AVAudioPlayer(contentsOf: url)
+        } catch {
+            return
+        }
+
+        player.delegate = self
+        player.volume = volume
+        player.prepareToPlay()
+        let identifier = ObjectIdentifier(player)
+        activePlayers[identifier] = player
+        guard player.play() else {
+            activePlayers.removeValue(forKey: identifier)
+            return
+        }
+    }
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor [weak self] in
+            self?.activePlayers.removeValue(forKey: ObjectIdentifier(player))
+        }
+    }
+
+    nonisolated func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
+        Task { @MainActor [weak self] in
+            self?.activePlayers.removeValue(forKey: ObjectIdentifier(player))
+        }
+    }
+}

--- a/macOS/Core/Transcription/TranscriptionManager+OverlayAndDebug.swift
+++ b/macOS/Core/Transcription/TranscriptionManager+OverlayAndDebug.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 import KeyVoxCore
 
@@ -15,10 +14,10 @@ extension TranscriptionManager {
 
     func playSound(named name: String) {
         guard appSettings.isSoundEnabled else { return }
-        if let sound = NSSound(named: name) {
-            sound.volume = Float(appSettings.soundVolume)
-            sound.play()
-        }
+        soundCuePlayer.play(
+            named: name,
+            volume: Float(appSettings.soundVolume)
+        )
     }
 
     #if DEBUG

--- a/macOS/Core/Transcription/TranscriptionManager.swift
+++ b/macOS/Core/Transcription/TranscriptionManager.swift
@@ -36,6 +36,7 @@ class TranscriptionManager: ObservableObject {
     let weeklyWordStatsStore: WeeklyWordStatsStore
     let postProcessor: TranscriptionPostProcessor
     let vibesCoordinator: MacVibesCoordinator
+    let soundCuePlayer = MacSoundCuePlayer()
     lazy var dictationChangeController = MacDictationChangeController(
         vibesCoordinator: vibesCoordinator
     )

--- a/macOS/KeyVox.xcodeproj/project.pbxproj
+++ b/macOS/KeyVox.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		9D4000162F4E000100AA0001 /* AudioRecorder+PostProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4000072F4E000100AA0001 /* AudioRecorder+PostProcessing.swift */; };
 		9D4000172F4E000100AA0001 /* AudioRecorder+Thresholds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4000082F4E000100AA0001 /* AudioRecorder+Thresholds.swift */; };
 		9D4000192F4E000100AA0001 /* AudioEngineInputCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4000092F4E000100AA0001 /* AudioEngineInputCapture.swift */; };
+		9D40001C2F4E000100AA0001 /* MacSoundCuePlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D40000B2F4E000100AA0001 /* MacSoundCuePlayer.swift */; };
 		9E5000112F4F000100AA0001 /* AppSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5000012F4F000100AA0001 /* AppSettingsStore.swift */; };
 		A11000012FC1000100AA0001 /* WeeklyWordStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11000112FC1000100AA0001 /* WeeklyWordStatsStore.swift */; };
 		A11000022FC1000100AA0001 /* WeeklyWordStatsCloudSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11000122FC1000100AA0001 /* WeeklyWordStatsCloudSync.swift */; };
@@ -335,6 +336,7 @@
 		9D4000072F4E000100AA0001 /* AudioRecorder+PostProcessing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioRecorder+PostProcessing.swift"; sourceTree = "<group>"; };
 		9D4000082F4E000100AA0001 /* AudioRecorder+Thresholds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioRecorder+Thresholds.swift"; sourceTree = "<group>"; };
 		9D4000092F4E000100AA0001 /* AudioEngineInputCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioEngineInputCapture.swift; sourceTree = "<group>"; };
+		9D40000B2F4E000100AA0001 /* MacSoundCuePlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacSoundCuePlayer.swift; sourceTree = "<group>"; };
 		9E5000012F4F000100AA0001 /* AppSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStore.swift; sourceTree = "<group>"; };
 		A11000112FC1000100AA0001 /* WeeklyWordStatsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyWordStatsStore.swift; sourceTree = "<group>"; };
 		A11000122FC1000100AA0001 /* WeeklyWordStatsCloudSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyWordStatsCloudSync.swift; sourceTree = "<group>"; };
@@ -729,6 +731,7 @@
 			isa = PBXGroup;
 			children = (
 				9D4000092F4E000100AA0001 /* AudioEngineInputCapture.swift */,
+				9D40000B2F4E000100AA0001 /* MacSoundCuePlayer.swift */,
 				8E6D05CB2F3C51D6003BD458 /* AudioRecorder.swift */,
 				9D4000072F4E000100AA0001 /* AudioRecorder+PostProcessing.swift */,
 				9D4000052F4E000100AA0001 /* AudioRecorder+Session.swift */,
@@ -1297,6 +1300,7 @@
 				9D4000152F4E000100AA0001 /* AudioRecorder+Streaming.swift in Sources */,
 				9D4000172F4E000100AA0001 /* AudioRecorder+Thresholds.swift in Sources */,
 				9D4000192F4E000100AA0001 /* AudioEngineInputCapture.swift in Sources */,
+				9D40001C2F4E000100AA0001 /* MacSoundCuePlayer.swift in Sources */,
 				8EA1C1022F3D111100A1B2C3 /* AudioDeviceManager.swift in Sources */,
 				8E6D05DE2F3C523D003BD458 /* OnboardingView.swift in Sources */,
 				D50000112FF5000100AA0001 /* OnboardingWelcomeScreen.swift in Sources */,


### PR DESCRIPTION
## Summary

- Restore reliable recording when built-in and Bluetooth microphones change between 24 kHz and 48 kHz formats
- Reduce application-added AirPods microphone startup delay without removing or muting any sound cues
- Preserve multichannel microphone and audio-interface support through the dedicated audio-engine path

## Behavior

- Built-in, AirPods, and other Bluetooth microphones now use an `AVCaptureSession` capture path that tolerates their dynamic hardware format changes
- Wired and other audio interfaces continue using `AVAudioEngine`, retaining multichannel input capture and channel mixing for transcription
- Audio-engine preparation now rebuilds the tap against the current hardware format instead of reusing a tap configured for an earlier sample rate
- Repeated captures drain queued audio work before finalizing so late buffers are included safely and cannot leak into the next recording
- Captured input from both backends still flows through the same mono 16 kHz conversion, metering, silence detection, and transcription pipeline
- Existing Morse, Frog, and Bottle cues remain enabled and honor the configured sound volume
- Sound cues now use retained `AVAudioPlayer` instances rather than `NSSound`, removing the additional cue-related delay observed before AirPods input became active
- The normal macOS Bluetooth microphone cold-start cost remains possible and continues to be communicated by the existing AirPods microphone warning
- Temporary route, timing, buffer, trigger, and sound diagnostics used during investigation were removed before delivery

## Coverage

- Repeated trigger-key recording with an AirPods microphone selected
- Switching between the MacBook microphone and an AirPods microphone
- Hardware input transitions between 24 kHz and 48 kHz without a stale engine tap
- Built-in, AirPods, generic Bluetooth, and wired or multichannel device routing
- Multichannel Float32 non-interleaved input mixed into the mono transcription contract
- Single-channel capture delivered directly into the shared conversion pipeline
- Start and stop behavior across both capture backends, including queued-buffer draining
- Enabled and disabled sound cues with the existing volume preference

## Validation

- Confirmed repeated AirPods microphone activation no longer incurs the previous application-added sound playback delay
- Confirmed microphone levels and capture behavior remain consistent when moving between built-in and AirPods inputs
- Confirmed all original sound cues remain audible and unchanged in selection
- Confirmed the multichannel audio-engine route and channel-mixing implementation remain present
- Ran the complete macOS `KeyVox DEBUG` test suite: 401 tests passed with 0 failures
- Verified the final project builds successfully as part of the test run
- Verified the final diff contains no whitespace errors or temporary diagnostic hooks