### PR TITLE
fix(ios-dictionary): prevent repeated add button animation

### DIFF
--- a/iOS/KeyVox iOS/Views/DictionaryTabView/DictionaryTabView.swift
+++ b/iOS/KeyVox iOS/Views/DictionaryTabView/DictionaryTabView.swift
@@ -88,7 +88,6 @@ struct DictionaryTabView: View {
                 DictionaryFloatingAddButton(action: presentAddWordEditor)
                     .scaleEffect(isFloatingAddButtonVisible ? 1 : 0.82)
                     .opacity(isFloatingAddButtonVisible ? 1 : 0)
-                    .animation(.spring(response: 0.26, dampingFraction: 0.72), value: isFloatingAddButtonVisible)
                     .frame(maxWidth: .infinity, alignment: .trailing)
                     .padding(.trailing, 20)
                     .padding(.top, 8)
@@ -132,11 +131,11 @@ struct DictionaryTabView: View {
         }
         .task(id: animationTriggerID) {
             guard isActive, dictionaryEditorMode == nil else {
-                isFloatingAddButtonVisible = false
+                hideFloatingAddButton()
                 return
             }
 
-            isFloatingAddButtonVisible = false
+            hideFloatingAddButton()
 
             if lastPresentedEditorID != nil {
                 try? await Task.sleep(for: .seconds(0.2))
@@ -152,7 +151,7 @@ struct DictionaryTabView: View {
             }
         }
         .onDisappear {
-            isFloatingAddButtonVisible = false
+            hideFloatingAddButton()
             lastPresentedEditorID = nil
             dictionaryStore.clearWarnings()
         }
@@ -161,6 +160,14 @@ struct DictionaryTabView: View {
     private func presentAddWordEditor() {
         appHaptics.light()
         dictionaryEditorMode = .add
+    }
+
+    private func hideFloatingAddButton() {
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            isFloatingAddButtonVisible = false
+        }
     }
 
     private func rebuildDisplayedEntries() {


### PR DESCRIPTION
## Summary

- Prevent the Dictionary add button from jumping during repeated tab switches
- Preserve the existing entrance spring while making tab exits immediate

## Behavior

- The add button now receives one explicit entrance animation when Dictionary becomes active
- Hidden-state resets no longer animate or carry an interrupted exit spring into the next entrance
- Add and edit sheet presentation behavior remains unchanged

## Coverage

- Repeated switching between Dictionary and the same neighboring tab
- Dictionary re-entry after other tab-navigation patterns
- Add-button reappearance after editor dismissal

## Validation

- Analyzed 19 captured Dictionary entries; each contained exactly one task, reset, and show event
- Built successfully for the iPhone 17 Pro simulator destination
- Confirmed the final diff contains one entrance spring and no animation-enabled hide path
- `git diff --check` passed