### PR TITLE
fix(core): normalize ellipses without corrupting casing

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -24,7 +24,8 @@ Core now also provides portable audio, resource, linguistic, and runtime boundar
 - Added shared state publishing and injectable Whisper and Parakeet runtime boundaries without changing the platform-native defaults.
 - Propagated the selected or detected dictation language through continuation analysis, post-processing, pipeline results, and downstream text processing.
 - Added portable linguistic evidence that allows qualifying quantities before following words to receive thousands separators.
-- Kept words after inline ellipses lowercase while preserving stylized dictionary entries and capitalization at real paragraph breaks.
+- Kept words after inline ellipses lowercase while preserving stylized dictionary entries, standalone `I`, and capitalization at real paragraph breaks.
+- Normalized spoken and three-period ellipses to Unicode.
 
 ### Notes
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/EllipsisContinuationNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/EllipsisContinuationNormalizer.swift
@@ -13,19 +13,18 @@ struct EllipsisContinuationNormalizer {
         let matches = regex.matches(in: text, options: [], range: fullRange)
         guard !matches.isEmpty else { return text }
 
-        let stylizedEntries = Set(
-            dictionaryEntries
-                .map(\.phrase)
-                .filter(isStylizedSingleToken)
-        )
         let mutable = NSMutableString(string: text)
 
         for match in matches.reversed() {
             let tokenRange = match.range(at: 1)
             let token = nsText.substring(with: tokenRange)
             guard token.first?.isUppercase == true,
-                  token != "I",
-                  !stylizedEntries.contains(token),
+                  !shouldPreserveCasing(
+                      of: token,
+                      at: tokenRange,
+                      in: text,
+                      dictionaryEntries: dictionaryEntries
+                  ),
                   let firstScalar = token.unicodeScalars.first else {
                 continue
             }
@@ -39,10 +38,51 @@ struct EllipsisContinuationNormalizer {
         return mutable as String
     }
 
-    private func isStylizedSingleToken(_ phrase: String) -> Bool {
-        guard !phrase.contains(where: \.isWhitespace) else { return false }
-        let scalars = Array(phrase.unicodeScalars)
-        guard scalars.count > 1 else { return false }
-        return scalars.dropFirst().contains { $0.properties.isUppercase }
+    private func shouldPreserveCasing(
+        of token: String,
+        at tokenRange: NSRange,
+        in text: String,
+        dictionaryEntries: [DictionaryEntry]
+    ) -> Bool {
+        token == "I"
+            || token.unicodeScalars.dropFirst().contains { $0.properties.isUppercase }
+            || isDottedAcronym(startingAt: tokenRange, in: text)
+            || beginsDictionaryEntry(at: tokenRange, in: text, dictionaryEntries: dictionaryEntries)
+    }
+
+    private func isDottedAcronym(startingAt tokenRange: NSRange, in text: String) -> Bool {
+        guard let tokenStringRange = Range(tokenRange, in: text) else { return false }
+        return text[tokenStringRange.lowerBound...].range(
+            of: #"^(?:\p{Lu}\.){2,}"#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private func beginsDictionaryEntry(
+        at tokenRange: NSRange,
+        in text: String,
+        dictionaryEntries: [DictionaryEntry]
+    ) -> Bool {
+        guard let tokenStringRange = Range(tokenRange, in: text) else { return false }
+        let suffix = text[tokenStringRange.lowerBound...]
+
+        for entry in dictionaryEntries {
+            let phrase = entry.phrase.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !phrase.isEmpty,
+                  let match = suffix.range(
+                      of: phrase,
+                      options: [.anchored, .caseInsensitive, .diacriticInsensitive]
+                  ) else {
+                continue
+            }
+
+            guard match.upperBound < suffix.endIndex else { return true }
+            let nextCharacter = suffix[match.upperBound]
+            if !nextCharacter.isLetter, !nextCharacter.isNumber, nextCharacter != "_" {
+                return true
+            }
+        }
+
+        return false
     }
 }

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/EllipsisContinuationNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/EllipsisContinuationNormalizer.swift
@@ -24,6 +24,7 @@ struct EllipsisContinuationNormalizer {
             let tokenRange = match.range(at: 1)
             let token = nsText.substring(with: tokenRange)
             guard token.first?.isUppercase == true,
+                  token != "I",
                   !stylizedEntries.contains(token),
                   let firstScalar = token.unicodeScalars.first else {
                 continue

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/SentenceCapitalizationNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/SentenceCapitalizationNormalizer.swift
@@ -114,6 +114,9 @@ public struct SentenceCapitalizationNormalizer {
                 if isLikelyFilenameExtensionBoundary(text, dotLocation: match.range(at: 1).location) {
                     continue
                 }
+                if isDottedAbbreviationBoundary(text, dotLocation: match.range(at: 1).location) {
+                    continue
+                }
 
                 let prefixText = nsText.substring(to: match.range(at: 1).location)
                 let previousToken = prefixText.split(whereSeparator: \.isWhitespace).last.map(String.init) ?? ""
@@ -469,5 +472,28 @@ public struct SentenceCapitalizationNormalizer {
         }
 
         return FileExtensionRecognition.status(for: extensionToken) == .known
+    }
+
+    private func isDottedAbbreviationBoundary(_ text: String, dotLocation: Int) -> Bool {
+        let nsText = text as NSString
+        guard dotLocation >= 0, dotLocation < nsText.length else { return false }
+
+        var start = dotLocation
+        while start > 0 {
+            guard let scalar = UnicodeScalar(nsText.character(at: start - 1)),
+                  !CharacterSet.whitespacesAndNewlines.contains(scalar) else {
+                break
+            }
+            start -= 1
+        }
+
+        let candidate = nsText.substring(
+            with: NSRange(location: start, length: dotLocation - start + 1)
+        ).trimmingCharacters(in: CharacterSet(charactersIn: "\"'“”‘’()[]{}"))
+
+        return candidate.range(
+            of: #"^(?:\p{L}\.){2,}$"#,
+            options: .regularExpression
+        ) != nil
     }
 }

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/TerminalPunctuationNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/TerminalPunctuationNormalizer.swift
@@ -27,7 +27,7 @@ public struct TerminalPunctuationNormalizer {
         pattern: #"[.!?…][\"'”’\)\]\}]*\s*$"#
     )
     private static let literalEllipsisRegex = try? NSRegularExpression(
-        pattern: #"\.{3}"#
+        pattern: #"\.{3,}(?:[ \t]+\.)?"#
     )
 
     public init() {}

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/TerminalPunctuationNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/TerminalPunctuationNormalizer.swift
@@ -26,24 +26,75 @@ public struct TerminalPunctuationNormalizer {
     private static let terminalSentencePunctuationRegex = try? NSRegularExpression(
         pattern: #"[.!?…][\"'”’\)\]\}]*\s*$"#
     )
+    private static let literalEllipsisRegex = try? NSRegularExpression(
+        pattern: #"\.{3}"#
+    )
 
     public init() {}
 
     public func normalizeSpokenTerminalPunctuation(in text: String) -> String {
         guard !text.isEmpty else { return text }
 
-        let words = wordTokens(in: text)
-        guard !words.isEmpty else { return text }
-        let commandMatches = terminalCommandMatches(in: words, text: text)
-            .filter { isEligibleCommand(match: $0, words: words, text: text) }
-        guard !commandMatches.isEmpty else { return text }
+        var normalized = normalizeSpokenEllipses(in: normalizeLiteralEllipses(in: text))
+        let words = wordTokens(in: normalized)
+        guard !words.isEmpty else { return normalized }
+        let commandMatches = terminalCommandMatches(in: words, text: normalized)
+            .filter { isEligibleCommand(match: $0, words: words, text: normalized) }
+        guard !commandMatches.isEmpty else { return normalized }
 
-        var normalized = text
         for commandMatch in commandMatches.reversed() {
             let replacementRange = replacementRange(for: commandMatch, words: words, text: normalized)
             normalized.replaceSubrange(replacementRange, with: commandMatch.symbols)
         }
         return normalized
+    }
+
+    private func normalizeLiteralEllipses(in text: String) -> String {
+        guard let regex = Self.literalEllipsisRegex else { return text }
+        let range = NSRange(location: 0, length: (text as NSString).length)
+        return regex.stringByReplacingMatches(in: text, options: [], range: range, withTemplate: "…")
+    }
+
+    private func normalizeSpokenEllipses(in text: String) -> String {
+        let words = wordTokens(in: text)
+        guard words.count >= 3 else { return text }
+
+        var matches: [CommandMatch] = []
+        var index = words.startIndex
+
+        while index + 2 < words.endIndex {
+            let nextIndex = index + 1
+            let finalIndex = index + 2
+
+            guard isSpokenDot(words[index]),
+                  isSpokenDot(words[nextIndex]),
+                  isSpokenDot(words[finalIndex]),
+                  isPunctuationOnly(text[words[index].range.upperBound..<words[nextIndex].range.lowerBound]),
+                  isPunctuationOnly(text[words[nextIndex].range.upperBound..<words[finalIndex].range.lowerBound]) else {
+                index += 1
+                continue
+            }
+
+            matches.append(CommandMatch(firstWordIndex: index, nextWordIndex: finalIndex + 1, symbols: "…"))
+            index = finalIndex + 1
+        }
+
+        guard !matches.isEmpty else { return text }
+
+        var normalized = text
+        for match in matches.reversed() {
+            let range = replacementRange(for: match, words: words, text: normalized)
+            normalized.replaceSubrange(range, with: match.symbols)
+        }
+        return normalized
+    }
+
+    private func isSpokenDot(_ word: WordToken) -> Bool {
+        word.text.caseInsensitiveCompare("dot") == .orderedSame
+    }
+
+    private func isPunctuationOnly(_ text: Substring) -> Bool {
+        text.allSatisfy { $0.isWhitespace || $0.isPunctuation }
     }
 
     func hasTerminalSentencePunctuation(_ text: String) -> Bool {

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+Ellipsis.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+Ellipsis.swift
@@ -7,10 +7,11 @@ extension TranscriptionPostProcessorTests {
         let processor = TranscriptionPostProcessor()
         let stylizedToken = "KvX"
         let cases: [(String, [DictionaryEntry], String)] = [
-            ("A... B.", [], "A... b."),
+            ("A... B.", [], "A… b."),
             ("C… D.", [], "C… d."),
-            ("E... \(stylizedToken).", [DictionaryEntry(phrase: stylizedToken)], "E... \(stylizedToken)."),
-            ("F...\n\ng.", [], "F...\n\nG."),
+            ("E... \(stylizedToken).", [DictionaryEntry(phrase: stylizedToken)], "E… \(stylizedToken)."),
+            ("F...\n\ng.", [], "F…\n\nG."),
+            ("Well... I agree.", [], "Well… I agree."),
         ]
 
         for (input, dictionaryEntries, expected) in cases {

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+Ellipsis.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+Ellipsis.swift
@@ -7,11 +7,22 @@ extension TranscriptionPostProcessorTests {
         let processor = TranscriptionPostProcessor()
         let stylizedToken = "KvX"
         let cases: [(String, [DictionaryEntry], String)] = [
-            ("A... B.", [], "A… b."),
-            ("C… D.", [], "C… d."),
-            ("E... \(stylizedToken).", [DictionaryEntry(phrase: stylizedToken)], "E… \(stylizedToken)."),
-            ("F...\n\ng.", [], "F…\n\nG."),
-            ("Well... I agree.", [], "Well… I agree."),
+            ("Okay, now... Split up the work.", [], "Okay, now… split up the work."),
+            ("We paused… Then continued.", [], "We paused… then continued."),
+            ("We paused dot dot dot. Then continued.", [], "We paused… then continued."),
+            ("We paused... “Then continued.”", [], "We paused… “then continued.”"),
+            ("We paused... (Then continued.)", [], "We paused… (then continued.)"),
+            ("We paused... \(stylizedToken) responded.", [], "We paused… \(stylizedToken) responded."),
+            ("We paused... GPT 5.6 responded.", [], "We paused… GPT 5.6 responded."),
+            ("We paused... U.S. officials responded.", [], "We paused… U.S. officials responded."),
+            ("We paused... I agreed.", [], "We paused… I agreed."),
+            ("Hello. . . .", [], "Hello…"),
+            (
+                "We paused... Dom Esposito responded.",
+                [DictionaryEntry(phrase: "Dom Esposito")],
+                "We paused… Dom Esposito responded."
+            ),
+            ("We paused...\n\nthen continued.", [], "We paused…\n\nThen continued."),
         ]
 
         for (input, dictionaryEntries, expected) in cases {

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+Email.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+Email.swift
@@ -513,12 +513,12 @@ extension TranscriptionPostProcessorTests {
         let processor = TranscriptionPostProcessor()
 
         let output = processor.process(
-            "Oh yeah, itsuh...dom@example.com.that's my email address.",
+            "Oh yeah, it's uh...dom@example.com.that's my email address.",
             dictionaryEntries: [],
             renderMode: .singleLineInline
         )
 
-        XCTAssertEqual(output, "Oh yeah, itsuh... dom@example.com. That's my email address.")
+        XCTAssertEqual(output, "Oh yeah, it's uh… dom@example.com. That's my email address.")
     }
     func testSeparatesCollapsedPrefixFromKnownDictionaryEmail() async {
         let processor = TranscriptionPostProcessor()

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Normalization/TerminalPunctuationNormalizerTests.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Normalization/TerminalPunctuationNormalizerTests.swift
@@ -2,6 +2,22 @@ import XCTest
 @testable import KeyVoxCore
 
 final class TerminalPunctuationNormalizerTests: LinguisticAnalyzerTestCase {
+    func testCanonicalizesThreeDotsToUnicodeEllipsis() {
+        let normalizer = TerminalPunctuationNormalizer()
+        let cases = [
+            ("dot dot dot", "…"),
+            ("dot, dot, dot", "…"),
+            ("dot. Dot dot", "…"),
+            ("Wait dot dot dot maybe", "Wait… maybe"),
+            ("Wait... maybe", "Wait… maybe"),
+            ("...", "…"),
+        ]
+
+        for (input, expected) in cases {
+            XCTAssertEqual(normalizer.normalizeSpokenTerminalPunctuation(in: input), expected)
+        }
+    }
+
     func testConvertsTerminalQuestionMarkCommand() {
         let normalizer = TerminalPunctuationNormalizer()
 

--- a/Packages/KeyVoxStyleRewrite/CHANGELOG.md
+++ b/Packages/KeyVoxStyleRewrite/CHANGELOG.md
@@ -17,6 +17,7 @@ Vibes rewrite repair now uses shared, health-routed linguistic analysis across s
 - Passed request language into the configured analyzer so a shared health router can select a matching portable provider when native evidence is unhealthy.
 - Carried dictation language context through rewrite requests and saved utterance artifacts so initial and later style changes use the same language-aware analysis.
 - Preserved currency-unit evidence when lemmas are unavailable and tightened ambiguous split-date handling without relying on example-specific vocabulary.
+- Preserved source-backed ellipses through shared output repair for Casual, Polished, and Chill rewrites.
 
 ### Notes
 

--- a/Packages/KeyVoxStyleRewrite/Sources/KeyVoxStyleRewrite/OutputRepair/Repairs/TerminalPunctuationBoundaryRepair.swift
+++ b/Packages/KeyVoxStyleRewrite/Sources/KeyVoxStyleRewrite/OutputRepair/Repairs/TerminalPunctuationBoundaryRepair.swift
@@ -119,8 +119,8 @@ struct TerminalPunctuationBoundaryRepair {
     }
 
     private func punctuationCluster(in text: Substring) -> String? {
-        let punctuation = text.filter { $0 == "!" || $0 == "?" }
-        guard punctuation.contains("!") else {
+        let punctuation = text.filter { $0 == "!" || $0 == "?" || $0 == "…" }
+        guard punctuation.contains("!") || punctuation.contains("…") else {
             return nil
         }
 

--- a/Packages/KeyVoxStyleRewrite/Tests/KeyVoxStyleRewriteTests/OutputRepair/TerminalPunctuationBoundaryRepairTests.swift
+++ b/Packages/KeyVoxStyleRewrite/Tests/KeyVoxStyleRewriteTests/OutputRepair/TerminalPunctuationBoundaryRepairTests.swift
@@ -3,6 +3,20 @@ import XCTest
 @testable import KeyVoxStyleRewrite
 
 final class TerminalPunctuationBoundaryRepairTests: LinguisticAnalyzerTestCase {
+    func testTerminalPunctuationBoundaryRepairRestoresSourceEllipsis() {
+        let inlineOutput = TerminalPunctuationBoundaryRepair().repair(
+            original: "Well… I agree.",
+            rewritten: "well i agree"
+        )
+        let terminalOutput = TerminalPunctuationBoundaryRepair().repair(
+            original: "Wait…",
+            rewritten: "wait"
+        )
+
+        XCTAssertEqual(inlineOutput, "well… i agree")
+        XCTAssertEqual(terminalOutput, "wait…")
+    }
+
     func testTerminalPunctuationBoundaryRepairRestoresSourceBoundaryExclamation() {
         let output = TerminalPunctuationBoundaryRepair().repair(
             original: "That is wild! Are we shipping this?",


### PR DESCRIPTION
## Summary

- Normalize spoken and model-generated ellipses to the Unicode ellipsis character.
- Preserve dictionary entries, acronyms, and standalone I while keeping ordinary inline continuations lowercase.
- Preserve source-backed ellipses through every Vibes rewrite style.

## Behavior

- Convert spoken dot sequences, punctuation-separated spoken variants, literal period runs, and separated trailing model periods to a single Unicode ellipsis.
- Treat inline ellipses as continuations without lowercasing matching dictionary phrases, mixed-case terms, acronyms, dotted abbreviations, or standalone I.
- Keep words after dotted abbreviations lowercase when the abbreviation is not a sentence boundary.
- Preserve capitalization at real paragraph breaks.
- Restore inline and terminal ellipses through Casual, Polished, and Chill output repair.

## Coverage

- Cover spoken, literal, and model-separated ellipsis shapes through shared Core processing.
- Cover ordinary continuations, quotes, brackets, dictionary names, acronyms, dotted abbreviations, standalone I, and paragraph boundaries.
- Cover inline and terminal ellipsis restoration through shared Vibes output repair.

## Validation

- KeyVoxCore package suite passed: 588 tests, 0 failures.
- KeyVoxStyleRewrite package suite passed: 126 tests, 0 failures.
- Diff validation passed with no whitespace errors.