### PR TITLE
fix(ios-audio): adopt iOS 27 audio session APIs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,7 @@ jobs:
         run: Tools/Quality/check_core_coverage.sh /tmp/keyvox-tests.xcresult
 
   ios-app-tests:
-    runs-on: macos-26
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
+    runs-on: xcode-27
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/iOS/KeyVox iOS/App/iCloud/KeyVoxPlaybackVoice.swift
+++ b/iOS/KeyVox iOS/App/iCloud/KeyVoxPlaybackVoice.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum KeyVoxPlaybackVoice: String, CaseIterable, Identifiable, Codable {
+enum KeyVoxPlaybackVoice: String, CaseIterable, Identifiable, Codable, Sendable {
     case alba
     case azelma
     case cosette

--- a/iOS/KeyVox iOS/Core/Audio/AudioRecorder+AudioSessionActivation.swift
+++ b/iOS/KeyVox iOS/Core/Audio/AudioRecorder+AudioSessionActivation.swift
@@ -1,0 +1,79 @@
+import AVFoundation
+import Foundation
+
+extension AudioRecorder {
+    func configureAudioSessionForRecording() async throws {
+        try await performAudioSessionOperation { audioSession in
+            try audioSession.setCategory(
+                .playAndRecord,
+                mode: .default,
+                options: [.defaultToSpeaker, .mixWithOthers, .allowBluetoothHFP]
+            )
+            try audioSession.setAllowHapticsAndSystemSoundsDuringRecording(true)
+        }
+    }
+
+    func activateAudioSession() async throws {
+        if #available(iOS 27.0, *) {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                audioSession.activate(options: []) { activated, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else if activated {
+                        continuation.resume()
+                    } else {
+                        continuation.resume(
+                            throwing: AudioRecorderError.engineStartFailed(
+                                underlying: CocoaError(.featureUnsupported)
+                            )
+                        )
+                    }
+                }
+            }
+        } else {
+            try await performAudioSessionOperation { audioSession in
+                try audioSession.setActive(true)
+            }
+        }
+    }
+
+    func deactivateAudioSession() async throws {
+        if #available(iOS 27.0, *) {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                audioSession.deactivate(options: []) { deactivated, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else if deactivated {
+                        continuation.resume()
+                    } else {
+                        continuation.resume(
+                            throwing: AudioRecorderError.engineStopFailed(
+                                underlying: CocoaError(.featureUnsupported)
+                            )
+                        )
+                    }
+                }
+            }
+        } else {
+            try await performAudioSessionOperation { audioSession in
+                try audioSession.setActive(false)
+            }
+        }
+    }
+
+    private func performAudioSessionOperation(
+        _ operation: @escaping @Sendable (AVAudioSession) throws -> Void
+    ) async throws {
+        let audioSession = audioSession
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    try operation(audioSession)
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/iOS/KeyVox iOS/Core/Audio/AudioRecorder+Session.swift
+++ b/iOS/KeyVox iOS/Core/Audio/AudioRecorder+Session.swift
@@ -79,7 +79,7 @@ extension AudioRecorder {
             throw AudioRecorderError.microphonePermissionDenied
         }
 
-        try ensureEngineRunning()
+        try await ensureEngineRunning()
     }
 
     func repairMonitoringAfterPlayback() async throws {
@@ -99,13 +99,13 @@ extension AudioRecorder {
         for (attemptIndex, delay) in recoveryDelays.enumerated() {
             if delay > 0 {
                 invalidateAudioEngine(clearSessionActive: true)
-                deactivateAudioSessionForRouteRecovery()
+                await deactivateAudioSessionForRouteRecovery()
                 try? await Task.sleep(nanoseconds: delay)
                 refreshCurrentCaptureDeviceName()
             }
 
             do {
-                try ensureEngineRunning()
+                try await ensureEngineRunning()
                 lastError = nil
                 break
             } catch {
@@ -125,7 +125,7 @@ extension AudioRecorder {
         }
     }
 
-    func ensureEngineRunning() throws {
+    func ensureEngineRunning() async throws {
         guard !isMonitoring || audioEngine == nil || !audioEngine!.isRunning else { return }
 
         let routeInputPorts = audioSession.currentRoute.inputs
@@ -141,25 +141,18 @@ extension AudioRecorder {
 
         // Set up audio session for background persistence
         do {
-            try audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .mixWithOthers, .allowBluetoothHFP])
+            try await configureAudioSessionForRecording()
             Self.log("setCategory(playAndRecord) succeeded")
-        } catch {
-            Self.log("setCategory(playAndRecord) failed error=\(error.localizedDescription)")
-            throw error
-        }
-
-        do {
-            try audioSession.setAllowHapticsAndSystemSoundsDuringRecording(true)
             Self.log("setAllowHapticsAndSystemSoundsDuringRecording(true) succeeded")
         } catch {
-            Self.log("setAllowHapticsAndSystemSoundsDuringRecording(true) failed error=\(error.localizedDescription)")
+            Self.log("configureAudioSessionForRecording failed error=\(error.localizedDescription)")
             throw error
         }
         // Keep the hardware route's native sample rate. Bluetooth HFP routes can reject
         // a forced 16 kHz preference, and we already convert captured audio into the
         // recorder's 16 kHz output format downstream.
         do {
-            try audioSession.setActive(true)
+            try await activateAudioSession()
             let activeRouteInputPorts = audioSession.currentRoute.inputs
                 .map { $0.portType.rawValue }
                 .joined(separator: ",")
@@ -255,7 +248,7 @@ extension AudioRecorder {
         KeyVoxIPCBridge.setSessionActive()
     }
 
-    func stopMonitoring(keepAudioSessionActive: Bool = false) throws {
+    func stopMonitoring(keepAudioSessionActive: Bool = false) async throws {
         guard isMonitoring else { return }
         guard !isRecording else {
             throw AudioRecorderError.monitoringShutdownWhileRecording
@@ -265,7 +258,7 @@ extension AudioRecorder {
 
         if keepAudioSessionActive == false {
             do {
-                try audioSession.setActive(false)
+                try await deactivateAudioSession()
             } catch {
                 throw AudioRecorderError.engineStopFailed(underlying: error)
             }
@@ -297,13 +290,13 @@ extension AudioRecorder {
         for (attemptIndex, delay) in recoveryDelays.enumerated() {
             if delay > 0 {
                 invalidateAudioEngine(clearSessionActive: true)
-                deactivateAudioSessionForRouteRecovery()
+                await deactivateAudioSessionForRouteRecovery()
                 try await Task.sleep(nanoseconds: delay)
                 refreshCurrentCaptureDeviceName()
             }
 
             do {
-                try ensureEngineRunning()
+                try await ensureEngineRunning()
                 try applyInputPreference()
                 lastError = nil
                 break
@@ -389,16 +382,18 @@ extension AudioRecorder {
             "handleMonitoringInterruption routeInputs=\(String(audioSession.currentRoute.inputs.count)) engineRunning=\(String(audioEngine?.isRunning == true))"
         )
         invalidateAudioEngine(clearSessionActive: true)
-        deactivateAudioSessionForRouteRecovery()
+        Task { [weak self] in
+            await self?.deactivateAudioSessionForRouteRecovery()
+        }
         refreshCurrentCaptureDeviceName()
         audioSessionInterruptedHandler?()
     }
 
-    func deactivateAudioSessionForRouteRecovery() {
+    func deactivateAudioSessionForRouteRecovery() async {
         // The session may already be transitioning during a route change, but recovery
         // should continue with a fresh engine either way.
         Self.log("deactivateAudioSessionForRouteRecovery")
-        try? audioSession.setActive(false)
+        try? await deactivateAudioSession()
     }
 
     private func shouldRetryRecordingStartAfterRouteTransition(for error: Error) -> Bool {

--- a/iOS/KeyVox iOS/Core/Audio/AudioRecorder+Session.swift
+++ b/iOS/KeyVox iOS/Core/Audio/AudioRecorder+Session.swift
@@ -126,6 +126,7 @@ extension AudioRecorder {
     }
 
     func ensureEngineRunning() async throws {
+        await awaitRouteRecoveryAudioSessionDeactivation()
         guard !isMonitoring || audioEngine == nil || !audioEngine!.isRunning else { return }
 
         let routeInputPorts = audioSession.currentRoute.inputs
@@ -382,11 +383,22 @@ extension AudioRecorder {
             "handleMonitoringInterruption routeInputs=\(String(audioSession.currentRoute.inputs.count)) engineRunning=\(String(audioEngine?.isRunning == true))"
         )
         invalidateAudioEngine(clearSessionActive: true)
-        Task { [weak self] in
-            await self?.deactivateAudioSessionForRouteRecovery()
-        }
+        scheduleAudioSessionDeactivationForRouteRecovery()
         refreshCurrentCaptureDeviceName()
         audioSessionInterruptedHandler?()
+    }
+
+    func scheduleAudioSessionDeactivationForRouteRecovery() {
+        guard routeRecoveryAudioSessionDeactivationTask == nil else { return }
+        routeRecoveryAudioSessionDeactivationTask = Task { @MainActor [weak self] in
+            await self?.deactivateAudioSessionForRouteRecovery()
+        }
+    }
+
+    func awaitRouteRecoveryAudioSessionDeactivation() async {
+        guard let routeRecoveryAudioSessionDeactivationTask else { return }
+        await routeRecoveryAudioSessionDeactivationTask.value
+        self.routeRecoveryAudioSessionDeactivationTask = nil
     }
 
     func deactivateAudioSessionForRouteRecovery() async {

--- a/iOS/KeyVox iOS/Core/Audio/AudioRecorder+StopPipeline.swift
+++ b/iOS/KeyVox iOS/Core/Audio/AudioRecorder+StopPipeline.swift
@@ -106,7 +106,9 @@ extension AudioRecorder {
         )
 
         invalidateAudioEngine(clearSessionActive: true)
-        deactivateAudioSessionForRouteRecovery()
+        Task { [weak self] in
+            await self?.deactivateAudioSessionForRouteRecovery()
+        }
         isRecording = false
         captureStartedAt = .distantPast
         apply(stopResult: interruptedCapture, hadNonDeadSignal: snapshot.hadNonDeadSignal)

--- a/iOS/KeyVox iOS/Core/Audio/AudioRecorder+StopPipeline.swift
+++ b/iOS/KeyVox iOS/Core/Audio/AudioRecorder+StopPipeline.swift
@@ -106,9 +106,7 @@ extension AudioRecorder {
         )
 
         invalidateAudioEngine(clearSessionActive: true)
-        Task { [weak self] in
-            await self?.deactivateAudioSessionForRouteRecovery()
-        }
+        scheduleAudioSessionDeactivationForRouteRecovery()
         isRecording = false
         captureStartedAt = .distantPast
         apply(stopResult: interruptedCapture, hadNonDeadSignal: snapshot.hadNonDeadSignal)

--- a/iOS/KeyVox iOS/Core/Audio/AudioRecorder.swift
+++ b/iOS/KeyVox iOS/Core/Audio/AudioRecorder.swift
@@ -21,8 +21,8 @@ protocol AudioRecording: AnyObject {
     func repairMonitoringAfterPlayback() async throws
     func startRecording() async throws
     func stopRecording() async -> StoppedCapture
-    func ensureEngineRunning() throws
-    func stopMonitoring(keepAudioSessionActive: Bool) throws
+    func ensureEngineRunning() async throws
+    func stopMonitoring(keepAudioSessionActive: Bool) async throws
     func cancelCurrentUtterance()
 }
 

--- a/iOS/KeyVox iOS/Core/Audio/AudioRecorder.swift
+++ b/iOS/KeyVox iOS/Core/Audio/AudioRecorder.swift
@@ -73,6 +73,7 @@ final class AudioRecorder: ObservableObject, AudioRecording {
     var audioSessionInterruptedHandler: (() -> Void)?
     var engineConfigurationObserver: NSObjectProtocol?
     var audioSessionInterruptionObserver: NSObjectProtocol?
+    var routeRecoveryAudioSessionDeactivationTask: Task<Void, Never>?
 
     init(
         audioSession: AVAudioSession = .sharedInstance(),

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadJob.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSBackgroundDownloadJob.swift
@@ -98,7 +98,7 @@ struct PocketTTSBackgroundDownloadJob: Codable, Equatable, Sendable {
     }
 }
 
-extension PocketTTSInstallTarget: Codable, Sendable {
+extension PocketTTSInstallTarget: Codable {
     private enum CodingKeys: String, CodingKey {
         case kind
         case voice

--- a/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/PocketTTSModelManager.swift
@@ -24,7 +24,7 @@ enum PocketTTSInstallState: Equatable {
     }
 }
 
-enum PocketTTSInstallTarget: Equatable {
+enum PocketTTSInstallTarget: Equatable, Sendable {
     case sharedModel
     case voice(AppSettingsStore.TTSVoice)
 }

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+AppLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+AppLifecycle.swift
@@ -25,6 +25,14 @@ extension TTSManager {
 
     func handleAppDidBecomeActive() {
         KeyVoxIPCBridge.touchHeartbeat()
+        // iOS 27 seed 1 can report active during device lock; retest without this guard in later betas.
+        if isProtectedDataLockTransitionActive,
+           state == .playing,
+           isPlaybackPaused == false,
+           isReplayingCachedPlayback == false {
+            Self.log("Skipping foreground TTS restore during protected-data lock transition.")
+            return
+        }
         hasRequestedFastModeBackgroundContinuation = false
         requestImmediateForegroundSynthesis()
         playbackCoordinator.prepareForForegroundPlayback()
@@ -130,6 +138,7 @@ extension TTSManager {
 
     @objc
     func handleProtectedDataWillBecomeUnavailableNotification(_ notification: Notification) {
+        isProtectedDataLockTransitionActive = true
         let isActiveLiveGeneration =
             state == .playing
             && isPlaybackPaused == false
@@ -163,6 +172,7 @@ extension TTSManager {
 
     @objc
     func handleProtectedDataDidBecomeAvailableNotification(_ notification: Notification) {
+        isProtectedDataLockTransitionActive = false
         Self.log(
             "Protected data did become available state=\(state.rawValue) paused=\(isPlaybackPaused) replaying=\(isReplayingCachedPlayback)"
         )

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+AppLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+AppLifecycle.swift
@@ -274,7 +274,9 @@ extension TTSManager {
             isPlaybackPaused = false
             dismissPlaybackPreparationView()
             beginBackgroundTaskIfNeeded()
-            playbackCoordinator.replayLastPlayback(startingAtSample: resumeOffset, shouldAutoplay: true)
+            Task { @MainActor [weak self] in
+                await self?.playbackCoordinator.replayLastPlayback(startingAtSample: resumeOffset, shouldAutoplay: true)
+            }
         default:
             break
         }

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+Playback.swift
@@ -110,7 +110,7 @@ extension TTSManager {
                 voiceID: request.voiceID,
                 fastModeEnabled: settingsStore.fastPlaybackModeEnabled
             )
-            playbackCoordinator.play(stream, fastModeEnabled: settingsStore.fastPlaybackModeEnabled)
+            await playbackCoordinator.play(stream, fastModeEnabled: settingsStore.fastPlaybackModeEnabled)
         } catch {
             shouldConsumeFreeSpeakOnPlaybackStart = false
             handleError(error.localizedDescription)
@@ -140,11 +140,15 @@ extension TTSManager {
             lastErrorMessage = nil
             dismissPlaybackPreparationView()
             beginBackgroundTaskIfNeeded()
-            playbackCoordinator.replayLastPlayback(startingAtSample: pausedReplaySampleOffset)
+            Task { @MainActor [weak self] in
+                await self?.playbackCoordinator.replayLastPlayback(startingAtSample: pausedReplaySampleOffset)
+            }
             return
         }
 
-        playbackCoordinator.resume()
+        Task { @MainActor [weak self] in
+            await self?.playbackCoordinator.resume()
+        }
     }
 
     func replayLastPlayback() {
@@ -162,7 +166,9 @@ extension TTSManager {
         lastErrorMessage = nil
         dismissPlaybackPreparationView()
         beginBackgroundTaskIfNeeded()
-        playbackCoordinator.replayLastPlayback()
+        Task { @MainActor [weak self] in
+            await self?.playbackCoordinator.replayLastPlayback()
+        }
     }
 
     func seekReplay(toProgress progress: Double) {
@@ -192,10 +198,12 @@ extension TTSManager {
         dismissPlaybackPreparationView()
         if shouldAutoplay {
             beginBackgroundTaskIfNeeded()
-            playbackCoordinator.replayLastPlayback(
-                startingAtSample: sampleOffset,
-                shouldAutoplay: true
-            )
+            Task { @MainActor [weak self] in
+                await self?.playbackCoordinator.replayLastPlayback(
+                    startingAtSample: sampleOffset,
+                    shouldAutoplay: true
+                )
+            }
             return
         }
 
@@ -210,10 +218,12 @@ extension TTSManager {
         }
 
         beginBackgroundTaskIfNeeded()
-        playbackCoordinator.replayLastPlayback(
-            startingAtSample: sampleOffset,
-            shouldAutoplay: false
-        )
+        Task { @MainActor [weak self] in
+            await self?.playbackCoordinator.replayLastPlayback(
+                startingAtSample: sampleOffset,
+                shouldAutoplay: false
+            )
+        }
     }
 
     func stopPlayback() async {

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+SystemPlayback.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager+SystemPlayback.swift
@@ -29,7 +29,7 @@ extension TTSManager {
     func refreshSystemPlaybackControls() {
         guard let systemPlaybackController else { return }
         guard state == .playing || shouldExposeFinishedReplaySystemPlayback else {
-            Self.log("System playback controls cleared because state=\(state.rawValue)")
+            clearSystemPlaybackControlsIfNeeded(reason: "state=\(state.rawValue)")
             systemPlaybackController.clear()
             return
         }
@@ -40,11 +40,12 @@ extension TTSManager {
             || shouldExposeFinishedReplaySystemPlayback
         guard let displayText = currentPlaybackDisplayText,
               displayText.isEmpty == false else {
-            Self.log("System playback controls cleared because no playback display text was available.")
+            clearSystemPlaybackControlsIfNeeded(reason: "no playback display text was available")
             systemPlaybackController.clear()
             return
         }
 
+        lastSystemPlaybackClearReason = nil
         let elapsedSeconds = currentSystemPlaybackElapsedSeconds(isReplayTransport: isReplayTransport)
         let durationSeconds = isReplayTransport ? currentSystemReplayDurationSeconds : nil
         systemPlaybackController.update(
@@ -55,6 +56,12 @@ extension TTSManager {
             elapsedSeconds: elapsedSeconds,
             durationSeconds: durationSeconds
         )
+    }
+
+    private func clearSystemPlaybackControlsIfNeeded(reason: String) {
+        guard lastSystemPlaybackClearReason != reason else { return }
+        lastSystemPlaybackClearReason = reason
+        Self.log("System playback controls cleared because \(reason)")
     }
 
     private var currentSystemPlaybackVoiceName: String? {

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
@@ -49,6 +49,7 @@ final class TTSManager: ObservableObject {
     var pendingRuntimeUnloadReason: TTSRuntimeUnloadReason?
     var pendingRuntimeUnloadStartedAt: Date?
     var hasRequestedFastModeBackgroundContinuation = false
+    var isProtectedDataLockTransitionActive = false
     var shouldExposeFinishedSystemPlayback = false
     var onWillTeardownPlayback: (() async -> Void)?
     var cancellables = Set<AnyCancellable>()

--- a/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSManager/TTSManager.swift
@@ -51,6 +51,7 @@ final class TTSManager: ObservableObject {
     var hasRequestedFastModeBackgroundContinuation = false
     var isProtectedDataLockTransitionActive = false
     var shouldExposeFinishedSystemPlayback = false
+    var lastSystemPlaybackClearReason: String?
     var onWillTeardownPlayback: (() async -> Void)?
     var cancellables = Set<AnyCancellable>()
 

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+AudioSessionActivation.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+AudioSessionActivation.swift
@@ -1,0 +1,109 @@
+import AVFoundation
+import Foundation
+
+extension TTSPlaybackCoordinator {
+    var shouldUseAsynchronousAudioSessionActivation: Bool {
+        if audioSession is AVAudioSession,
+           #available(iOS 27.0, *) {
+            return true
+        }
+        return false
+    }
+
+    func activatePlaybackAudioSession() async throws {
+        if let systemAudioSession = audioSession as? AVAudioSession,
+           #available(iOS 27.0, *) {
+            try await systemAudioSession.activateForPlayback()
+            hasActivatedAudioSession = true
+            return
+        }
+
+        try audioSession.setActive(true, options: [])
+        hasActivatedAudioSession = true
+    }
+
+    func activatePlaybackAudioSessionSynchronously() throws {
+        try audioSession.setActive(true, options: [])
+        hasActivatedAudioSession = true
+    }
+
+    func deactivatePlaybackAudioSession(notifyOthers: Bool = false) async throws {
+        if let systemAudioSession = audioSession as? AVAudioSession,
+           #available(iOS 27.0, *) {
+            try await systemAudioSession.deactivateForPlayback(notifyOthers: notifyOthers)
+            hasActivatedAudioSession = false
+            configuredAudioSessionMode = nil
+            return
+        }
+
+        let options: AVAudioSession.SetActiveOptions = notifyOthers ? [.notifyOthersOnDeactivation] : []
+        try audioSession.setActive(false, options: options)
+        hasActivatedAudioSession = false
+        configuredAudioSessionMode = nil
+    }
+
+    func deactivatePlaybackAudioSessionSynchronously(notifyOthers: Bool = false) throws {
+        let options: AVAudioSession.SetActiveOptions = notifyOthers ? [.notifyOthersOnDeactivation] : []
+        try audioSession.setActive(false, options: options)
+        hasActivatedAudioSession = false
+        configuredAudioSessionMode = nil
+    }
+
+    func configurePlaybackAudioSession(_ operation: @escaping (any TTSPlaybackAudioSessionControlling) throws -> Void) async throws {
+        if let systemAudioSession = audioSession as? AVAudioSession,
+           shouldUseAsynchronousAudioSessionActivation {
+            try await systemAudioSession.performPlaybackConfiguration { audioSession in
+                try operation(audioSession)
+            }
+            return
+        }
+
+        try operation(audioSession)
+    }
+}
+
+private extension AVAudioSession {
+    @available(iOS 27.0, *)
+    func activateForPlayback() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            activate(options: []) { activated, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if activated {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: CocoaError(.featureUnsupported))
+                }
+            }
+        }
+    }
+
+    @available(iOS 27.0, *)
+    func deactivateForPlayback(notifyOthers: Bool) async throws {
+        let options: AVAudioSessionDeactivationOptions = notifyOthers ? [.notifyOthersOnDeactivation] : []
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            deactivate(options: options) { deactivated, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if deactivated {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: CocoaError(.featureUnsupported))
+                }
+            }
+        }
+    }
+
+    func performPlaybackConfiguration(_ operation: @escaping (AVAudioSession) throws -> Void) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    try operation(self)
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Lifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Lifecycle.swift
@@ -365,6 +365,7 @@ extension TTSPlaybackCoordinator {
                     mode: .default,
                     options: resolvedCategoryOptions
                 )
+                try audioSession.setAllowHapticsAndSystemSoundsDuringRecording(true)
                 Self.log("Configuring preserved playback session routePolicy=\(routePolicyFamily)")
                 let isUsingBuiltInReceiver = audioSession.currentOutputPortTypes.contains(.builtInReceiver)
                 try? audioSession.overrideOutputAudioPort(isUsingBuiltInReceiver ? .speaker : .none)

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Lifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Lifecycle.swift
@@ -201,7 +201,7 @@ extension TTSPlaybackCoordinator {
     func replayLastPlayback(startingAtSample startSampleOffset: Int = 0, shouldAutoplay: Bool = true) async {
         guard !replayablePlaybackSamples.isEmpty else { return }
 
-        stop(emitCallback: false)
+        stop(emitCallback: false, deactivateAudioSession: false)
         let safeStartSampleOffset = min(max(0, startSampleOffset), max(0, replayablePlaybackSamples.count - 1))
         Self.log(
             "Replaying cached playback samples=\(replayablePlaybackSamples.count) startOffset=\(safeStartSampleOffset) autoplay=\(shouldAutoplay)"
@@ -281,7 +281,7 @@ extension TTSPlaybackCoordinator {
         }
     }
 
-    func stop(emitCallback: Bool) {
+    func stop(emitCallback: Bool, deactivateAudioSession: Bool = true) {
         let hadPlayback = playbackTask != nil || playerNode.isPlaying || queuedBufferCount > 0
         playbackSessionID = UUID()
 
@@ -317,7 +317,9 @@ extension TTSPlaybackCoordinator {
             playerNode.stop()
         }
         audioEngine.stop()
-        deactivateAudioSessionIfNeeded()
+        if deactivateAudioSession {
+            deactivateAudioSessionIfNeeded()
+        }
 
         if emitCallback, hadPlayback {
             onPlaybackCancelled?()

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Lifecycle.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Lifecycle.swift
@@ -41,7 +41,7 @@ extension TTSPlaybackCoordinator {
         return replayPausedSampleOffset
     }
 
-    func play(_ stream: AsyncThrowingStream<KeyVoxTTSAudioFrame, Error>, fastModeEnabled: Bool = false) {
+    func play(_ stream: AsyncThrowingStream<KeyVoxTTSAudioFrame, Error>, fastModeEnabled: Bool = false) async {
         stop(emitCallback: false)
         Self.log("Playback requested. fastMode=\(fastModeEnabled)")
         playbackSessionID = UUID()
@@ -49,7 +49,7 @@ extension TTSPlaybackCoordinator {
 
         do {
             configureAudioGraphIfNeeded()
-            try configureAudioSession()
+            try await configureAudioSession()
             if audioEngine.isRunning == false {
                 try audioEngine.start()
             }
@@ -141,7 +141,13 @@ extension TTSPlaybackCoordinator {
             audioEngine.pause()
         }
         if audioSessionMode == .playbackWhilePreservingRecording {
-            handoffPausedAudioSessionIfNeeded()
+            if shouldUseAsynchronousAudioSessionActivation {
+                Task { [weak self] in
+                    await self?.handoffPausedAudioSessionIfNeeded()
+                }
+            } else {
+                handoffPausedAudioSessionIfNeededSynchronously()
+            }
         }
         isPaused = true
         stopPlaybackProgressTimer()
@@ -151,11 +157,11 @@ extension TTSPlaybackCoordinator {
         onPlaybackPaused?()
     }
 
-    func resume() {
+    func resume() async {
         guard canResumePlayback else { return }
         if isReplayingCachedAudio,
            let pausedReplaySampleOffset = replayPausedSampleOffsetSnapshot() {
-            replayLastPlayback(startingAtSample: pausedReplaySampleOffset, shouldAutoplay: true)
+            await replayLastPlayback(startingAtSample: pausedReplaySampleOffset, shouldAutoplay: true)
             return
         }
         if shouldDelayResumeUntilBuffered() {
@@ -172,8 +178,8 @@ extension TTSPlaybackCoordinator {
         }
 
         do {
-            try configureAudioSession()
-            try ensureAudioEngineReadyForPlayback(context: "resume")
+            try await configureAudioSession()
+            try await ensureAudioEngineReadyForPlayback(context: "resume")
         } catch {
             handleFailure(error)
             return
@@ -192,7 +198,7 @@ extension TTSPlaybackCoordinator {
         onPlaybackResumed?()
     }
 
-    func replayLastPlayback(startingAtSample startSampleOffset: Int = 0, shouldAutoplay: Bool = true) {
+    func replayLastPlayback(startingAtSample startSampleOffset: Int = 0, shouldAutoplay: Bool = true) async {
         guard !replayablePlaybackSamples.isEmpty else { return }
 
         stop(emitCallback: false)
@@ -204,7 +210,7 @@ extension TTSPlaybackCoordinator {
 
         do {
             configureAudioGraphIfNeeded()
-            try configureAudioSession()
+            try await configureAudioSession()
             if audioEngine.isRunning == false {
                 try audioEngine.start()
             }
@@ -270,7 +276,7 @@ extension TTSPlaybackCoordinator {
                 playerNode.stop()
             }
             audioEngine.stop()
-            handoffPausedAudioSessionIfNeeded()
+            await handoffPausedAudioSessionIfNeeded()
             Self.log("Replay prepared in paused state; audio engine stopped while keeping the playback session active.")
         }
     }
@@ -320,17 +326,30 @@ extension TTSPlaybackCoordinator {
         emitPlaybackProgress()
     }
 
-    func configureAudioSession() throws {
-        switch audioSessionMode {
+    func configureAudioSession() async throws {
+        let targetAudioSessionMode = audioSessionMode
+        if hasActivatedAudioSession, configuredAudioSessionMode == targetAudioSessionMode {
+            return
+        }
+
+        if hasActivatedAudioSession {
+            try await deactivatePlaybackAudioSession()
+        } else if shouldUseAsynchronousAudioSessionActivation, targetAudioSessionMode == .playback {
+            try? await deactivatePlaybackAudioSession()
+        }
+
+        switch targetAudioSessionMode {
         case .playback:
             hasHandedOffPausedPlaybackSession = false
-            try audioSession.setCategory(
-                .playback,
-                mode: .spokenAudio,
-                policy: .longFormAudio,
-                options: []
-            )
-            try? audioSession.overrideOutputAudioPort(.none)
+            try await configurePlaybackAudioSession { audioSession in
+                try audioSession.setCategory(
+                    .playback,
+                    mode: .spokenAudio,
+                    policy: .longFormAudio,
+                    options: []
+                )
+                try? audioSession.overrideOutputAudioPort(.none)
+            }
         case .playbackWhilePreservingRecording:
             hasHandedOffPausedPlaybackSession = false
             let bluetoothRoutePolicy = AudioBluetoothRoutePolicy(
@@ -338,24 +357,29 @@ extension TTSPlaybackCoordinator {
             )
             var categoryOptions: AVAudioSession.CategoryOptions = [.defaultToSpeaker]
             categoryOptions.formUnion(bluetoothRoutePolicy.bluetoothCategoryOptions)
-            try audioSession.setCategory(
-                .playAndRecord,
-                mode: .default,
-                options: categoryOptions
-            )
-            Self.log("Configuring preserved playback session routePolicy=\(bluetoothRoutePolicy.family.rawValue)")
-            let isUsingBuiltInReceiver = audioSession.currentOutputPortTypes.contains(.builtInReceiver)
-            try? audioSession.overrideOutputAudioPort(isUsingBuiltInReceiver ? .speaker : .none)
+            let resolvedCategoryOptions = categoryOptions
+            let routePolicyFamily = bluetoothRoutePolicy.family.rawValue
+            try await configurePlaybackAudioSession { audioSession in
+                try audioSession.setCategory(
+                    .playAndRecord,
+                    mode: .default,
+                    options: resolvedCategoryOptions
+                )
+                Self.log("Configuring preserved playback session routePolicy=\(routePolicyFamily)")
+                let isUsingBuiltInReceiver = audioSession.currentOutputPortTypes.contains(.builtInReceiver)
+                try? audioSession.overrideOutputAudioPort(isUsingBuiltInReceiver ? .speaker : .none)
+            }
         }
-        try audioSession.setActive(true, options: [])
+        configuredAudioSessionMode = targetAudioSessionMode
+        try await activatePlaybackAudioSession()
     }
 
-    func ensureAudioEngineReadyForPlayback(context: String) throws {
+    func ensureAudioEngineReadyForPlayback(context: String) async throws {
         configureAudioGraphIfNeeded()
         if audioEngine.isRunning { return }
 
         Self.log("Audio engine was stopped before playback context=\(context); reconfiguring session and restarting engine.")
-        try configureAudioSession()
+        try await configureAudioSession()
         try audioEngine.start()
     }
 
@@ -386,7 +410,13 @@ extension TTSPlaybackCoordinator {
             return
         }
 
-        try? audioSession.setActive(false, options: [.notifyOthersOnDeactivation])
+        if shouldUseAsynchronousAudioSessionActivation {
+            Task { [weak self] in
+                try? await self?.deactivatePlaybackAudioSession(notifyOthers: true)
+            }
+        } else {
+            try? deactivatePlaybackAudioSessionSynchronously(notifyOthers: true)
+        }
         hasHandedOffPausedPlaybackSession = false
     }
 
@@ -395,11 +425,39 @@ extension TTSPlaybackCoordinator {
         onPlaybackFailed?(error)
     }
 
-    private func handoffPausedAudioSessionIfNeeded() {
+    private func handoffPausedAudioSessionIfNeeded() async {
         guard audioSessionMode == .playbackWhilePreservingRecording else { return }
 
         do {
-            try audioSession.setActive(false, options: [])
+            try await deactivatePlaybackAudioSession()
+        } catch {
+            Self.log("Failed to deactivate preserved recording session before paused handoff: \(error.localizedDescription)")
+        }
+
+        do {
+            try await configurePlaybackAudioSession { audioSession in
+                try audioSession.setCategory(
+                    .playback,
+                    mode: .spokenAudio,
+                    policy: .longFormAudio,
+                    options: []
+                )
+                try? audioSession.overrideOutputAudioPort(.none)
+            }
+            configuredAudioSessionMode = .playback
+            try await activatePlaybackAudioSession()
+            hasHandedOffPausedPlaybackSession = true
+            Self.log("Handed paused playback off to playback/spokenAudio session.")
+        } catch {
+            Self.log("Failed to hand paused playback off to playback session: \(error.localizedDescription)")
+        }
+    }
+
+    private func handoffPausedAudioSessionIfNeededSynchronously() {
+        guard audioSessionMode == .playbackWhilePreservingRecording else { return }
+
+        do {
+            try deactivatePlaybackAudioSessionSynchronously()
         } catch {
             Self.log("Failed to deactivate preserved recording session before paused handoff: \(error.localizedDescription)")
         }
@@ -412,7 +470,8 @@ extension TTSPlaybackCoordinator {
                 options: []
             )
             try? audioSession.overrideOutputAudioPort(.none)
-            try audioSession.setActive(true, options: [])
+            configuredAudioSessionMode = .playback
+            try activatePlaybackAudioSessionSynchronously()
             hasHandedOffPausedPlaybackSession = true
             Self.log("Handed paused playback off to playback/spokenAudio session.")
         } catch {

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Progress.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Progress.swift
@@ -61,26 +61,29 @@ extension TTSPlaybackCoordinator {
         )
         guard queuedSampleCount >= requiredSamples || (isFinishing && queuedSampleCount > 0) else { return }
 
-        do {
-            try ensureAudioEngineReadyForPlayback(context: "resumeIfBufferedEnough")
-        } catch {
-            handleFailure(error)
-            return
-        }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await self.ensureAudioEngineReadyForPlayback(context: "resumeIfBufferedEnough")
+            } catch {
+                self.handleFailure(error)
+                return
+            }
 
-        playerNode.play()
-        isPaused = false
-        isWaitingForResumeBuffer = false
-        if isReplayingCachedAudio {
-            replayPausedSampleOffset = 0
+            self.playerNode.play()
+            self.isPaused = false
+            self.isWaitingForResumeBuffer = false
+            if self.isReplayingCachedAudio {
+                self.replayPausedSampleOffset = 0
+            }
+            self.startPlaybackProgressTimer()
+            self.emitPlaybackProgress()
+            Self.log(
+                "Playback resumed after buffer refill. queuedSeconds=\(String(format: "%.3f", self.bufferedSeconds)) requiredSeconds=\(String(format: "%.3f", Double(requiredSamples) / self.playbackFormat.sampleRate)) generatedSeconds=\(String(format: "%.3f", Double(self.totalGeneratedSampleCount) / self.playbackFormat.sampleRate))"
+            )
+            self.notifyFastModeBackgroundSafetyChanged()
+            self.onPlaybackResumed?()
         }
-        startPlaybackProgressTimer()
-        emitPlaybackProgress()
-        Self.log(
-            "Playback resumed after buffer refill. queuedSeconds=\(String(format: "%.3f", bufferedSeconds)) requiredSeconds=\(String(format: "%.3f", Double(requiredSamples) / playbackFormat.sampleRate)) generatedSeconds=\(String(format: "%.3f", Double(totalGeneratedSampleCount) / playbackFormat.sampleRate))"
-        )
-        notifyFastModeBackgroundSafetyChanged()
-        onPlaybackResumed?()
     }
 
     func startPlaybackProgressTimer() {

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Progress.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Progress.swift
@@ -60,6 +60,7 @@ extension TTSPlaybackCoordinator {
             remainingEstimatedSamples: lastObservedRemainingEstimatedSamples
         )
         guard queuedSampleCount >= requiredSamples || (isFinishing && queuedSampleCount > 0) else { return }
+        isWaitingForResumeBuffer = false
         let sessionID = playbackSessionID
 
         Task { @MainActor [weak self] in
@@ -76,7 +77,6 @@ extension TTSPlaybackCoordinator {
 
             self.playerNode.play()
             self.isPaused = false
-            self.isWaitingForResumeBuffer = false
             if self.isReplayingCachedAudio {
                 self.replayPausedSampleOffset = 0
             }

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Progress.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Progress.swift
@@ -60,15 +60,19 @@ extension TTSPlaybackCoordinator {
             remainingEstimatedSamples: lastObservedRemainingEstimatedSamples
         )
         guard queuedSampleCount >= requiredSamples || (isFinishing && queuedSampleCount > 0) else { return }
+        let sessionID = playbackSessionID
 
         Task { @MainActor [weak self] in
             guard let self else { return }
+            guard self.playbackSessionID == sessionID else { return }
             do {
                 try await self.ensureAudioEngineReadyForPlayback(context: "resumeIfBufferedEnough")
             } catch {
+                guard self.playbackSessionID == sessionID else { return }
                 self.handleFailure(error)
                 return
             }
+            guard self.playbackSessionID == sessionID else { return }
 
             self.playerNode.play()
             self.isPaused = false

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Scheduling.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Scheduling.swift
@@ -202,19 +202,22 @@ extension TTSPlaybackCoordinator {
 
         let startPlayback = { [weak self] in
             guard let self else { return }
-            do {
-                try self.ensureAudioEngineReadyForPlayback(context: "startupBuffer")
-            } catch {
-                self.handleFailure(error)
-                return
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    try await self.ensureAudioEngineReadyForPlayback(context: "startupBuffer")
+                } catch {
+                    self.handleFailure(error)
+                    return
+                }
+                self.playerNode.play()
+                self.startPlaybackProgressTimer()
+                self.onPreparationProgress?(self.activeSilentStartSampleCount, self.activeSilentStartSampleCount, true)
+                Self.log("Playback started with bufferedSamples=\(bufferedSamples) queuedBuffers=\(self.queuedBufferCount)")
+                self.emitPlaybackProgress()
+                self.notifyFastModeBackgroundSafetyChanged()
+                self.onPlaybackStarted?()
             }
-            self.playerNode.play()
-            self.startPlaybackProgressTimer()
-            self.onPreparationProgress?(self.activeSilentStartSampleCount, self.activeSilentStartSampleCount, true)
-            Self.log("Playback started with bufferedSamples=\(bufferedSamples) queuedBuffers=\(self.queuedBufferCount)")
-            self.emitPlaybackProgress()
-            self.notifyFastModeBackgroundSafetyChanged()
-            self.onPlaybackStarted?()
         }
 
         if preparationCompletionDelaySeconds > 0 {

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Scheduling.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator+Scheduling.swift
@@ -199,17 +199,21 @@ extension TTSPlaybackCoordinator {
         onPreparationProgress?(activeSilentStartSampleCount, activeSilentStartSampleCount, false)
         onPreparationCompleted?()
         notifyFastModeBackgroundSafetyChanged()
+        let sessionID = playbackSessionID
 
         let startPlayback = { [weak self] in
             guard let self else { return }
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                guard self.playbackSessionID == sessionID else { return }
                 do {
                     try await self.ensureAudioEngineReadyForPlayback(context: "startupBuffer")
                 } catch {
+                    guard self.playbackSessionID == sessionID else { return }
                     self.handleFailure(error)
                     return
                 }
+                guard self.playbackSessionID == sessionID else { return }
                 self.playerNode.play()
                 self.startPlaybackProgressTimer()
                 self.onPreparationProgress?(self.activeSilentStartSampleCount, self.activeSilentStartSampleCount, true)

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator.swift
@@ -20,6 +20,7 @@ protocol TTSPlaybackAudioSessionControlling: AnyObject {
     ) throws
 
     func overrideOutputAudioPort(_ portOverride: AVAudioSession.PortOverride) throws
+    func setAllowHapticsAndSystemSoundsDuringRecording(_ inValue: Bool) throws
     func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws
 }
 

--- a/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPlaybackCoordinator/TTSPlaybackCoordinator.swift
@@ -92,6 +92,8 @@ final class TTSPlaybackCoordinator {
     var hasObservedFastModeBackgroundSafeCompute = false
     var hasConfiguredAudioGraph = false
     var hasHandedOffPausedPlaybackSession = false
+    var hasActivatedAudioSession = false
+    var configuredAudioSessionMode: AudioSessionMode?
     var overrideIsPlayerNodePlaying: Bool?
     let audioSession: any TTSPlaybackAudioSessionControlling
     let preferBuiltInMicrophoneProvider: () -> Bool

--- a/iOS/KeyVox iOS/Core/TTS/TTSPreviewPlayer.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPreviewPlayer.swift
@@ -78,9 +78,20 @@ final class TTSPreviewPlayer: NSObject, ObservableObject {
             return
         }
 
-        do {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await self.startPlayback(resourceName: resourceName, url: url)
+            } catch {
+                Self.log("Failed to play preview for \(resourceName): \(String(describing: error))")
+                self.stop()
+            }
+        }
+    }
+
+    private func startPlayback(resourceName: String, url: URL) async throws {
             resetPlaybackState(deactivateAudioSession: false)
-            try configureAudioSession()
+            try await configureAudioSession()
             let player = try AVAudioPlayer(contentsOf: url)
             player.delegate = self
             player.prepareToPlay()
@@ -89,10 +100,6 @@ final class TTSPreviewPlayer: NSObject, ObservableObject {
             appHaptics.light()
             player.play()
             isPlaying = true
-        } catch {
-            Self.log("Failed to play preview for \(resourceName): \(String(describing: error))")
-            stop()
-        }
     }
 
     private func resetPlaybackState(deactivateAudioSession: Bool) {
@@ -112,45 +119,115 @@ final class TTSPreviewPlayer: NSObject, ObservableObject {
     private func resumeCurrentPlayback() {
         guard let player else { return }
 
-        do {
-            try configureAudioSession()
-            appHaptics.light()
-            player.play()
-            isPlaying = true
-        } catch {
-            Self.log(
-                "Failed to resume preview for \(activePreviewResourceName ?? "unknown"): \(String(describing: error))"
-            )
-            stop()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await self.configureAudioSession()
+                self.appHaptics.light()
+                player.play()
+                self.isPlaying = true
+            } catch {
+                Self.log(
+                    "Failed to resume preview for \(self.activePreviewResourceName ?? "unknown"): \(String(describing: error))"
+                )
+                self.stop()
+            }
         }
     }
 
-    private func configureAudioSession() throws {
+    private func configureAudioSession() async throws {
         if isRecordingSessionActiveProvider() {
             let bluetoothRoutePolicy = AudioBluetoothRoutePolicy(
                 preferBuiltInMicrophone: preferBuiltInMicrophoneProvider()
             )
             var categoryOptions: AVAudioSession.CategoryOptions = [.defaultToSpeaker, .mixWithOthers]
             categoryOptions.formUnion(bluetoothRoutePolicy.bluetoothCategoryOptions)
-            try audioSession.setCategory(.playAndRecord, mode: .default, options: categoryOptions)
-            let isUsingBuiltInReceiver = audioSession.currentRoute.outputs.contains {
-                $0.portType == .builtInReceiver
+            let resolvedCategoryOptions = categoryOptions
+            try await performAudioSessionOperation { audioSession in
+                try audioSession.setCategory(.playAndRecord, mode: .default, options: resolvedCategoryOptions)
+                let isUsingBuiltInReceiver = audioSession.currentRoute.outputs.contains {
+                    $0.portType == .builtInReceiver
+                }
+                try? audioSession.overrideOutputAudioPort(isUsingBuiltInReceiver ? .speaker : .none)
             }
-            try? audioSession.overrideOutputAudioPort(isUsingBuiltInReceiver ? .speaker : .none)
             shouldDeactivateAudioSessionOnStop = false
         } else {
-            try audioSession.setCategory(.playback, mode: .spokenAudio, options: [.duckOthers])
-            try? audioSession.overrideOutputAudioPort(.none)
+            try? await deactivateAudioSession()
+            try await performAudioSessionOperation { audioSession in
+                try audioSession.setCategory(.playback, mode: .spokenAudio, options: [.duckOthers])
+                try? audioSession.overrideOutputAudioPort(.none)
+            }
             shouldDeactivateAudioSessionOnStop = true
         }
-        try audioSession.setActive(true)
+        try await activateAudioSession()
         hasActivatedAudioSession = true
     }
 
     private func deactivateAudioSessionIfNeeded() {
-        try? audioSession.setActive(false, options: [.notifyOthersOnDeactivation])
-        hasActivatedAudioSession = false
-        shouldDeactivateAudioSessionOnStop = false
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await self.deactivateAudioSession(notifyOthers: true)
+            self.hasActivatedAudioSession = false
+            self.shouldDeactivateAudioSessionOnStop = false
+        }
+    }
+
+    private func activateAudioSession() async throws {
+        if #available(iOS 27.0, *) {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                audioSession.activate(options: []) { activated, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else if activated {
+                        continuation.resume()
+                    } else {
+                        continuation.resume(throwing: CocoaError(.featureUnsupported))
+                    }
+                }
+            }
+        } else {
+            try await performAudioSessionOperation { audioSession in
+                try audioSession.setActive(true)
+            }
+        }
+    }
+
+    private func deactivateAudioSession(notifyOthers: Bool = false) async throws {
+        if #available(iOS 27.0, *) {
+            let options: AVAudioSessionDeactivationOptions = notifyOthers ? [.notifyOthersOnDeactivation] : []
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                audioSession.deactivate(options: options) { deactivated, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else if deactivated {
+                        continuation.resume()
+                    } else {
+                        continuation.resume(throwing: CocoaError(.featureUnsupported))
+                    }
+                }
+            }
+        } else {
+            let options: AVAudioSession.SetActiveOptions = notifyOthers ? [.notifyOthersOnDeactivation] : []
+            try await performAudioSessionOperation { audioSession in
+                try audioSession.setActive(false, options: options)
+            }
+        }
+    }
+
+    private func performAudioSessionOperation(
+        _ operation: @escaping @Sendable (AVAudioSession) throws -> Void
+    ) async throws {
+        let audioSession = audioSession
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    try operation(audioSession)
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 
     private static func log(_ message: String) {

--- a/iOS/KeyVox iOS/Core/TTS/TTSPreviewPlayer.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSPreviewPlayer.swift
@@ -14,6 +14,7 @@ final class TTSPreviewPlayer: NSObject, ObservableObject {
     private var player: AVAudioPlayer?
     private var hasActivatedAudioSession = false
     private var shouldDeactivateAudioSessionOnStop = false
+    private var audioSessionDeactivationTask: Task<Void, Never>?
 
     init(
         appHaptics: AppHapticsEmitting,
@@ -136,6 +137,7 @@ final class TTSPreviewPlayer: NSObject, ObservableObject {
     }
 
     private func configureAudioSession() async throws {
+        await awaitPendingAudioSessionDeactivation()
         if isRecordingSessionActiveProvider() {
             let bluetoothRoutePolicy = AudioBluetoothRoutePolicy(
                 preferBuiltInMicrophone: preferBuiltInMicrophoneProvider()
@@ -164,12 +166,19 @@ final class TTSPreviewPlayer: NSObject, ObservableObject {
     }
 
     private func deactivateAudioSessionIfNeeded() {
-        Task { @MainActor [weak self] in
+        guard audioSessionDeactivationTask == nil else { return }
+        audioSessionDeactivationTask = Task { @MainActor [weak self] in
             guard let self else { return }
             try? await self.deactivateAudioSession(notifyOthers: true)
             self.hasActivatedAudioSession = false
             self.shouldDeactivateAudioSessionOnStop = false
         }
+    }
+
+    private func awaitPendingAudioSessionDeactivation() async {
+        guard let audioSessionDeactivationTask else { return }
+        await audioSessionDeactivationTask.value
+        self.audioSessionDeactivationTask = nil
     }
 
     private func activateAudioSession() async throws {

--- a/iOS/KeyVox iOS/Core/TTS/TTSSystemPlaybackController.swift
+++ b/iOS/KeyVox iOS/Core/TTS/TTSSystemPlaybackController.swift
@@ -23,6 +23,7 @@ final class TTSSystemPlaybackController {
     private var lastIsReplay = false
     private var lastElapsedBucket: Int?
     private var lastDurationBucket: Int?
+    private var isCleared = true
     private lazy var artwork: MPMediaItemArtwork? = Self.makeArtwork()
 
     init(
@@ -105,6 +106,7 @@ final class TTSSystemPlaybackController {
         nowPlayingInfoCenter.nowPlayingInfo = info
         nowPlayingInfoCenter.playbackState = isPlaying ? .playing : .paused
 
+        isCleared = false
         lastTitle = title
         lastVoiceName = voiceName
         lastIsPlaying = isPlaying
@@ -114,10 +116,12 @@ final class TTSSystemPlaybackController {
     }
 
     func clear() {
+        guard isCleared == false else { return }
         updateRemoteCommandAvailability(isActive: false, isPlaying: false, canSeek: false)
         nowPlayingInfoCenter.nowPlayingInfo = nil
         Self.log("Cleared now playing info.")
 
+        isCleared = true
         lastTitle = nil
         lastVoiceName = nil
         lastIsPlaying = false

--- a/iOS/KeyVox iOS/Core/Transcription/TranscriptionManager+SessionLifecycle.swift
+++ b/iOS/KeyVox iOS/Core/Transcription/TranscriptionManager+SessionLifecycle.swift
@@ -125,7 +125,7 @@ extension TranscriptionManager {
         cancelUtteranceSafetyWatchdog()
 
         do {
-            try recorder.stopMonitoring(keepAudioSessionActive: isTTSPlaybackActiveProvider())
+            try await recorder.stopMonitoring(keepAudioSessionActive: isTTSPlaybackActiveProvider())
             isSessionActive = false
             sessionDisablePending = false
             sessionExpirationDate = nil

--- a/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
+++ b/iOS/KeyVoxiOSTests/App/KeyVoxURLRouterTests.swift
@@ -282,11 +282,11 @@ private final class StubAudioRecorder: AudioRecording {
         )
     }
 
-    func ensureEngineRunning() throws {
+    func ensureEngineRunning() async throws {
         isMonitoring = true
     }
 
-    func stopMonitoring(keepAudioSessionActive: Bool) throws {
+    func stopMonitoring(keepAudioSessionActive: Bool) async throws {
         isMonitoring = false
     }
 

--- a/iOS/KeyVoxiOSTests/Core/TTS/PocketTTSEngineTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/TTS/PocketTTSEngineTests.swift
@@ -10,9 +10,13 @@ struct PocketTTSEngineTests {
         await harness.engine.prepareForForegroundSynthesis()
         await harness.engine.prepareForBackgroundContinuation()
 
-        #expect(harness.factoryProbe.createCallCount == 0)
-        #expect(harness.runtime.prepareCount == 0)
-        #expect(harness.runtime.preferredModes.isEmpty)
+        let createCallCount = harness.factoryProbe.createCallCount
+        let prepareCount = await harness.runtime.prepareCountSnapshot()
+        let preferredModes = await harness.runtime.preferredModesSnapshot()
+
+        #expect(createCallCount == 0)
+        #expect(prepareCount == 0)
+        #expect(preferredModes.isEmpty)
     }
 
     @Test func explicitPreparationOwnsRuntimeUntilUnload() async throws {
@@ -25,13 +29,19 @@ struct PocketTTSEngineTests {
         await harness.engine.prepareForForegroundSynthesis()
         try await harness.engine.prepareIfNeeded()
 
-        #expect(harness.factoryProbe.createCallCount == 2)
-        #expect(harness.runtime.prepareCount == 1)
-        #expect(harness.recreatedRuntime.prepareCount == 1)
-        #expect(harness.runtime.preferredModes.count == 2)
-        #expect(matches(harness.runtime.preferredModes[safe: 0], .foreground))
-        #expect(matches(harness.runtime.preferredModes[safe: 1], .backgroundSafe))
-        #expect(harness.recreatedRuntime.preferredModes.isEmpty)
+        let createCallCount = harness.factoryProbe.createCallCount
+        let runtimePrepareCount = await harness.runtime.prepareCountSnapshot()
+        let recreatedRuntimePrepareCount = await harness.recreatedRuntime.prepareCountSnapshot()
+        let preferredModes = await harness.runtime.preferredModesSnapshot()
+        let recreatedPreferredModes = await harness.recreatedRuntime.preferredModesSnapshot()
+
+        #expect(createCallCount == 2)
+        #expect(runtimePrepareCount == 1)
+        #expect(recreatedRuntimePrepareCount == 1)
+        #expect(preferredModes.count == 2)
+        #expect(matches(preferredModes[safe: 0], .foreground))
+        #expect(matches(preferredModes[safe: 1], .backgroundSafe))
+        #expect(recreatedPreferredModes.isEmpty)
     }
 
     private func makeHarness() -> PocketTTSEngineHarness {
@@ -98,6 +108,14 @@ private final class SpyPocketTTSEngineRuntime: PocketTTSEngineRuntime {
     }
 
     func requestPreferredComputeMode(_ mode: KeyVoxTTSComputeMode) {}
+
+    func prepareCountSnapshot() async -> Int {
+        prepareCount
+    }
+
+    func preferredModesSnapshot() async -> [KeyVoxTTSComputeMode] {
+        preferredModes
+    }
 
     func synthesizeStreaming(
         text: String,

--- a/iOS/KeyVoxiOSTests/Core/TTS/TTSManager/TTSManagerLifecycleTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/TTS/TTSManager/TTSManagerLifecycleTests.swift
@@ -46,7 +46,7 @@ struct TTSManagerLifecycleTests {
         harness.manager.activeRequest = makeRequest(createdAt: 2)
         harness.manager.hasStartedPlaybackForActiveRequest = true
         harness.manager.updateState(.playing)
-        armPlaybackCoordinatorForPause(harness.manager.playbackCoordinator)
+        await armPlaybackCoordinatorForPause(harness.manager.playbackCoordinator)
 
         harness.manager.handleAppWillResignActive()
         await settleLifecycleTasks()
@@ -90,7 +90,7 @@ struct TTSManagerLifecycleTests {
         harness.manager.activeRequest = makeRequest(createdAt: 4)
         harness.manager.hasStartedPlaybackForActiveRequest = true
         harness.manager.updateState(.playing)
-        armPlaybackCoordinatorForPause(harness.manager.playbackCoordinator)
+        await armPlaybackCoordinatorForPause(harness.manager.playbackCoordinator)
 
         harness.manager.handleProtectedDataWillBecomeUnavailableNotification(
             Notification(name: UIApplication.protectedDataWillBecomeUnavailableNotification)
@@ -243,12 +243,13 @@ struct TTSManagerLifecycleTests {
         replayCache.clear()
 
         let engine = SpyTTSEngine()
+        let playbackCoordinator = TTSPlaybackCoordinator(audioSession: StubTTSPlaybackAudioSession())
         let manager = TTSManager(
             settingsStore: AppSettingsStore(defaults: defaults),
             appHaptics: StubAppHaptics(),
             keyboardBridge: KeyVoxKeyboardBridge(),
             engine: engine,
-            playbackCoordinator: TTSPlaybackCoordinator(),
+            playbackCoordinator: playbackCoordinator,
             purchaseGate: StubTTSPurchaseGate(),
             replayCache: replayCache
         )
@@ -278,7 +279,7 @@ struct TTSManagerLifecycleTests {
         await Task.yield()
     }
 
-    private func armPlaybackCoordinatorForPause(_ playbackCoordinator: TTSPlaybackCoordinator) {
+    private func armPlaybackCoordinatorForPause(_ playbackCoordinator: TTSPlaybackCoordinator) async {
         playbackCoordinator.fastModeEnabled = true
         playbackCoordinator.didStartPlayback = true
         playbackCoordinator.isPaused = false
@@ -287,7 +288,7 @@ struct TTSManagerLifecycleTests {
         playbackCoordinator.configureAudioGraphIfNeeded()
         let samples = Array(repeating: Float(0), count: 24_000)
         if let buffer = playbackCoordinator.makeBuffer(from: samples) {
-            try? playbackCoordinator.configureAudioSession()
+            try? await playbackCoordinator.configureAudioSession()
             try? playbackCoordinator.audioEngine.start()
             playbackCoordinator.scheduleBuffer(
                 buffer,
@@ -395,4 +396,25 @@ private final class StubTTSPurchaseGate: TTSPurchaseGating {
     func presentUnlockSheet() {}
     func dismissUnlockSheet() {}
     func consumeFreeTTSSpeakIfNeeded() {}
+}
+
+private final class StubTTSPlaybackAudioSession: TTSPlaybackAudioSessionControlling {
+    var currentOutputPortTypes: [AVAudioSession.Port] = []
+
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        policy: AVAudioSession.RouteSharingPolicy,
+        options: AVAudioSession.CategoryOptions
+    ) throws {}
+
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions
+    ) throws {}
+
+    func overrideOutputAudioPort(_ portOverride: AVAudioSession.PortOverride) throws {}
+
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {}
 }

--- a/iOS/KeyVoxiOSTests/Core/TTS/TTSManager/TTSManagerLifecycleTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/TTS/TTSManager/TTSManagerLifecycleTests.swift
@@ -444,5 +444,7 @@ private final class StubTTSPlaybackAudioSession: TTSPlaybackAudioSessionControll
 
     func overrideOutputAudioPort(_ portOverride: AVAudioSession.PortOverride) throws {}
 
+    func setAllowHapticsAndSystemSoundsDuringRecording(_ inValue: Bool) throws {}
+
     func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {}
 }

--- a/iOS/KeyVoxiOSTests/Core/TTS/TTSManager/TTSManagerLifecycleTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/TTS/TTSManager/TTSManagerLifecycleTests.swift
@@ -82,12 +82,40 @@ struct TTSManagerLifecycleTests {
         #expect(harness.manager.isPlaybackPaused == false)
     }
 
-    @Test func protectedDataLockPausesUnsafeFastModePlayback() async {
+    @Test func appDidBecomeActiveDuringProtectedDataLockDoesNotRestoreForegroundSynthesis() async {
         let harness = makeHarness()
         defer { harness.cleanup() }
 
         harness.manager.settingsStore.fastPlaybackModeEnabled = true
         harness.manager.activeRequest = makeRequest(createdAt: 4)
+        harness.manager.hasStartedPlaybackForActiveRequest = true
+        harness.manager.updateState(.playing)
+        harness.manager.playbackCoordinator.fastModeEnabled = true
+        harness.manager.playbackCoordinator.didStartPlayback = true
+        harness.manager.playbackCoordinator.isPaused = false
+        harness.manager.playbackCoordinator.isFastModeBackgroundSafeState = true
+        harness.manager.playbackCoordinator.hasObservedFastModeBackgroundSafeCompute = true
+
+        harness.manager.handleProtectedDataWillBecomeUnavailableNotification(
+            Notification(name: UIApplication.protectedDataWillBecomeUnavailableNotification)
+        )
+        await settleLifecycleTasks()
+
+        harness.manager.handleAppDidBecomeActive()
+        await settleLifecycleTasks()
+
+        #expect(harness.engine.immediateBackgroundRequestCount == 1)
+        #expect(harness.engine.prepareBackgroundCallCount == 1)
+        #expect(harness.engine.immediateForegroundRequestCount == 0)
+        #expect(harness.engine.prepareForegroundCallCount == 0)
+    }
+
+    @Test func protectedDataLockPausesUnsafeFastModePlayback() async {
+        let harness = makeHarness()
+        defer { harness.cleanup() }
+
+        harness.manager.settingsStore.fastPlaybackModeEnabled = true
+        harness.manager.activeRequest = makeRequest(createdAt: 5)
         harness.manager.hasStartedPlaybackForActiveRequest = true
         harness.manager.updateState(.playing)
         await armPlaybackCoordinatorForPause(harness.manager.playbackCoordinator)

--- a/iOS/KeyVoxiOSTests/Core/TTS/TTSSystemPlaybackTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/TTS/TTSSystemPlaybackTests.swift
@@ -339,6 +339,8 @@ private final class SpyPlaybackAudioSession: TTSPlaybackAudioSessionControlling 
         portOverrides.append(portOverride)
     }
 
+    func setAllowHapticsAndSystemSoundsDuringRecording(_ inValue: Bool) throws {}
+
     func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
         activeCalls.append(.init(active: active, options: options))
     }

--- a/iOS/KeyVoxiOSTests/Core/TTS/TTSSystemPlaybackTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/TTS/TTSSystemPlaybackTests.swift
@@ -200,6 +200,28 @@ struct TTSSystemPlaybackTests {
         #expect(coordinator.audioEngine.isRunning == false)
     }
 
+    @Test func repeatedBufferedResumeRequestsEmitSingleResumeCallback() async {
+        let audioSession = SpyPlaybackAudioSession()
+        let coordinator = TTSPlaybackCoordinator(audioSession: audioSession)
+        var resumedCallCount = 0
+
+        coordinator.didStartPlayback = true
+        coordinator.isPaused = true
+        coordinator.isWaitingForResumeBuffer = true
+        coordinator.isFinishing = true
+        coordinator.queuedSampleCount = 1
+        coordinator.onPlaybackResumed = {
+            resumedCallCount += 1
+        }
+
+        coordinator.resumeIfBufferedEnough()
+        coordinator.resumeIfBufferedEnough()
+        await Task.yield()
+        await Task.yield()
+
+        #expect(resumedCallCount == 1)
+    }
+
     @Test func stoppingBeforeBufferedStartTaskRunsKeepsPlaybackStopped() async throws {
         let audioSession = SpyPlaybackAudioSession()
         let coordinator = TTSPlaybackCoordinator(audioSession: audioSession)

--- a/iOS/KeyVoxiOSTests/Core/TTS/TTSSystemPlaybackTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/TTS/TTSSystemPlaybackTests.swift
@@ -176,6 +176,53 @@ struct TTSSystemPlaybackTests {
         #expect(coordinator.hasHandedOffPausedPlaybackSession == false)
     }
 
+    @Test func stoppingBeforeBufferedResumeTaskRunsKeepsPlaybackStopped() async {
+        let audioSession = SpyPlaybackAudioSession()
+        let coordinator = TTSPlaybackCoordinator(audioSession: audioSession)
+        var resumedCallCount = 0
+
+        coordinator.didStartPlayback = true
+        coordinator.isPaused = true
+        coordinator.isWaitingForResumeBuffer = true
+        coordinator.isFinishing = true
+        coordinator.queuedSampleCount = 1
+        coordinator.onPlaybackResumed = {
+            resumedCallCount += 1
+        }
+
+        coordinator.resumeIfBufferedEnough()
+        coordinator.stop()
+        await Task.yield()
+        await Task.yield()
+
+        #expect(resumedCallCount == 0)
+        #expect(coordinator.didStartPlayback == false)
+        #expect(coordinator.audioEngine.isRunning == false)
+    }
+
+    @Test func stoppingBeforeBufferedStartTaskRunsKeepsPlaybackStopped() async throws {
+        let audioSession = SpyPlaybackAudioSession()
+        let coordinator = TTSPlaybackCoordinator(audioSession: audioSession)
+        coordinator.configureAudioGraphIfNeeded()
+        let buffer = try #require(coordinator.makeBuffer(from: Array(repeating: 0.25, count: 2_400)))
+        var startedCallCount = 0
+
+        coordinator.pendingStartBuffers = [buffer]
+        coordinator.activeSilentStartSampleCount = Int(buffer.frameLength)
+        coordinator.onPlaybackStarted = {
+            startedCallCount += 1
+        }
+
+        coordinator.flushPendingStartBuffers()
+        coordinator.stop()
+        await Task.yield()
+        await Task.yield()
+
+        #expect(startedCallCount == 0)
+        #expect(coordinator.didStartPlayback == false)
+        #expect(coordinator.audioEngine.isRunning == false)
+    }
+
     @Test func pausingPlainPlaybackDoesNotDeactivateOrHandoffAudioSession() {
         let audioSession = SpyPlaybackAudioSession()
         let coordinator = TTSPlaybackCoordinator(audioSession: audioSession)

--- a/iOS/KeyVoxiOSTests/Core/Transcription/TranscriptionManagerTests.swift
+++ b/iOS/KeyVoxiOSTests/Core/Transcription/TranscriptionManagerTests.swift
@@ -981,12 +981,12 @@ private final class StubAudioRecorder: AudioRecording {
         return stoppedCapture
     }
 
-    func ensureEngineRunning() throws {
+    func ensureEngineRunning() async throws {
         ensureEngineRunningCallCount += 1
         isMonitoring = true
     }
 
-    func stopMonitoring(keepAudioSessionActive: Bool) throws {
+    func stopMonitoring(keepAudioSessionActive: Bool) async throws {
         stopMonitoringCallCount += 1
         lastStopMonitoringKeepAudioSessionActive = keepAudioSessionActive
         if !stopMonitoringErrors.isEmpty {


### PR DESCRIPTION
## Summary

- Adopt the asynchronous audio-session activation APIs introduced in iOS 27 for recording, speech playback, and voice previews
- Adapt playback lifecycle handling for warm audio sessions, device locking, and cached replay
- Serialize asynchronous audio-session handoffs and prevent stale buffered playback tasks from restarting stopped sessions
- Resolve concurrency warnings for playback voice and model-install state

## Behavior

- Recording and speech playback wait for asynchronous audio-session activation on iOS 27
- Existing synchronous audio-session behavior remains unchanged on earlier iOS releases
- Recorder route recovery and voice previews finish pending deactivation before activating a subsequent session
- Buffered TTS startup and resume tasks cannot restart playback after the active session has stopped or changed
- Warm recording-compatible playback sessions continue allowing app haptics and system sounds
- Cached replay preserves its active audio session and remains available through system playback controls
- Device-lock transitions avoid an incorrect foreground synthesis restore
- Repeated system playback clears are suppressed without changing active playback metadata

## Coverage

- Protected-data lock handling during active fast playback
- Playback startup, pause, resume, seeking, cached replay, and system playback integration
- Stale buffered startup and resume tasks after playback stops
- Recording lifecycle and audio-session protocol changes across app routing and transcription tests
- Concurrency-safe model runtime and playback state access

## Validation

- Manual smoke testing passes on an iPhone Air running iOS 27
- Confirmed speech playback and lock-screen playback controls on a physical device
- Physical-device ordering probes reproduced asynchronous deactivate/reactivate completion inversion for recording and playback sessions
- Complete iOS app suite passes with 384 tests and 0 failures
- Clean iOS app build succeeds
- Xcode reports 0 warnings, 0 analyzer warnings, and 0 errors
- `git diff --check` passes