### PR TITLE
fix(core): require sequential list markers

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -6,7 +6,7 @@ The format loosely follows Keep a Changelog and the package uses semantic versio
 
 ---
 
-## [1.2.9] - 2026-09-07
+## [1.2.9] - 2026-09-10
 
 Dictionary entries with embedded numbers now match their naturally spoken forms.
 
@@ -15,6 +15,7 @@ Dictionary entries with embedded numbers now match their naturally spoken forms.
 - Expanded digit runs inside alphanumeric dictionary terms into spoken-number phrase variants while preserving surrounding text segments.
 - Retained numeric source alignment for each expanded digit run so unrelated spoken numbers remain ineligible.
 - Added regression coverage for spoken matching of an alphanumeric brand and structural coverage for multiple embedded number segments.
+- Required numbered lists to contain consecutive spoken markers instead of converting repeated `one` markers across paragraphs into a sequence.
 
 ### Notes
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternDetector.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternDetector.swift
@@ -72,8 +72,7 @@ public struct ListPatternDetector {
                 }
                 content = cleanedItem
             }
-            let spokenIndex = detection.renumberSequentially ? (index + 1) : marker.number
-            items.append(DetectedListItem(spokenIndex: spokenIndex, content: content))
+            items.append(DetectedListItem(spokenIndex: marker.number, content: content))
         }
 
         guard items.count >= 2 else {
@@ -91,8 +90,7 @@ public struct ListPatternDetector {
             .map { "\($0.spokenIndex){chars=\($0.content.count),words=\($0.content.split(whereSeparator: \.isWhitespace).count)}" }
             .joined(separator: ",")
         logDetector(
-            "accept renumberSequentially=\(detection.renumberSequentially) " +
-            "leading=\(debugTextSummary(leadingText)) " +
+            "accept leading=\(debugTextSummary(leadingText)) " +
             "items=[\(itemSummary)] " +
             "trailing=\(debugTextSummary(trailingText))"
         )

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternRunSelector.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Lists/ListPatternRunSelector.swift
@@ -3,11 +3,9 @@ import NaturalLanguage
 
 public struct ListPatternDetection {
     public let run: [ListPatternMarker]
-    public let renumberSequentially: Bool
 
-    public init(run: [ListPatternMarker], renumberSequentially: Bool) {
+    public init(run: [ListPatternMarker]) {
         self.run = run
-        self.renumberSequentially = renumberSequentially
     }
 }
 
@@ -30,11 +28,7 @@ public struct ListPatternRunSelector {
         languageCode: String?
     ) -> ListPatternDetection? {
         if let bestRun = bestMonotonicRun(from: markers, in: text, languageCode: languageCode), bestRun.count >= 2 {
-            return ListPatternDetection(run: bestRun, renumberSequentially: false)
-        }
-        if let restartedRun = restartedOneRunAcrossParagraphBreaks(from: markers, in: text),
-           restartedRun.count >= 2 {
-            return ListPatternDetection(run: restartedRun, renumberSequentially: true)
+            return ListPatternDetection(run: bestRun)
         }
         return nil
     }
@@ -484,43 +478,4 @@ public struct ListPatternRunSelector {
         return prefix.range(of: boundaryPattern, options: .regularExpression) != nil
     }
 
-    // Paragraph chunking can restart list numbering context between chunks
-    // (e.g. "one ...", "one ...", "one ..."). Recover list intent only when
-    // those restarts are separated by explicit paragraph breaks.
-    private func restartedOneRunAcrossParagraphBreaks(from markers: [ListPatternMarker], in text: String) -> [ListPatternMarker]? {
-        guard markers.count >= 2 else { return nil }
-        let nsText = text as NSString
-
-        var best: [ListPatternMarker] = []
-        var current: [ListPatternMarker] = []
-
-        for marker in markers {
-            guard marker.number == 1 else {
-                if current.count > best.count { best = current }
-                current = []
-                continue
-            }
-
-            guard let previous = current.last else {
-                current = [marker]
-                continue
-            }
-
-            let gapStart = previous.contentStart
-            let gapLength = max(0, marker.markerTokenStart - gapStart)
-            let gap = nsText.substring(with: NSRange(location: gapStart, length: gapLength))
-            if gap.contains("\n\n") {
-                current.append(marker)
-            } else {
-                if current.count > best.count { best = current }
-                current = [marker]
-            }
-        }
-
-        if current.count > best.count {
-            best = current
-        }
-
-        return best.count >= 2 ? best : nil
-    }
 }

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Lists/ListPatternDetectorTests.swift
@@ -129,7 +129,7 @@ final class ListPatternDetectorTests: XCTestCase {
         XCTAssertTrue(detected?.trailingText == "and because we leave early")
     }
 
-    func testDetectsRestartedOneMarkersAcrossParagraphBreaks() {
+    func testDoesNotDetectRepeatedOneMarkersAcrossParagraphBreaks() {
         let detector = ListPatternDetector()
         let text = """
         For this trip:
@@ -142,9 +142,7 @@ final class ListPatternDetectorTests: XCTestCase {
         """
 
         let detected = detector.detectList(in: text)
-        XCTAssertTrue(detected != nil)
-        XCTAssertTrue(detected?.items.map(\.spokenIndex) == [1, 2, 3])
-        XCTAssertTrue(detected?.items.map(\.content) == ["Pack charger", "Pack toothbrush", "Pack socks"])
+        XCTAssertNil(detected)
     }
 
     func testDoesNotDetectRestartedOneMarkersWithoutParagraphBreaks() {


### PR DESCRIPTION
## Summary

- Stop repeated paragraph-separated `one` markers from being renumbered as a list
- Preserve normal list detection for consecutive spoken markers
- Update the current KeyVoxCore changelog entry

## Behavior

- Incidental repeated markers no longer fabricate later list indices
- Genuine consecutive markers retain their spoken values
- Paragraph formatting remains unchanged

## Coverage

- Repeated `one` markers across paragraph boundaries are rejected
- Existing sequential, explicit, and paragraph-aware list scenarios remain covered

## Validation

- Confirmed the reported failure path from captured pipeline diagnostics
- Verified four controlled local Whisper samples preserved spoken `1`, `2`, and `3` across independent chunks
- KeyVoxCore test suite: 557 tests passed with 0 failures
- `git diff --check` passed