### PR TITLE
feat(ios-tabbar): use yellow selected item tint

### DIFF
--- a/iOS/KeyVox iOS/Views/MainTabView.swift
+++ b/iOS/KeyVox iOS/Views/MainTabView.swift
@@ -37,10 +37,10 @@ struct MainTabView: View {
                 if #available(iOS 26.0, *) {
                     tabContent
                         .tabBarMinimizeBehavior(.automatic)
-                        .tint(.indigo)
+                        .tint(.yellow)
                 } else {
                     tabContent
-                        .tint(.indigo)
+                        .tint(.yellow)
                 }
             }
             .navigationTitle(selectedTab == .home ? "" : selectedTab.title)


### PR DESCRIPTION
## Summary

- Changes the selected tab bar item from indigo to KeyVox yellow.

## Behavior

- Selected tab icons and labels now display in yellow.
- Unselected tab styling and tab behavior remain unchanged.

## Coverage

- Covers the iOS 26 tab bar presentation path.
- Covers the legacy tab bar presentation path.

## Validation

- Reviewed the focused diff for both selected-item tint paths.
- Confirmed the diff passes whitespace validation.