### PR TITLE
fix(composition): attach dictated ellipses to existing text

### DIFF
--- a/Packages/KeyVoxTextComposition/CHANGELOG.md
+++ b/Packages/KeyVoxTextComposition/CHANGELOG.md
@@ -17,6 +17,7 @@ Shared text composition now provides portable insertion behavior for Apple and A
 - Added calendar-date prefix detection and explicit document-start context for consistent capitalization decisions.
 - Moved dictionary-aware leading capitalization into a shared policy that can be used by each client’s editor integration.
 - Added platform-neutral verification and probe targets for consuming the same composition behavior outside Apple application targets.
+- Attached a dictated ellipsis directly to preceding editor text without inserting a space.
 
 ### Notes
 

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
@@ -364,7 +364,7 @@ public enum TextCompositionPolicy {
             return false
         }
 
-        let punctuation = CharacterSet(charactersIn: ".,!?;:)]}\\\"'”’&")
+        let punctuation = CharacterSet(charactersIn: ".,!?;:…)]}\\\"'”’&")
         if firstIncomingCharacter.unicodeScalars.allSatisfy(punctuation.contains) {
             return false
         }

--- a/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TextCompositionPolicyTests.swift
+++ b/Packages/KeyVoxTextComposition/Tests/KeyVoxTextCompositionTests/TextCompositionPolicyTests.swift
@@ -441,6 +441,8 @@ final class TextCompositionPolicyTests: XCTestCase {
         XCTAssertEqual(applySpacing(to: "there", after: "&"), " there")
         XCTAssertEqual(applySpacing(to: "there", after: "😎"), " there")
         XCTAssertEqual(applySpacing(to: ".", after: "o"), ".")
+        XCTAssertEqual(applySpacing(to: "…", after: "o"), "…")
+        XCTAssertEqual(applySpacing(to: "…", after: "7"), "…")
         XCTAssertEqual(applySpacing(to: "there", after: " "), "there")
         XCTAssertEqual(applySpacing(to: "there", after: "("), "there")
     }


### PR DESCRIPTION
## Summary

- Attach a dictated ellipsis directly to existing editor text.
- Add focused composition coverage for preceding letters and numbers.
- Document the corrected behavior in the current composition changelog entry.

## Behavior

- Existing text followed by a newly dictated ellipsis now composes as `text…` instead of `text …`.
- Existing leading-spacing behavior for ordinary dictated text remains unchanged.

## Coverage

- Covers ellipsis insertion after an existing letter.
- Covers ellipsis insertion after an existing number.

## Validation

- KeyVoxTextComposition package suite: 44 tests passed.
- `git diff --check` passed.