### PR TITLE
fix(mac-paste): preserve Gmail sentence spacing

### DIFF
--- a/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
+++ b/macOS/Core/Services/Paste/Accessibility/PasteAXInspector.swift
@@ -379,21 +379,14 @@ final class PasteAXInspector: PasteAXInspecting {
                 element: element
             )
             let caretIndexLine = lineForIndex(caretLocation, element: element)
-            let shouldTreatTrailingNewline = Self.shouldTreatNewlineRangeAtCaret(
-                rangeAfterCaret,
+            let shouldTreatTrailingNewline = Self.shouldTreatNewlineAsPrecedingCaret(
+                rangeAfterCaret: rangeAfterCaret,
                 rangeText: rangeText,
                 value: value,
                 caretLocation: caretLocation,
                 insertionLine: insertionLine,
                 caretIndexLine: caretIndexLine
             )
-                || (value.map {
-                    Self.shouldTreatTrailingValueNewlineAsPrecedingCaret(
-                        rangeText: rangeText,
-                        value: $0,
-                        caretLocation: caretLocation
-                    )
-                } ?? false)
             if shouldTreatTrailingNewline {
                 return rangeText + "\n"
             }
@@ -463,6 +456,34 @@ final class PasteAXInspector: PasteAXInspecting {
             return false
         }
         return insertionLine == caretIndexLine
+    }
+
+    static func shouldTreatNewlineAsPrecedingCaret(
+        rangeAfterCaret: String?,
+        rangeText: String,
+        value: String?,
+        caretLocation: Int?,
+        insertionLine: Int?,
+        caretIndexLine: Int?
+    ) -> Bool {
+        let rangeDecision = shouldTreatNewlineRangeAtCaret(
+            rangeAfterCaret,
+            rangeText: rangeText,
+            value: value,
+            caretLocation: caretLocation,
+            insertionLine: insertionLine,
+            caretIndexLine: caretIndexLine
+        )
+        guard isNewlineRangeAtCaret(rangeAfterCaret) == false else {
+            return rangeDecision
+        }
+        return rangeDecision || (value.map {
+            shouldTreatTrailingValueNewlineAsPrecedingCaret(
+                rangeText: rangeText,
+                value: $0,
+                caretLocation: caretLocation
+            )
+        } ?? false)
     }
 
     private static func valueConfirmsNewlineFollowsCaret(

--- a/macOS/KeyVoxTests/Services/PastePoliciesStabilityTests.swift
+++ b/macOS/KeyVoxTests/Services/PastePoliciesStabilityTests.swift
@@ -85,6 +85,21 @@ final class PastePoliciesStabilityTests: XCTestCase {
         )
     }
 
+    func testValueConfirmedTrailingEditorNewlineRemainsAfterCaret() {
+        let precedingText = "abc"
+
+        XCTAssertFalse(
+            PasteAXInspector.shouldTreatNewlineAsPrecedingCaret(
+                rangeAfterCaret: "\n",
+                rangeText: precedingText,
+                value: precedingText + "\n",
+                caretLocation: precedingText.utf16.count,
+                insertionLine: 0,
+                caretIndexLine: 0
+            )
+        )
+    }
+
     func testMismatchedValueKeepsNewlineCaretCorrection() {
         XCTAssertTrue(
             PasteAXInspector.shouldTreatNewlineRangeAtCaret(


### PR DESCRIPTION
## Summary

- Preserve sentence spacing while dictating into Gmail in Chrome.
- Keep invisible editor sentinel newlines on the correct side of the caret.

## Behavior

- Consecutive dictations in Gmail now receive the expected separating space.
- Explicit accessibility range evidence takes precedence over the older trailing-value fallback.
- Existing newline-boundary correction remains unchanged when the editor cannot provide authoritative range evidence.

## Coverage

- Gmail-style content-editable values with a trailing sentinel newline.
- Existing paste spacing and newline caret correction scenarios.

## Validation

- Reproduced and verified the corrected behavior in a live Gmail compose field in Chrome.
- 30 focused paste policy and spacing tests passed.
- macOS Debug and optimized Release builds succeeded.
- Diff consistency check passed.