### PR TITLE
fix(core): cover ellipsis normalization edges

### DIFF
--- a/Packages/KeyVoxCore/CHANGELOG.md
+++ b/Packages/KeyVoxCore/CHANGELOG.md
@@ -24,8 +24,8 @@ Core now also provides portable audio, resource, linguistic, and runtime boundar
 - Added shared state publishing and injectable Whisper and Parakeet runtime boundaries without changing the platform-native defaults.
 - Propagated the selected or detected dictation language through continuation analysis, post-processing, pipeline results, and downstream text processing.
 - Added portable linguistic evidence that allows qualifying quantities before following words to receive thousands separators.
-- Kept words after inline ellipses lowercase while preserving stylized dictionary entries, standalone `I`, and capitalization at real paragraph breaks.
-- Normalized spoken and three-period ellipses to Unicode.
+- Kept words after inline ellipses lowercase while preserving recognized multiword names, stylized dictionary entries, standalone `I`, first-person `I` contractions, and capitalization at real paragraph breaks.
+- Normalized spoken, three-period, and Parakeet-emitted `.dot.dot.` ellipses to Unicode.
 
 ### Notes
 

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/EllipsisContinuationNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/EllipsisContinuationNormalizer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import KeyVoxLinguistics
 
 struct EllipsisContinuationNormalizer {
     private static let continuationRegex = try? NSRegularExpression(
@@ -44,10 +45,44 @@ struct EllipsisContinuationNormalizer {
         in text: String,
         dictionaryEntries: [DictionaryEntry]
     ) -> Bool {
-        token == "I"
+        isFirstPersonPronoun(token)
             || token.unicodeScalars.dropFirst().contains { $0.properties.isUppercase }
+            || beginsRecognizedNamePhrase(at: tokenRange, in: text)
             || isDottedAcronym(startingAt: tokenRange, in: text)
             || beginsDictionaryEntry(at: tokenRange, in: text, dictionaryEntries: dictionaryEntries)
+    }
+
+    private func isFirstPersonPronoun(_ token: String) -> Bool {
+        guard token.first == "I" else { return false }
+        let remainder = token.dropFirst()
+        guard !remainder.isEmpty else { return true }
+        guard remainder.first == "'" || remainder.first == "’" else { return false }
+        let contraction = remainder.dropFirst()
+        return !contraction.isEmpty && contraction.allSatisfy { $0.isLetter }
+    }
+
+    private func beginsRecognizedNamePhrase(at tokenRange: NSRange, in text: String) -> Bool {
+        let analysis = TextLinguistics.analyze(
+            text,
+            features: [.names, .wordBoundaries]
+        )
+        guard let tokenIndex = analysis.tokens.firstIndex(where: {
+            NSLocationInRange(tokenRange.location, $0.range)
+        }),
+        tokenIndex + 1 < analysis.tokens.count else { return false }
+
+        let token = analysis.tokens[tokenIndex]
+        let nextToken = analysis.tokens[tokenIndex + 1]
+        guard case .name = token.identity,
+              case .name = nextToken.identity,
+              let separatorRange = Range(
+                  NSRange(
+                      location: NSMaxRange(token.range),
+                      length: nextToken.range.location - NSMaxRange(token.range)
+                  ),
+                  in: text
+              ) else { return false }
+        return text[separatorRange].allSatisfy(\.isWhitespace)
     }
 
     private func isDottedAcronym(startingAt tokenRange: NSRange, in text: String) -> Bool {

--- a/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/TerminalPunctuationNormalizer.swift
+++ b/Packages/KeyVoxCore/Sources/KeyVoxCore/Normalization/TerminalPunctuationNormalizer.swift
@@ -35,7 +35,12 @@ public struct TerminalPunctuationNormalizer {
     public func normalizeSpokenTerminalPunctuation(in text: String) -> String {
         guard !text.isEmpty else { return text }
 
-        var normalized = normalizeSpokenEllipses(in: normalizeLiteralEllipses(in: text))
+        let artifactNormalized = text.replacingOccurrences(
+            of: ".dot.dot.",
+            with: "…",
+            options: .caseInsensitive
+        )
+        var normalized = normalizeSpokenEllipses(in: normalizeLiteralEllipses(in: artifactNormalized))
         let words = wordTokens(in: normalized)
         guard !words.isEmpty else { return normalized }
         let commandMatches = terminalCommandMatches(in: words, text: normalized)

--- a/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+Ellipsis.swift
+++ b/Packages/KeyVoxCore/Tests/KeyVoxCoreTests/Core/TranscriptionPostProcessorTests+Ellipsis.swift
@@ -16,7 +16,20 @@ extension TranscriptionPostProcessorTests {
             ("We paused... GPT 5.6 responded.", [], "We paused… GPT 5.6 responded."),
             ("We paused... U.S. officials responded.", [], "We paused… U.S. officials responded."),
             ("We paused... I agreed.", [], "We paused… I agreed."),
+            ("We paused... I'm ready.", [], "We paused… I'm ready."),
+            ("We paused... I’ll handle it.", [], "We paused… I’ll handle it."),
+            ("We paused... I'd agree.", [], "We paused… I'd agree."),
+            ("We paused... I've finished.", [], "We paused… I've finished."),
             ("Hello. . . .", [], "Hello…"),
+            // Regression coverage for Parakeet EncoderInt4 artifact …36367d9.
+            ("This is creepy.dot.dot. What's wrong with you?", [], "This is creepy… what's wrong with you?"),
+            ("I'm annoying.dot.dot. That's okay.", [], "I'm annoying… that's okay."),
+            ("This is funny.dot.dot. I'm laughing so hard right now.", [], "This is funny… I'm laughing so hard right now."),
+            (
+                "This is absolutely crazy. Dot dot dot. San Francisco is the best.",
+                [],
+                "This is absolutely crazy… San Francisco is the best."
+            ),
             (
                 "We paused... Dom Esposito responded.",
                 [DictionaryEntry(phrase: "Dom Esposito")],


### PR DESCRIPTION
## Summary

- Normalize the repeatable Parakeet `.dot.dot.` transcript artifact as an ellipsis.
- Preserve first-person contractions and recognized multiword names following inline ellipses.
- Document the corrected Core behavior.

## Behavior

- Spoken, literal, and artifact-shaped ellipses produce one Unicode ellipsis.
- Capitalized `I` contractions and recognized multiword names retain their casing.
- Ordinary inline continuations remain lowercase, while existing dictionary, acronym, and paragraph safeguards remain unchanged.

## Coverage

- Covers the three captured `.dot.dot.` transcript shapes and common `I` contractions.
- Covers a spoken ellipsis followed by a recognized multiword name.
- Retains existing coverage for quotes, brackets, acronyms, dictionary entries, and paragraph boundaries.

## Validation

- Reproduced the proper-name failure from the captured runtime transcript.
- Passed the focused ellipsis pipeline test with both the default and forced portable linguistic analyzers.
- Passed all 588 KeyVoxCore package tests with the portable perceptron and WordNet resources.
- Passed `git diff --check`.
