### PR TITLE
fix(core): preserve continuation casing after ellipses

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -24,6 +24,7 @@ Core now also provides portable audio, resource, linguistic, and runtime boundar
 - Added shared state publishing and injectable Whisper and Parakeet runtime boundaries without changing the platform-native defaults.
 - Propagated the selected or detected dictation language through continuation analysis, post-processing, pipeline results, and downstream text processing.
 - Added portable linguistic evidence that allows qualifying quantities before following words to receive thousands separators.
+- Kept words after inline ellipses lowercase while preserving stylized dictionary entries and capitalization at real paragraph breaks.
 
 ### Notes
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/EllipsisContinuationNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/EllipsisContinuationNormalizer.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct EllipsisContinuationNormalizer {
+    private static let continuationRegex = try? NSRegularExpression(
+        pattern: #"(?:\.{3,}|…+)[\"'”’\)\]\}]*[ \t]*[\"'“”‘’\(\[\{]*([\p{L}][\p{L}\p{M}\p{N}_'’-]*)"#
+    )
+
+    func normalize(in text: String, dictionaryEntries: [DictionaryEntry]) -> String {
+        guard let regex = Self.continuationRegex else { return text }
+
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        let matches = regex.matches(in: text, options: [], range: fullRange)
+        guard !matches.isEmpty else { return text }
+
+        let stylizedEntries = Set(
+            dictionaryEntries
+                .map(\.phrase)
+                .filter(isStylizedSingleToken)
+        )
+        let mutable = NSMutableString(string: text)
+
+        for match in matches.reversed() {
+            let tokenRange = match.range(at: 1)
+            let token = nsText.substring(with: tokenRange)
+            guard token.first?.isUppercase == true,
+                  !stylizedEntries.contains(token),
+                  let firstScalar = token.unicodeScalars.first else {
+                continue
+            }
+
+            mutable.replaceCharacters(
+                in: NSRange(location: tokenRange.location, length: String(firstScalar).utf16.count),
+                with: String(firstScalar).lowercased()
+            )
+        }
+
+        return mutable as String
+    }
+
+    private func isStylizedSingleToken(_ phrase: String) -> Bool {
+        guard !phrase.contains(where: \.isWhitespace) else { return false }
+        let scalars = Array(phrase.unicodeScalars)
+        guard scalars.count > 1 else { return false }
+        return scalars.dropFirst().contains { $0.properties.isUppercase }
+    }
+}

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Transcription/TranscriptionPostProcessor.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Transcription/TranscriptionPostProcessor.swift
@@ -36,6 +36,7 @@ public final class TranscriptionPostProcessor: @unchecked Sendable {
     private let allCapsOverrideNormalizer = AllCapsOverrideNormalizer()
     private let whitespaceNormalizer = WhitespaceNormalizer()
     private let capitalizationNormalizer = SentenceCapitalizationNormalizer()
+    private let ellipsisContinuationNormalizer = EllipsisContinuationNormalizer()
     private let terminalPunctuationNormalizer = TerminalPunctuationNormalizer()
     private let terminalPeriodNormalizer = TerminalPeriodNormalizer()
     private var dictionaryFingerprint = ""
@@ -267,8 +268,15 @@ public final class TranscriptionPostProcessor: @unchecked Sendable {
         #if DEBUG
         logPipelineStage("sentenceNormalized", sentenceNormalized)
         #endif
+        let ellipsisContinuationNormalized = ellipsisContinuationNormalizer.normalize(
+            in: sentenceNormalized,
+            dictionaryEntries: dictionaryEntries
+        )
+        #if DEBUG
+        logPipelineStage("ellipsisContinuationNormalized", ellipsisContinuationNormalized)
+        #endif
         let punctuatedOutput = terminalPunctuationNormalizer.appendTerminalPeriodIfEndingInFormattedTime(
-            sentenceNormalized
+            ellipsisContinuationNormalized
         )
         let terminalPeriodNormalized = terminalPeriodNormalizer.appendTerminalPeriodIfNeeded(
             to: punctuatedOutput,

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+Ellipsis.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+Ellipsis.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import KeyVoxCore
+
+@MainActor
+extension TranscriptionPostProcessorTests {
+    func testEllipsisContinuationCasing() async {
+        let processor = TranscriptionPostProcessor()
+        let stylizedToken = "KvX"
+        let cases: [(String, [DictionaryEntry], String)] = [
+            ("A... B.", [], "A... b."),
+            ("C… D.", [], "C… d."),
+            ("E... \(stylizedToken).", [DictionaryEntry(phrase: stylizedToken)], "E... \(stylizedToken)."),
+            ("F...\n\ng.", [], "F...\n\nG."),
+        ]
+
+        for (input, dictionaryEntries, expected) in cases {
+            let output = processor.process(
+                input,
+                dictionaryEntries: dictionaryEntries,
+                renderMode: .multiline
+            )
+
+            XCTAssertEqual(output, expected)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Keep ordinary words lowercase after inline ellipses.
- Preserve stylized dictionary entries and capitalization at real paragraph breaks.

## Behavior

- Treat ASCII and Unicode ellipses as continuations rather than sentence boundaries.
- Apply the rule through the shared transcription post-processor across providers.
- Leave genuine paragraph-boundary capitalization unchanged.

## Coverage

- Cover ASCII and Unicode ellipses, stylized dictionary entries, and paragraph breaks in one focused regression test.

## Validation

- KeyVoxCore focused ellipsis regression test passed.
- Full KeyVoxCore package suite passed: 587 tests, 0 failures.
- Staged diff validation passed with no whitespace errors.