### PR TITLE
fix(composition): preserve spacing in optimized builds

### DIFF
--- a/Packages/KeyVoxTextComposition/CHANGELOG.md
+++ b/Packages/KeyVoxTextComposition/CHANGELOG.md
@@ -18,6 +18,7 @@ Shared text composition now provides portable insertion behavior for Apple and A
 - Moved dictionary-aware leading capitalization into a shared policy that can be used by each client’s editor integration.
 - Added platform-neutral verification and probe targets for consuming the same composition behavior outside Apple application targets.
 - Attached a dictated ellipsis directly to preceding editor text without inserting a space.
+- Preserved leading spaces after existing punctuation in optimized release builds.
 
 ### Notes
 

--- a/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
+++ b/Packages/KeyVoxTextComposition/Sources/KeyVoxTextComposition/TextCompositionPolicy.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public enum TextCompositionPolicy {
+    private static let attachingPunctuation = Set(".,!?;:…)]}\\\"'”’&".unicodeScalars)
+
     public static func composeForInsertion(
         text: String,
         precedingContext: TextCompositionContext?,
@@ -364,8 +366,7 @@ public enum TextCompositionPolicy {
             return false
         }
 
-        let punctuation = CharacterSet(charactersIn: ".,!?;:…)]}\\\"'”’&")
-        if firstIncomingCharacter.unicodeScalars.allSatisfy(punctuation.contains) {
+        if firstIncomingCharacter.unicodeScalars.allSatisfy(attachingPunctuation.contains) {
             return false
         }
 
@@ -377,7 +378,7 @@ public enum TextCompositionPolicy {
             CharacterSet.alphanumerics.contains($0)
         }
         let previousIsTriggerPunctuation = previousCharacter.unicodeScalars.contains(
-            where: punctuation.contains
+            where: attachingPunctuation.contains
         )
         return previousIsWordLike
             || previousIsTriggerPunctuation


### PR DESCRIPTION
## Summary

- Preserve leading spaces after existing punctuation in optimized builds
- Keep ellipsis attachment behavior unchanged
- Record the correction in the current composition changelog entry

## Behavior

- Dictation following a sentence-ending punctuation mark receives the expected leading separator
- Incoming punctuation, including ellipses, remains attached to preceding editor text
- Existing delimiter and whitespace behavior remains unchanged

## Coverage

- Existing punctuation-boundary coverage reproduces the optimized-build regression
- Period, ampersand, ellipsis, word, whitespace, and opening-delimiter cases remain covered

## Validation

- Focused Release-optimized reproduction failed before the change and passed afterward
- KeyVoxTextComposition Release suite: 44 tests passed
- macOS Release scheme build succeeded
- Git diff validation passed